### PR TITLE
Set pre-commit autoupdate_schedule to monthly not weekly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
Make `pre-commit.ci` [less chatty](https://github.com/tox-dev/toml-fmt/pulls?q=is%3Apr+author%3Aapp%2Fpre-commit-ci+) by doing `pre-commit autoupdate` [monthly](https://pre-commit.ci/#configuration-autoupdate_schedule) instead of weekly.
* #78

@gaborbernat your review, please. 