### PR TITLE
Group all GitHub Actions updates into a single larger pull

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,6 @@ updates:
     groups:
       github-actions:
         patterns:
-          - "*"  # Group all Actions updates into a single larger pull request
+          - "*" # Group all Actions updates into a single larger pull request
     schedule:
       interval: "daily"


### PR DESCRIPTION
Half of the currently open pull requests are generated by this tool.
* #72 
* #73 
* #74 
* #77 

They would be easier to review and merge if they were in a single PR.

GitHub Actions are only used at CI test-time, while most other dependencies are also used at runtime.  This means that if the CI tests pass, maintainers have more confidence that the proposed changes will not break runtime.  

GitHub Actions have very infrequent major version changes .  `setup-python`, the most frequent, has only had five major upgrades in its lifetime.

When GitHub Actions are upgraded, it often happens in batches.  The `pattern: *` proposed in this PR will consolidate all GHA updates into a single pull request to further reduce chattiness.

There is a tradeoff between supply chain security and chattiness.  Given that we have a few GHAs that are updated rarely and usually in batches, and we are using `pattern: *` to ensure that ___there will only ever be a single GHA upgrade PR at a time___.

@gaborbernat your review, please. 