### PR TITLE
fix: bump musllinux to 1.2

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -107,7 +107,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: -m pyproject-fmt/Cargo.toml --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.8' }} --target-dir target
-          sccache: "true"
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -136,7 +135,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: -m pyproject-fmt/Cargo.toml --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.8' }} --target-dir target
-          sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -84,10 +84,10 @@ jobs:
             target: x86
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            manylinux: musllinux_1_1
+            manylinux: musllinux_1_2
           - runner: ubuntu-latest
             target: i686-unknown-linux-musl
-            manylinux: musllinux_1_1
+            manylinux: musllinux_1_2
           - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -106,7 +106,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: -m tox-toml-fmt/Cargo.toml --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.8' }} --target-dir target
-          sccache: "false"
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -103,11 +103,10 @@ jobs:
           name: source
       - name: Build wheels
         uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3
-
         with:
           target: ${{ matrix.platform.target }}
           args: -m tox-toml-fmt/Cargo.toml --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.8' }} --target-dir target
-          sccache: "true"
+          sccache: "false"
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -84,10 +84,10 @@ jobs:
             target: x86
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            manylinux: musllinux_1_1
+            manylinux: musllinux_1_2
           - runner: ubuntu-latest
             target: i686-unknown-linux-musl
-            manylinux: musllinux_1_1
+            manylinux: musllinux_1_2
           - runner: ubuntu-latest
             target: aarch64
           - runner: ubuntu-latest


### PR DESCRIPTION
Rust dropped support for 1.1. (Manylinux has too).

https://doc.rust-lang.org/beta/rustc/platform-support.html
