### PR TITLE
Do not remove space before .ext

### DIFF
--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -26,6 +26,7 @@ pub fn fix(
         return;
     }
     let table = &mut table_element.unwrap().first().unwrap().borrow_mut();
+    let re = Regex::new(r" \.(\W)").unwrap();
     expand_entry_points_inline_tables(table);
     for_entries(table, &mut |key, entry| match key.split('.').next().unwrap() {
         "name" => {
@@ -36,18 +37,20 @@ pub fn fix(
         }
         "description" => {
             update_content(entry, |s| {
-                s.trim()
-                    .lines()
-                    .map(|part| {
-                        part.trim()
-                            .split(char::is_whitespace)
-                            .filter(|part| !part.trim().is_empty())
-                            .collect::<Vec<&str>>()
-                            .join(" ")
-                            .replace(" .", ".")
-                    })
-                    .collect::<Vec<String>>()
-                    .join(" ")
+                re.replace_all(
+                    &s.trim()
+                        .lines()
+                        .map(|part| {
+                            part.split_whitespace()
+                                .filter(|part| !part.trim().is_empty())
+                                .collect::<Vec<&str>>()
+                                .join(" ")
+                        })
+                        .collect::<Vec<String>>()
+                        .join(" "),
+                    ".$1",
+                )
+                .to_string()
             });
         }
         "requires-python" => {

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -289,10 +289,10 @@ fn evaluate(start: &str, keep_full_version: bool, max_supported_python: (u8, u8)
         (3, 13),
 )]
 #[case::project_description_whitespace(
-        "[project]\ndescription = ' A  magic stuff \t is great\t\t.\r\n  Like  really  .\t\'\nrequires-python = '==3.12'",
+        "[project]\ndescription = ' A  magic stuff \t is great\t\t.\r\n  Like  really  . Works on .rst and .NET :)\t\'\nrequires-python = '==3.12'",
         indoc ! {r#"
     [project]
-    description = "A magic stuff is great. Like really."
+    description = "A magic stuff is great. Like really. Works on .rst and .NET :)"
     requires-python = "==3.12"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Re-fix https://github.com/tox-dev/pyproject-fmt/issues/270.

This was originally fixed in https://github.com/tox-dev/pyproject-fmt-rust/pull/61 and released in https://github.com/tox-dev/pyproject-fmt-rust/releases/tag/1.2.1.

But three days later that repo was archived and looks like the change was lost in the refactor in this new repo.

So let's fix again :)