### PR TITLE
Bump default value for `--max-supported-python` to 3.14 and add rationale

### DIFF
--- a/pyproject-fmt/src/pyproject_fmt/__main__.py
+++ b/pyproject-fmt/src/pyproject_fmt/__main__.py
@@ -49,20 +49,20 @@ class PyProjectFormatter(TOMLFormatter[PyProjectFmtNamespace]):
         def _version_argument(got: str) -> tuple[int, int]:
             parts = got.split(".")
             if len(parts) != 2:  # noqa: PLR2004
-                err = f"invalid version: {got}, must be e.g. 3.13"
+                err = f"invalid version: {got}, must be e.g. 3.14"
                 raise ArgumentTypeError(err)
             try:
                 return int(parts[0]), int(parts[1])
             except ValueError as exc:
-                err = f"invalid version: {got} due {exc!r}, must be e.g. 3.13"
+                err = f"invalid version: {got} due {exc!r}, must be e.g. 3.14"
                 raise ArgumentTypeError(err) from exc
 
         parser.add_argument(
             "--max-supported-python",
             metavar="minor.major",
             type=_version_argument,
-            default=(3, 13),
-            help="latest Python version the project supports (e.g. 3.13)",
+            default=(3, 14),  # latest stable release known at time of writing
+            help="latest Python version the project supports (e.g. 3.14)",
         )
 
     @property


### PR DESCRIPTION
- Bump `--max-supported-python` to latest stable Python version
- Add small rationale for future edits

Closes #91. Second proposal has been chosen because it's more conservative.
