### PR TITLE
Default Python support is now 3.10 to 3.14

### DIFF
--- a/pyproject-fmt/src/pyproject_fmt/__main__.py
+++ b/pyproject-fmt/src/pyproject_fmt/__main__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from toml_fmt_common import ArgumentGroup, FmtNamespace, TOMLFormatter, _build_cli, run  # noqa: PLC2701
 
-from ._lib import Settings, format_toml
+from pyproject_fmt._lib import Settings, format_toml
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -49,20 +49,20 @@ class PyProjectFormatter(TOMLFormatter[PyProjectFmtNamespace]):
         def _version_argument(got: str) -> tuple[int, int]:
             parts = got.split(".")
             if len(parts) != 2:  # noqa: PLR2004
-                err = f"invalid version: {got}, must be e.g. 3.13"
+                err = f"invalid version: {got}, must be e.g. 3.14"
                 raise ArgumentTypeError(err)
             try:
                 return int(parts[0]), int(parts[1])
             except ValueError as exc:
-                err = f"invalid version: {got} due {exc!r}, must be e.g. 3.13"
+                err = f"invalid version: {got} due {exc!r}, must be e.g. 3.14"
                 raise ArgumentTypeError(err) from exc
 
         parser.add_argument(
             "--max-supported-python",
             metavar="minor.major",
             type=_version_argument,
-            default=(3, 13),
-            help="latest Python version the project supports (e.g. 3.13)",
+            default=(3, 14),
+            help="latest Python version the project supports (e.g. 3.14)",
         )
 
     @property
@@ -83,7 +83,7 @@ class PyProjectFormatter(TOMLFormatter[PyProjectFmtNamespace]):
             indent=opt.indent,
             keep_full_version=opt.keep_full_version,
             max_supported_python=opt.max_supported_python,
-            min_supported_python=(3, 9),  # default for when the user didn't specify via requires-python
+            min_supported_python=(3, 10),  # default for when the user didn't specify via requires-python
         )
         return format_toml(text, settings)
 

--- a/pyproject-fmt/tests/test_main.py
+++ b/pyproject-fmt/tests/test_main.py
@@ -135,7 +135,7 @@ def test_keep_full_version_cli(tmp_path: Path) -> None:
     [project]
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
     ]
     dependencies = [
       "a==1.0.0",
@@ -146,7 +146,7 @@ def test_keep_full_version_cli(tmp_path: Path) -> None:
     """
     pyproject_toml = tmp_path / "pyproject.toml"
     pyproject_toml.write_text(dedent(start))
-    args = [str(pyproject_toml), "--keep-full-version", "--max-supported-python", "3.9"]
+    args = [str(pyproject_toml), "--keep-full-version", "--max-supported-python", "3.10"]
     run(args)
     output = pyproject_toml.read_text()
     assert output == dedent(start)
@@ -186,7 +186,6 @@ def test_pyproject_toml_config(tmp_path: Path, capsys: pytest.CaptureFixture[str
     ]
     classifiers = [
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ]


### PR DESCRIPTION
Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>
