### PR TITLE
Add `[tool.nuitka]` and `[tool.typos]`

### DIFF
--- a/pyproject-fmt/rust/src/global.rs
+++ b/pyproject-fmt/rust/src/global.rs
@@ -29,6 +29,7 @@ pub fn reorder_tables(root_ast: &SyntaxNode<Lang>, tables: &Tables) {
             "tool.uv",
             // Builders
             "tool.cibuildwheel",
+            "tool.nuitka",
             // Formatters and linters
             "tool.autopep8",
             "tool.black",
@@ -48,6 +49,7 @@ pub fn reorder_tables(root_ast: &SyntaxNode<Lang>, tables: &Tables) {
             "tool.check-wheel-contents",
             "tool.deptry",
             "tool.pyproject-fmt",
+            "tool.typos",
             // Testing
             "tool.pytest",
             "tool.pytest_env",


### PR DESCRIPTION
Just tried `pyproject-fmt` and I love it!

Here is a couple of additions to the table of configuration sections for `pyproject.toml`:
- `[tool.nuitka]`: for the [Nuitka](https://github.com/Nuitka/Nuitka) project
- `[tool.typos]`: for [`typos`](https://github.com/Nuitka/Nuitka) CLI

I don't have strong opinions about the semantic sorting of these new sections relative to the others, so I tried to guess their categories and place them at the end of each. If you don't like how it looks like, feel free to sort them out differently or ask me to alter their order.