### PR TITLE
fix: Windows build setup Python 3.9

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -118,6 +118,7 @@ jobs:
     needs: [bump]
     runs-on: ${{ matrix.platform.runner }}
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - runner: windows-latest

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -117,6 +117,7 @@ jobs:
     needs: [bump]
     runs-on: ${{ matrix.platform.runner }}
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - runner: windows-latest


### PR DESCRIPTION
Demonstrate that Windows builds fail only on x86 but not on x64.
