### PR TITLE
Sort `[tool.uv]` higher in the pyproject.toml

### DIFF
--- a/pyproject-fmt/rust/src/global.rs
+++ b/pyproject-fmt/rust/src/global.rs
@@ -26,6 +26,7 @@ pub fn reorder_tables(root_ast: &SyntaxNode<Lang>, tables: &Tables) {
             "tool.whey",
             "tool.py-build-cmake",
             "tool.sphinx-theme-builder",
+            "tool.uv",
             // Builders
             "tool.cibuildwheel",
             // Formatters and linters

--- a/pyproject-fmt/rust/src/tests/global_tests.rs
+++ b/pyproject-fmt/rust/src/tests/global_tests.rs
@@ -42,6 +42,8 @@ use common::table::Tables;
     ef="fg"
     [tool.pytest]
     mk="mv"
+    [tool.uv]
+    vu="uv"
     "#},
         indoc ! {r#"
     # comment
@@ -68,6 +70,9 @@ use common::table::Tables;
       "p",
       "q",
     ]
+
+    [tool.uv]
+    vu = "uv"
 
     [tool.ruff]
     mr = "vr"


### PR DESCRIPTION
Move it closer to the `[project]` section where dependencies are defined

On a project, I needed the `override-dependencies` option from uv and noticed that it was put quite far down in my `pyproject.toml`. Full list of options is documented [here](https://docs.astral.sh/uv/reference/settings/#configuration).

As this is packaging related, I've put it at the end of the "Build backend" section. Not sure whether it should be higher in the list