### PR TITLE
feat: PEP 794 support

### DIFF
--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -86,6 +86,13 @@ pub fn fix(
             transform(entry, &|s| String::from(s));
             sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
         }
+        "import-names" | "import-namespaces" => {
+            transform(entry, &|s| {
+                let re = Regex::new(r"\s*;\s*").unwrap();
+                re.replace_all(s, "; ").trim_end().to_string()
+            });
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
         "classifiers" => {
             transform(entry, &|s| String::from(s));
             sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
@@ -111,6 +118,8 @@ pub fn fix(
             "",
             "name",
             "version",
+            "import-names",
+            "import-namespaces",
             "description",
             "readme",
             "keywords",

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -626,6 +626,31 @@ fn evaluate(
     (3, 10),
     false,
 )]
+#[case::import_names_and_namespaces(
+    indoc! {r#"
+    [project]
+    name = "hi"
+    import-namespaces = ["ddd"]
+    import-names = ["bbb;private", "aaa", "ccC ; private"]
+    version = "1.0.0"
+    "#},
+    indoc! {r#"
+    [project]
+    name = "hi"
+    version = "1.0.0"
+    import-names = [
+      "aaa",
+      "bbb; private",
+      "ccC; private",
+    ]
+    import-namespaces = [
+      "ddd",
+    ]
+    "#},
+    true,
+    (3, 14),
+    false,
+)]
 fn test_format_project(
     #[case] start: &str,
     #[case] expected: &str,


### PR DESCRIPTION
Working on PEP 794. Not validating, just formatting. Not sure how to get the "black"-style comma lists, it would be nice if users could keep these inline by avoiding a trailing comma, often they will be short (one item).
