### PR TITLE
Fix empty lines placed within a sorted table

### DIFF
--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -187,6 +187,13 @@ pub fn reorder_table_keys(table: &mut RefMut<Vec<SyntaxElement>>, order: &[&str]
 }
 
 fn load_keys(table: &[SyntaxElement]) -> (HashMap<String, usize>, Vec<Vec<SyntaxElement>>) {
+    let table_clone = if table.last().unwrap().kind() == NEWLINE {
+        // drop the final element if it is a new line, multiple new lines are handled together and add unwanted
+        // empty lines within the table when reordered
+        &table[..table.len() - 1]
+    } else {
+        table
+    };
     let mut key_to_pos = HashMap::<String, usize>::new();
     let mut key_set = Vec::<Vec<SyntaxElement>>::new();
     let entry_set = RefCell::new(Vec::<SyntaxElement>::new());
@@ -200,7 +207,7 @@ fn load_keys(table: &[SyntaxElement]) -> (HashMap<String, usize>, Vec<Vec<Syntax
     };
     let mut key = String::new();
     let mut cutoff = false;
-    for element in table {
+    for element in table_clone {
         let kind = element.kind();
         if kind == ENTRY {
             if cutoff {

--- a/pyproject-fmt/rust/src/tests/dependency_groups_tests.rs
+++ b/pyproject-fmt/rust/src/tests/dependency_groups_tests.rs
@@ -96,6 +96,28 @@ fn evaluate(start: &str, keep_full_version: bool) -> String {
     "#},
         false,
 )]
+#[case::multiple_groups_and_extra_line(
+  indoc ! {r#"
+    [dependency-groups]
+    example = [ "c<1" ]
+    coverage = ["b<2"]
+    type = [ "a>1" ]
+
+    "#},
+  indoc ! {r#"
+    [dependency-groups]
+    type = [
+      "a>1",
+    ]
+    example = [
+      "c<1",
+    ]
+    coverage = [
+      "b<2",
+    ]
+    "#},
+  false,
+)]
 #[case::include_single_group(
         indoc ! {r#"
     [dependency-groups]


### PR DESCRIPTION
This resolves the addition of an empty line within a table after it's been ordered. Resolves [one of the issues](https://github.com/tox-dev/toml-fmt/issues/53#issuecomment-2955771674) listed in #53.