### PR TITLE
Fix parsing of versions in parentheses

### DIFF
--- a/common/src/pep508/requirement.rs
+++ b/common/src/pep508/requirement.rs
@@ -45,7 +45,7 @@ impl Requirement {
             (name, extras)
         } else {
             // No extras, but need to find where version specifiers start
-            let name_end = req_part.find(|c: char| "=!<>~".contains(c)).unwrap_or(req_part.len());
+            let name_end = req_part.find(|c: char| "=!<>~(".contains(c)).unwrap_or(req_part.len());
             let name = &req_part[..name_end];
             (name, vec![])
         };
@@ -55,7 +55,8 @@ impl Requirement {
             let url = &raw_req[url_idx..];
             Some(VersionOrUrl::Url(url.trim().to_string()))
         } else if let Some(specs_start) = req_part.find(|c: char| "=!<>~".contains(c)) {
-            let specs = &req_part[specs_start..];
+            let specs_end = req_part.find(|c: char| ")".contains(c)).unwrap_or(req_part.len());
+            let specs = &req_part[specs_start..specs_end];
             let mut parsed = Vec::new();
             for spec in specs.split(',') {
                 match VersionOp::new(spec) {

--- a/common/src/tests/pep508_tests.rs
+++ b/common/src/tests/pep508_tests.rs
@@ -37,6 +37,8 @@ fn test_get_canonic_requirement_name(#[case] start: &str, #[case] expected: &str
 #[case::post_dev_local("pkg>=2.7.0.post2.dev3+abc", "pkg>=2.7.0.post2.dev3+abc", false)]
 #[case::all_segments("pkg>=2.7.0rc1.post2.dev3+abc", "pkg>=2.7.0rc1.post2.dev3+abc", false)]
 #[case::pre_release_keep("pkg>=2.7.0rc1", "pkg>=2.7.0rc1", true)]
+#[case::parentheses("pkg (>=0.5.5,<0.6.1)", "pkg>=0.5.5,<0.6.1", false)]
+#[case::parentheses_extras("pkg [extra] (>=0.5.5,<0.6.1)", "pkg[extra]>=0.5.5,<0.6.1", false)]
 fn test_format_requirement(#[case] start: &str, #[case] expected: &str, #[case] keep_full_version: bool) {
     let got = Requirement::new(start)
         .unwrap()

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -375,6 +375,25 @@ fn evaluate(
         (3, 13),
         true,
 )]
+#[case::project_dependencies_with_version_in_parentheses(
+        indoc ! {r#"
+    [project]
+    dependencies = [
+        "sqlparse (>=0.5.5,<0.6.0)",
+   ]
+    requires-python = "==3.12"
+    "#},
+        indoc ! {r#"
+    [project]
+    dependencies = [
+      "sqlparse>=0.5.5,<0.6.0",
+    ]
+    requires-python = "==3.12"
+    "#},
+        true,
+        (3, 13),
+        false,
+)]
 #[case::project_platform_dependencies(
         indoc ! {r#"
     [project]


### PR DESCRIPTION
Fix `Requirement::new()` to parse requirements where versions are in parenthenses correctly, for example `"sqlparse (>=0.5.5,<0.6.0)"`.

Currently these are parsed incorrectly. The opening `(` is kept, but the last segment of the version number and closing `)` is removed.

This fixes #112.
