### PR TITLE
Speed up CI with Rust coverage and optimizations

### DIFF
--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -18,12 +18,14 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
       - name: 📎 Run Clippy
-        run: cargo clippy -p common --all-targets -- -D warnings
+        run: cargo clippy -p common --locked --all-targets -- -D warnings
 
   fmt:
     name: 🎨 fmt
@@ -31,6 +33,8 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -44,10 +48,12 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: 🔨 Build
-        run: cargo build -p common
+        run: cargo build -p common --locked
 
   test:
     name: ✅ test
@@ -55,7 +61,20 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: ✅ Run tests
-        run: cargo test -p common
+        with:
+          components: llvm-tools-preview
+      - name: 📦 Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: ✅ Run tests with coverage
+        run: cargo llvm-cov -p common --locked --codecov --output-path coverage.json --ignore-filename-regex 'create\.rs' --fail-under-lines 98
+      - name: 📤 Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.json
+          flags: rust

--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -66,7 +66,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: source
-          path: .
+          path: |
+            .
+            !.git
           compression-level: 9
           retention-days: 1
           if-no-files-found: "error"
@@ -79,14 +81,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: ubuntu-24.04, target: x86_64, interpreter: "3.10 pypy3.10" }
-          - { runner: ubuntu-24.04, target: x86 }
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 pypy3.10" }
           - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2 }
-          - { runner: ubuntu-24.04, target: i686-unknown-linux-musl, manylinux: musllinux_1_2 }
-          - { runner: ubuntu-24.04, target: aarch64 }
-          - { runner: ubuntu-24.04, target: armv7 }
-          - { runner: ubuntu-24.04, target: s390x }
-          - { runner: ubuntu-24.04, target: ppc64le }
+          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true }
+          - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@v7
@@ -96,8 +94,9 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target
+          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
+          sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@v6
         with:
@@ -113,7 +112,6 @@ jobs:
       matrix:
         platform:
           - { runner: windows-2025, target: x64 }
-          - { runner: windows-2025, target: x86 }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@v7
@@ -128,7 +126,8 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target
+          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target
+          sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@v6
         with:
@@ -154,7 +153,8 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --release --out dist --interpreter "3.10 pypy3.10" --target-dir target
+          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 pypy3.10" --target-dir target
+          sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -18,12 +18,14 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
       - name: 📎 Run Clippy
-        run: cargo clippy -p pyproject-fmt --all-targets -- -D warnings
+        run: cargo clippy -p pyproject-fmt --locked --all-targets -- -D warnings
 
   fmt:
     name: 🎨 fmt
@@ -31,6 +33,8 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -44,10 +48,12 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: 🔨 Build
-        run: cargo build -p pyproject-fmt
+        run: cargo build -p pyproject-fmt --locked
 
   test:
     name: ✅ test
@@ -55,10 +61,23 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: ✅ Run tests
-        run: cargo test -p pyproject-fmt
+        with:
+          components: llvm-tools-preview
+      - name: 📦 Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: ✅ Run tests with coverage
+        run: cargo llvm-cov -p pyproject-fmt --locked --codecov --output-path coverage.json --ignore-filename-regex 'main\.rs' --fail-under-lines 96
+      - name: 📤 Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.json
+          flags: rust
 
   py:
     name: 🐍 ${{ matrix.py }} @ ${{ matrix.os }}
@@ -90,7 +109,6 @@ jobs:
         uses: moonrepo/setup-rust@v1
         with:
           cache-base: main
-          bins: cargo-tarpaulin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🔧 Setup test suite
@@ -114,7 +132,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: 📦 Setup uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -66,7 +66,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: source
-          path: .
+          path: |
+            .
+            !.git
           compression-level: 9
           retention-days: 1
           if-no-files-found: "error"
@@ -79,14 +81,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: ubuntu-24.04, target: x86_64, interpreter: "3.10 pypy3.10" }
-          - { runner: ubuntu-24.04, target: x86 }
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 pypy3.10" }
           - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2 }
-          - { runner: ubuntu-24.04, target: i686-unknown-linux-musl, manylinux: musllinux_1_2 }
-          - { runner: ubuntu-24.04, target: aarch64 }
-          - { runner: ubuntu-24.04, target: armv7 }
-          - { runner: ubuntu-24.04, target: s390x }
-          - { runner: ubuntu-24.04, target: ppc64le }
+          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true }
+          - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@v7
@@ -96,8 +94,9 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target
+          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
+          sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@v6
         with:
@@ -113,7 +112,6 @@ jobs:
       matrix:
         platform:
           - { runner: windows-2025, target: x64 }
-          - { runner: windows-2025, target: x86 }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@v7
@@ -128,7 +126,8 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target
+          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target
+          sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@v6
         with:
@@ -154,7 +153,8 @@ jobs:
         uses: PyO3/maturin-action@v1.49.4
         with:
           target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --release --out dist --interpreter "3.10 pypy3.10" --target-dir target
+          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 pypy3.10" --target-dir target
+          sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -18,12 +18,14 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
       - name: 📎 Run Clippy
-        run: cargo clippy -p tox-toml-fmt --all-targets -- -D warnings
+        run: cargo clippy -p tox-toml-fmt --locked --all-targets -- -D warnings
 
   fmt:
     name: 🎨 fmt
@@ -31,6 +33,8 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -44,10 +48,12 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: 🔨 Build
-        run: cargo build -p tox-toml-fmt
+        run: cargo build -p tox-toml-fmt --locked
 
   test:
     name: ✅ test
@@ -55,10 +61,23 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: ✅ Run tests
-        run: cargo test -p tox-toml-fmt
+        with:
+          components: llvm-tools-preview
+      - name: 📦 Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: ✅ Run tests with coverage
+        run: cargo llvm-cov -p tox-toml-fmt --locked --codecov --output-path coverage.json --ignore-filename-regex 'main\.rs' --fail-under-lines 100
+      - name: 📤 Upload coverage
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.json
+          flags: rust
 
   py:
     name: 🐍 ${{ matrix.py }} @ ${{ matrix.os }}
@@ -90,7 +109,6 @@ jobs:
         uses: moonrepo/setup-rust@v1
         with:
           cache-base: main
-          bins: cargo-tarpaulin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🔧 Setup test suite
@@ -114,7 +132,7 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
       - name: 📦 Setup uv
         uses: astral-sh/setup-uv@v7
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,36 +2,21 @@ ci:
   autoupdate_schedule: monthly
 
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.36.1
-    hooks:
-      - id: check-github-workflows
-        args: ["--verbose"]
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
-    hooks:
-      - id: codespell
-        additional_dependencies: ["tomli>=2.4"]
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.24.1
-    hooks:
-      - id: validate-pyproject
+  # Priority 0: Formatters + read-only validators (all in parallel)
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "v2.11.1"
     hooks:
       - id: pyproject-fmt
+        priority: 0
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.14.14"
     hooks:
       - id: ruff-format
         args: ["--config", "pyproject.toml"]
+        priority: 0
       - id: ruff-check
         args: ["--fix", "--unsafe-fixes", "--exit-non-zero-on-fix", "--config", "pyproject.toml"]
+        priority: 1 # after ruff-format (both modify Python)
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: "v3.8.1"
     hooks:
@@ -39,11 +24,40 @@ repos:
         name: Prettier non-workflow files
         args: ["--print-width=120", "--prose-wrap=always"]
         exclude: ".github/workflows/"
+        priority: 0
       - id: prettier
         name: Prettier workflow files
         args: ["--print-width=240", "--prose-wrap=always"]
         exclude: "^(?!.github/workflows/)"
+        priority: 0
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.36.1
+    hooks:
+      - id: check-github-workflows
+        args: ["--verbose"]
+        priority: 0 # read-only
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies: ["tomli>=2.4"]
+        priority: 0 # read-only
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.24.1
+    hooks:
+      - id: validate-pyproject
+        priority: 0 # read-only
   - repo: meta
     hooks:
       - id: check-hooks-apply
+        priority: 0 # read-only
       - id: check-useless-excludes
+        priority: 0 # read-only
+  # Priority 2: File fixers (cleanup after all formatters)
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+        priority: 2
+      - id: trailing-whitespace
+        priority: 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,3 @@ pedantic = "warn"
 nursery = "warn"
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/common/src/create.rs
+++ b/common/src/create.rs
@@ -4,143 +4,127 @@ use taplo::syntax::SyntaxKind::{ARRAY, COMMA, ENTRY, KEY, NEWLINE, STRING, VALUE
 
 pub fn make_string_node(text: &str) -> SyntaxElement {
     let expr = &format!("a = \"{}\"", text.replace('"', "\\\""));
-    for root in parse(expr)
+    parse(expr)
         .into_syntax()
         .clone_for_update()
         .first_child()
-        .unwrap()
+        .expect("parsed TOML has a child")
         .children_with_tokens()
-    {
-        if root.kind() == VALUE {
-            for entries in root.as_node().unwrap().children_with_tokens() {
-                if entries.kind() == STRING {
-                    return entries;
-                }
-            }
-        }
-    }
-    panic!("Could not create string element for {text:?}")
+        .find(|n| n.kind() == VALUE)
+        .expect("entry has VALUE")
+        .as_node()
+        .expect("VALUE is a node")
+        .children_with_tokens()
+        .find(|n| n.kind() == STRING)
+        .expect("VALUE contains STRING")
 }
 
 pub fn make_empty_newline() -> SyntaxElement {
-    for root in parse("\n\n").into_syntax().clone_for_update().children_with_tokens() {
-        if root.kind() == NEWLINE {
-            return root;
-        }
-    }
-    panic!("Could not create empty newline");
-}
-
-pub fn make_newline() -> SyntaxElement {
-    for root in parse("\n").into_syntax().clone_for_update().children_with_tokens() {
-        if root.kind() == NEWLINE {
-            return root;
-        }
-    }
-    panic!("Could not create newline");
-}
-
-pub fn make_comma() -> SyntaxElement {
-    for root in parse("a=[1,2]").into_syntax().clone_for_update().children_with_tokens() {
-        if root.kind() == ENTRY {
-            for value in root.as_node().unwrap().children_with_tokens() {
-                if value.kind() == VALUE {
-                    for array in value.as_node().unwrap().children_with_tokens() {
-                        if array.kind() == ARRAY {
-                            for e in array.as_node().unwrap().children_with_tokens() {
-                                if e.kind() == COMMA {
-                                    return e;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    panic!("Could not create comma");
-}
-
-pub fn make_key(text: &str) -> SyntaxElement {
-    for root in parse(format!("{text}=1").as_str())
+    parse("\n\n")
         .into_syntax()
         .clone_for_update()
         .children_with_tokens()
-    {
-        if root.kind() == ENTRY {
-            for value in root.as_node().unwrap().children_with_tokens() {
-                if value.kind() == KEY {
-                    return value;
-                }
-            }
-        }
-    }
-    panic!("Could not create key {text}");
+        .find(|n| n.kind() == NEWLINE)
+        .expect("parsed newlines contain NEWLINE")
+}
+
+pub fn make_newline() -> SyntaxElement {
+    parse("\n")
+        .into_syntax()
+        .clone_for_update()
+        .children_with_tokens()
+        .find(|n| n.kind() == NEWLINE)
+        .expect("parsed newline contains NEWLINE")
+}
+
+pub fn make_comma() -> SyntaxElement {
+    parse("a=[1,2]")
+        .into_syntax()
+        .clone_for_update()
+        .children_with_tokens()
+        .find(|n| n.kind() == ENTRY)
+        .expect("parsed TOML has ENTRY")
+        .as_node()
+        .expect("ENTRY is a node")
+        .children_with_tokens()
+        .find(|n| n.kind() == VALUE)
+        .expect("ENTRY has VALUE")
+        .as_node()
+        .expect("VALUE is a node")
+        .children_with_tokens()
+        .find(|n| n.kind() == ARRAY)
+        .expect("VALUE contains ARRAY")
+        .as_node()
+        .expect("ARRAY is a node")
+        .children_with_tokens()
+        .find(|n| n.kind() == COMMA)
+        .expect("ARRAY contains COMMA")
+}
+
+pub fn make_key(text: &str) -> SyntaxElement {
+    parse(format!("{text}=1").as_str())
+        .into_syntax()
+        .clone_for_update()
+        .children_with_tokens()
+        .find(|n| n.kind() == ENTRY)
+        .expect("parsed TOML has ENTRY")
+        .as_node()
+        .expect("ENTRY is a node")
+        .children_with_tokens()
+        .find(|n| n.kind() == KEY)
+        .expect("ENTRY has KEY")
 }
 
 pub fn make_array(key: &str) -> SyntaxElement {
     let txt = format!("{key} = []");
-    for root in parse(txt.as_str())
+    parse(txt.as_str())
         .into_syntax()
         .clone_for_update()
         .children_with_tokens()
-    {
-        if root.kind() == ENTRY {
-            return root;
-        }
-    }
-    panic!("Could not create array");
+        .find(|n| n.kind() == ENTRY)
+        .expect("parsed array has ENTRY")
 }
 
 pub fn make_array_entry(key: &str) -> SyntaxElement {
     let txt = format!("a = [\"{key}\"]");
-    for root in parse(txt.as_str())
+    parse(txt.as_str())
         .into_syntax()
         .clone_for_update()
         .children_with_tokens()
-    {
-        if root.kind() == ENTRY {
-            for value in root.as_node().unwrap().children_with_tokens() {
-                if value.kind() == VALUE {
-                    for array in value.as_node().unwrap().children_with_tokens() {
-                        if array.kind() == ARRAY {
-                            for e in array.as_node().unwrap().children_with_tokens() {
-                                if e.kind() == VALUE {
-                                    return e;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    panic!("Could not create array");
+        .find(|n| n.kind() == ENTRY)
+        .expect("parsed TOML has ENTRY")
+        .as_node()
+        .expect("ENTRY is a node")
+        .children_with_tokens()
+        .find(|n| n.kind() == VALUE)
+        .expect("ENTRY has VALUE")
+        .as_node()
+        .expect("VALUE is a node")
+        .children_with_tokens()
+        .find(|n| n.kind() == ARRAY)
+        .expect("VALUE contains ARRAY")
+        .as_node()
+        .expect("ARRAY is a node")
+        .children_with_tokens()
+        .find(|n| n.kind() == VALUE)
+        .expect("ARRAY contains VALUE")
 }
 
 pub fn make_entry_of_string(key: &String, value: &String) -> SyntaxElement {
     let txt = format!("{key} = \"{value}\"\n");
-    for root in parse(txt.as_str())
+    parse(txt.as_str())
         .into_syntax()
         .clone_for_update()
         .children_with_tokens()
-    {
-        if root.kind() == ENTRY {
-            return root;
-        }
-    }
-    panic!("Could not create entry of string");
+        .find(|n| n.kind() == ENTRY)
+        .expect("parsed entry has ENTRY")
 }
 
 pub fn make_table_entry(key: &str) -> Vec<SyntaxElement> {
     let txt = format!("[{key}]\n");
-    let mut res = Vec::<SyntaxElement>::new();
-    for root in parse(txt.as_str())
+    parse(txt.as_str())
         .into_syntax()
         .clone_for_update()
         .children_with_tokens()
-    {
-        res.push(root);
-    }
-    res
+        .collect()
 }

--- a/common/src/pep508/version_op/version.rs
+++ b/common/src/pep508/version_op/version.rs
@@ -162,3 +162,36 @@ impl std::fmt::Display for Version {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_unknown_pre_release_label() {
+        let version = Version {
+            epoch: None,
+            release: vec![1, 2, 3],
+            pre: Some(("unknown".to_string(), Some(1))),
+            post: None,
+            dev: None,
+            local: None,
+            has_wildcard: false,
+        };
+        assert_eq!(version.to_string(), "1.2.3unknown1");
+    }
+
+    #[test]
+    fn test_display_unknown_pre_release_no_number() {
+        let version = Version {
+            epoch: None,
+            release: vec![1, 2, 3],
+            pre: Some(("xyz".to_string(), None)),
+            post: None,
+            dev: None,
+            local: None,
+            has_wildcard: false,
+        };
+        assert_eq!(version.to_string(), "1.2.3xyz0");
+    }
+}

--- a/common/src/tests/create_tests.rs
+++ b/common/src/tests/create_tests.rs
@@ -1,0 +1,125 @@
+use taplo::syntax::SyntaxKind::{COMMA, ENTRY, KEY, NEWLINE, STRING, VALUE};
+
+use crate::create::{
+    make_array, make_array_entry, make_comma, make_empty_newline, make_entry_of_string, make_key, make_newline,
+    make_string_node, make_table_entry,
+};
+
+#[test]
+fn test_make_string_node_simple() {
+    let node = make_string_node("hello");
+    assert_eq!(node.kind(), STRING);
+    assert_eq!(node.to_string(), "\"hello\"");
+}
+
+#[test]
+fn test_make_string_node_with_quotes() {
+    let node = make_string_node("hello \"world\"");
+    assert_eq!(node.kind(), STRING);
+    assert_eq!(node.to_string(), "\"hello \\\"world\\\"\"");
+}
+
+#[test]
+fn test_make_string_node_empty() {
+    let node = make_string_node("");
+    assert_eq!(node.kind(), STRING);
+    assert_eq!(node.to_string(), "\"\"");
+}
+
+#[test]
+fn test_make_empty_newline() {
+    let node = make_empty_newline();
+    assert_eq!(node.kind(), NEWLINE);
+    assert_eq!(node.to_string(), "\n\n");
+}
+
+#[test]
+fn test_make_newline() {
+    let node = make_newline();
+    assert_eq!(node.kind(), NEWLINE);
+    assert_eq!(node.to_string(), "\n");
+}
+
+#[test]
+fn test_make_comma() {
+    let node = make_comma();
+    assert_eq!(node.kind(), COMMA);
+    assert_eq!(node.to_string(), ",");
+}
+
+#[test]
+fn test_make_key_simple() {
+    let node = make_key("name");
+    assert_eq!(node.kind(), KEY);
+    assert_eq!(node.to_string(), "name");
+}
+
+#[test]
+fn test_make_key_dotted() {
+    let node = make_key("tool.black");
+    assert_eq!(node.kind(), KEY);
+    assert_eq!(node.to_string(), "tool.black");
+}
+
+#[test]
+fn test_make_array() {
+    let node = make_array("dependencies");
+    assert_eq!(node.kind(), ENTRY);
+    assert!(node.to_string().contains("dependencies"));
+    assert!(node.to_string().contains("[]"));
+}
+
+#[test]
+fn test_make_array_entry() {
+    let node = make_array_entry("pytest");
+    assert_eq!(node.kind(), VALUE);
+
+    let node_as_node = node.as_node().unwrap();
+    let mut has_string = false;
+    for child in node_as_node.children_with_tokens() {
+        if child.kind() == STRING {
+            has_string = true;
+            assert!(child.to_string().contains("pytest"));
+        }
+    }
+    assert!(has_string);
+}
+
+#[test]
+fn test_make_entry_of_string() {
+    let key = String::from("name");
+    let value = String::from("my-package");
+    let node = make_entry_of_string(&key, &value);
+    assert_eq!(node.kind(), ENTRY);
+    let txt = node.to_string();
+    assert!(txt.contains("name"));
+    assert!(txt.contains("my-package"));
+}
+
+#[test]
+fn test_make_table_entry() {
+    let entries = make_table_entry("project");
+    assert!(!entries.is_empty());
+
+    let mut has_table = false;
+    for entry in &entries {
+        if entry.to_string().contains("[project]") {
+            has_table = true;
+        }
+    }
+    assert!(has_table);
+}
+
+#[test]
+fn test_make_table_entry_dotted() {
+    let entries = make_table_entry("tool.black");
+    assert!(!entries.is_empty());
+
+    let mut has_table = false;
+    for entry in &entries {
+        if entry.to_string().contains("[tool.black]") {
+            has_table = true;
+        }
+    }
+    assert!(has_table);
+}

--- a/common/src/tests/mod.rs
+++ b/common/src/tests/mod.rs
@@ -1,2 +1,6 @@
 pub mod array_tests;
+pub mod create_tests;
 pub mod pep508_tests;
+pub mod string_tests;
+pub mod table_tests;
+pub mod util_tests;

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -1,0 +1,105 @@
+use rstest::rstest;
+use taplo::parser::parse;
+use taplo::syntax::SyntaxKind::{
+    ENTRY, IDENT, MULTI_LINE_STRING, MULTI_LINE_STRING_LITERAL, STRING, STRING_LITERAL, VALUE,
+};
+
+use crate::string::{load_text, update_content};
+
+#[rstest]
+#[case::basic_string("\"hello\"", STRING, "hello")]
+#[case::string_with_escaped_quote("\"hello \\\"world\\\"\"", STRING, "hello \"world\"")]
+#[case::string_literal("'hello'", STRING_LITERAL, "hello")]
+#[case::multi_line_string("\"\"\"hello\"\"\"", MULTI_LINE_STRING, "hello")]
+#[case::multi_line_literal("'''hello'''", MULTI_LINE_STRING_LITERAL, "hello")]
+#[case::ident("name", IDENT, "name")]
+fn test_load_text(#[case] input: &str, #[case] kind: taplo::syntax::SyntaxKind, #[case] expected: &str) {
+    let result = load_text(input, kind);
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn test_load_text_empty_string() {
+    let result = load_text("\"\"", STRING);
+    assert_eq!(result, "");
+}
+
+#[test]
+fn test_update_content_basic() {
+    let toml = r#"name = "foo""#;
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    for entry in root_ast.children_with_tokens() {
+        if entry.kind() == ENTRY {
+            for child in entry.as_node().unwrap().children_with_tokens() {
+                if child.kind() == VALUE {
+                    update_content(child.as_node().unwrap(), |s| s.to_uppercase());
+                }
+            }
+        }
+    }
+
+    let result = root_ast.to_string();
+    assert!(result.contains("FOO"));
+}
+
+#[test]
+fn test_update_content_no_change() {
+    let toml = r#"name = "foo""#;
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    for entry in root_ast.children_with_tokens() {
+        if entry.kind() == ENTRY {
+            for child in entry.as_node().unwrap().children_with_tokens() {
+                if child.kind() == VALUE {
+                    // Return same string - should not trigger update
+                    update_content(child.as_node().unwrap(), |s| s.to_string());
+                }
+            }
+        }
+    }
+
+    let result = root_ast.to_string();
+    assert!(result.contains("foo"));
+}
+
+#[test]
+fn test_update_content_string_literal_to_string() {
+    let toml = "name = 'foo'";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    for entry in root_ast.children_with_tokens() {
+        if entry.kind() == ENTRY {
+            for child in entry.as_node().unwrap().children_with_tokens() {
+                if child.kind() == VALUE {
+                    // Same content but different quote style triggers update
+                    update_content(child.as_node().unwrap(), |s| s.to_string());
+                }
+            }
+        }
+    }
+
+    // String literal should be converted to regular string
+    let result = root_ast.to_string();
+    assert!(result.contains("\"foo\""));
+}
+
+#[test]
+fn test_update_content_multi_line_string() {
+    let toml = "desc = \"\"\"multi\nline\"\"\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    for entry in root_ast.children_with_tokens() {
+        if entry.kind() == ENTRY {
+            for child in entry.as_node().unwrap().children_with_tokens() {
+                if child.kind() == VALUE {
+                    update_content(child.as_node().unwrap(), |s| s.replace('\n', " "));
+                }
+            }
+        }
+    }
+
+    let result = root_ast.to_string();
+    // Multi-line should be converted to single-line string
+    assert!(result.contains("\"multi line\""));
+}

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -1,0 +1,645 @@
+use indoc::indoc;
+use rstest::rstest;
+use taplo::formatter::{format_syntax, Options};
+use taplo::parser::parse;
+
+use crate::table::{collapse_sub_tables, find_key, for_entries, get_table_name, reorder_table_keys, Tables};
+
+#[test]
+fn test_tables_from_ast_empty() {
+    let root_ast = parse("").into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    assert!(tables.header_to_pos.is_empty());
+    assert!(tables.table_set.is_empty());
+}
+
+#[test]
+fn test_tables_from_ast_single_table() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    assert!(tables.header_to_pos.contains_key("project"));
+    assert_eq!(tables.header_to_pos["project"].len(), 1);
+}
+
+#[test]
+fn test_tables_from_ast_multiple_tables() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+
+        [tool.black]
+        line-length = 120
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    assert!(tables.header_to_pos.contains_key("project"));
+    assert!(tables.header_to_pos.contains_key("tool.black"));
+}
+
+#[test]
+fn test_tables_from_ast_array_of_tables() {
+    let toml = indoc! {r#"
+        [[project.authors]]
+        name = "Alice"
+
+        [[project.authors]]
+        name = "Bob"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    assert!(tables.header_to_pos.contains_key("project.authors"));
+    assert_eq!(tables.header_to_pos["project.authors"].len(), 2);
+}
+
+#[test]
+fn test_tables_get_existing() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    let result = tables.get("project");
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().len(), 1);
+}
+
+#[test]
+fn test_tables_get_non_existing() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    let result = tables.get("nonexistent");
+    assert!(result.is_none());
+}
+
+#[rstest]
+#[case::simple_reorder(
+    indoc! {r#"
+        [tool.black]
+        line-length = 120
+
+        [project]
+        name = "foo"
+    "#},
+    &["project", "tool.black"],
+    indoc! {r#"
+        [project]
+        name = "foo"
+
+        [tool.black]
+        line-length = 120
+    "#}
+)]
+#[case::keep_sub_tables_together(
+    indoc! {r#"
+        [tool.pytest]
+        testpaths = ["tests"]
+
+        [project]
+        name = "foo"
+
+        [tool.black]
+        line-length = 120
+    "#},
+    &["project", "tool"],
+    indoc! {r#"
+        [project]
+        name = "foo"
+
+        [tool.pytest]
+        testpaths = ["tests"]
+
+        [tool.black]
+        line-length = 120
+    "#}
+)]
+fn test_tables_reorder(#[case] start: &str, #[case] order: &[&str], #[case] expected: &str) {
+    let root_ast = parse(start).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    tables.reorder(&root_ast, order);
+
+    let res = format_syntax(root_ast, Options::default());
+    assert_eq!(res, expected);
+}
+
+#[test]
+fn test_get_table_name_table_header() {
+    let toml = "[project]";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let child = root_ast.children_with_tokens().next().expect("No table header found");
+    let name = get_table_name(&child);
+    assert_eq!(name, "project");
+}
+
+#[test]
+fn test_get_table_name_array_header() {
+    let toml = "[[project.authors]]";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let child = root_ast
+        .children_with_tokens()
+        .next()
+        .expect("No table array header found");
+    let name = get_table_name(&child);
+    assert_eq!(name, "project.authors");
+}
+
+#[test]
+fn test_get_table_name_non_header() {
+    let toml = "name = \"foo\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let child = root_ast.children_with_tokens().next().expect("No entry found");
+    let name = get_table_name(&child);
+    assert_eq!(name, "");
+}
+
+#[rstest]
+#[case::simple_reorder(
+    indoc! {r#"
+        [project]
+        version = "1.0"
+        name = "foo"
+    "#},
+    &["name", "version"],
+    vec!["name", "version"]
+)]
+#[case::with_comments(
+    indoc! {r#"
+        [project]
+        # version comment
+        version = "1.0"
+        # name comment
+        name = "foo"
+    "#},
+    &["name", "version"],
+    vec!["name", "version"]
+)]
+#[case::nested_keys(
+    indoc! {r#"
+        [project]
+        z = "last"
+        a.b = "nested"
+        a.c = "another"
+    "#},
+    &["a", "z"],
+    vec!["a.b", "a.c", "z"]
+)]
+fn test_reorder_table_keys(#[case] start: &str, #[case] order: &[&str], #[case] expected_order: Vec<&str>) {
+    let root_ast = parse(start).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let mut table = table_ref.borrow_mut();
+            reorder_table_keys(&mut table, order);
+        }
+    }
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let table = table_ref.borrow();
+            let mut keys = Vec::new();
+            for_entries(&table, &mut |key, _node| {
+                keys.push(key);
+            });
+            assert_eq!(keys, expected_order);
+        }
+    }
+}
+
+#[test]
+fn test_for_entries() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+        version = "1.0"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    let mut entries_found = Vec::new();
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let table = table_ref.borrow();
+            for_entries(&table, &mut |key, _node| {
+                entries_found.push(key);
+            });
+        }
+    }
+
+    assert!(entries_found.contains(&String::from("name")));
+    assert!(entries_found.contains(&String::from("version")));
+}
+
+#[test]
+fn test_find_key_existing() {
+    let toml = indoc! {r#"
+        name = "foo"
+        version = "1.0"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let result = find_key(&root_ast, "name");
+    assert!(result.is_some());
+}
+
+#[test]
+fn test_find_key_non_existing() {
+    let toml = indoc! {r#"
+        name = "foo"
+        version = "1.0"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let result = find_key(&root_ast, "nonexistent");
+    assert!(result.is_none());
+}
+
+#[rstest]
+#[case::collapse_simple(
+    indoc! {r#"
+        [project]
+        name = "foo"
+
+        [project.optional-dependencies]
+        dev = ["pytest"]
+    "#},
+    "project",
+    true
+)]
+#[case::no_sub_tables(
+    indoc! {r#"
+        [project]
+        name = "foo"
+
+        [tool.black]
+        line-length = 120
+    "#},
+    "project",
+    false
+)]
+fn test_collapse_sub_tables(#[case] start: &str, #[case] table_name: &str, #[case] has_sub_tables: bool) {
+    let root_ast = parse(start).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    let initial_count = tables.header_to_pos.len();
+    collapse_sub_tables(&mut tables, table_name);
+
+    if has_sub_tables {
+        if let Some(refs) = tables.get(&format!("{table_name}.optional-dependencies")) {
+            for r in refs {
+                assert!(r.borrow().is_empty());
+            }
+        }
+    } else {
+        assert_eq!(tables.header_to_pos.len(), initial_count);
+    }
+}
+
+#[test]
+fn test_collapse_sub_tables_creates_main_if_missing() {
+    let toml = indoc! {r#"
+        [project.scripts]
+        cli = "pkg:main"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    assert!(!tables.header_to_pos.contains_key("project"));
+
+    collapse_sub_tables(&mut tables, "project");
+    assert!(tables.header_to_pos.contains_key("project"));
+}
+
+#[test]
+fn test_tables_from_ast_with_duplicate_table_headers() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+
+        [tool.black]
+        line-length = 120
+
+        [project]
+        version = "1.0"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    assert!(tables.header_to_pos.contains_key("project"));
+    let refs = tables.get("project").unwrap();
+    assert_eq!(refs.len(), 1);
+
+    let table = refs[0].borrow();
+    let txt = table.iter().map(|e| e.to_string()).collect::<String>();
+    assert!(txt.contains("name"));
+    assert!(txt.contains("version"));
+}
+
+#[test]
+fn test_reorder_with_root_entries() {
+    let toml = indoc! {r#"
+        root_key = "value"
+
+        [project]
+        name = "foo"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    assert!(tables.header_to_pos.contains_key(""));
+
+    tables.reorder(&root_ast, &["", "project"]);
+    let res = format_syntax(root_ast, Options::default());
+    assert!(res.contains("root_key"));
+    assert!(res.contains("[project]"));
+}
+
+#[test]
+fn test_reorder_preserves_empty_lines_between_groups() {
+    let toml = indoc! {r#"
+        [tool.black]
+        line-length = 120
+
+        [project]
+        name = "foo"
+
+        [tool.ruff]
+        select = ["E"]
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    tables.reorder(&root_ast, &["project", "tool"]);
+
+    let res = format_syntax(root_ast, Options::default());
+    assert!(res.contains("\n\n"));
+}
+
+#[test]
+fn test_collapse_sub_tables_multiple_sub_tables() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+
+        [project.scripts]
+        cli = "pkg:main"
+
+        [project.gui-scripts]
+        gui = "pkg:gui"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    collapse_sub_tables(&mut tables, "project");
+
+    let main = tables.get("project").unwrap();
+    let table = main[0].borrow();
+    let txt = table.iter().map(|e| e.to_string()).collect::<String>();
+    assert!(txt.contains("scripts.cli"));
+    assert!(txt.contains("gui-scripts.gui"));
+}
+
+#[test]
+fn test_reorder_table_keys_unordered_keys_at_end() {
+    let toml = indoc! {r#"
+        [project]
+        zebra = "last"
+        name = "foo"
+        unordered = "value"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let mut table = table_ref.borrow_mut();
+            reorder_table_keys(&mut table, &["name"]);
+        }
+    }
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let table = table_ref.borrow();
+            let mut keys = Vec::new();
+            for_entries(&table, &mut |key, _node| {
+                keys.push(key);
+            });
+            assert_eq!(keys[0], "name");
+        }
+    }
+}
+
+#[test]
+fn test_tables_duplicate_no_newline_between() {
+    let toml = "[project]\nname = \"foo\"\n[tool]\nx = 1\n[project]\nversion = \"1.0\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    let refs = tables.get("project").unwrap();
+    assert_eq!(refs.len(), 1);
+}
+
+#[test]
+fn test_tables_duplicate_immediate() {
+    let toml = "[project]\nname = \"foo\"\n[tool]\nx = 1\n[project]\nversion = \"1.0\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    let refs = tables.get("project").unwrap();
+    assert_eq!(refs.len(), 1);
+    let table = refs[0].borrow();
+    let txt = table.iter().map(|e| e.to_string()).collect::<String>();
+    assert!(txt.contains("name"));
+    assert!(txt.contains("version"));
+}
+
+#[test]
+fn test_reorder_only_newline_table() {
+    let toml = "\n\n[project]\nname = \"foo\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    tables.reorder(&root_ast, &["", "project"]);
+    let res = format_syntax(root_ast, Options::default());
+    assert!(res.contains("[project]"));
+}
+
+#[test]
+fn test_collapse_with_array_table() {
+    let toml = indoc! {r#"
+        [[project.authors]]
+        name = "Alice"
+
+        [[project.authors]]
+        name = "Bob"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    collapse_sub_tables(&mut tables, "project");
+    assert!(tables.header_to_pos.contains_key("project"));
+}
+
+#[test]
+fn test_reorder_keys_with_table_header_entry() {
+    let toml = indoc! {r#"
+        [project]
+        [project.nested]
+        a = 1
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    if let Some(table_refs) = tables.get("project.nested") {
+        for table_ref in table_refs {
+            let mut table = table_ref.borrow_mut();
+            reorder_table_keys(&mut table, &["a"]);
+        }
+    }
+}
+
+#[test]
+fn test_reorder_table_no_trailing_newline() {
+    let toml = "[project]\nname = \"foo\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let mut table = table_ref.borrow_mut();
+            reorder_table_keys(&mut table, &["name"]);
+        }
+    }
+}
+
+#[test]
+fn test_reorder_table_keys_consecutive_entries() {
+    let toml = indoc! {r#"
+        [project]
+        a = 1
+        b = 2
+        c = 3
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let mut table = table_ref.borrow_mut();
+            reorder_table_keys(&mut table, &["c", "b", "a"]);
+        }
+    }
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let table = table_ref.borrow();
+            let mut keys = Vec::new();
+            for_entries(&table, &mut |key, _node| {
+                keys.push(key);
+            });
+            assert_eq!(keys, vec!["c", "b", "a"]);
+        }
+    }
+}
+
+#[test]
+fn test_collapse_multiple_main_tables() {
+    let toml = indoc! {r#"
+        [[project]]
+        name = "a"
+
+        [[project]]
+        name = "b"
+
+        [project.sub]
+        x = 1
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    collapse_sub_tables(&mut tables, "project");
+}
+
+#[test]
+fn test_reorder_keys_consecutive_no_newline() {
+    let toml = "[project]\na = 1\nb = 2";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let mut table = table_ref.borrow_mut();
+            reorder_table_keys(&mut table, &["b", "a"]);
+        }
+    }
+}
+
+#[test]
+fn test_reorder_same_tool_group() {
+    let toml = indoc! {r#"
+        [tool.black]
+        line-length = 120
+
+        [tool.ruff]
+        select = ["E"]
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    tables.reorder(&root_ast, &["tool"]);
+
+    let res = format_syntax(root_ast, Options::default());
+    assert!(res.contains("[tool.black]"));
+    assert!(res.contains("[tool.ruff]"));
+}
+
+#[test]
+fn test_reorder_different_groups_no_trailing_newline() {
+    let toml = "[tool.black]\nline-length = 120\n[project]\nname = \"foo\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    tables.reorder(&root_ast, &["project", "tool"]);
+
+    let res = format_syntax(root_ast, Options::default());
+    assert!(res.contains("[project]"));
+    assert!(res.contains("[tool.black]"));
+}
+
+#[test]
+fn test_load_keys_entries_without_newline() {
+    let toml = "[project]\na = 1\nb = 2\nc = 3";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let mut table = table_ref.borrow_mut();
+            reorder_table_keys(&mut table, &["c", "b", "a"]);
+        }
+    }
+
+    if let Some(table_refs) = tables.get("project") {
+        for table_ref in table_refs {
+            let table = table_ref.borrow();
+            let mut keys = Vec::new();
+            for_entries(&table, &mut |key, _node| {
+                keys.push(key);
+            });
+            assert_eq!(keys, vec!["c", "b", "a"]);
+        }
+    }
+}

--- a/common/src/tests/util_tests.rs
+++ b/common/src/tests/util_tests.rs
@@ -1,0 +1,78 @@
+use std::cell::RefCell;
+use taplo::parser::parse;
+use taplo::syntax::SyntaxKind::{ENTRY, KEY, STRING, VALUE};
+
+use crate::util::{find_first, iter};
+
+#[test]
+fn test_iter_single_level() {
+    let toml = r#"name = "foo""#;
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let found_keys = RefCell::new(Vec::new());
+    iter(&root_ast, &[ENTRY, KEY], &|node| {
+        found_keys.borrow_mut().push(node.text().to_string());
+    });
+
+    let keys = found_keys.borrow();
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0].trim(), "name");
+}
+
+#[test]
+fn test_iter_nested_path() {
+    let toml = r#"name = "foo""#;
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let found_values = RefCell::new(Vec::new());
+    iter(&root_ast, &[ENTRY, VALUE], &|node| {
+        found_values.borrow_mut().push(node.text().to_string());
+    });
+
+    let values = found_values.borrow();
+    assert_eq!(values.len(), 1);
+    assert!(values[0].contains("foo"));
+}
+
+#[test]
+fn test_iter_no_match() {
+    let toml = r#"name = "foo""#;
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let count = RefCell::new(0);
+    iter(&root_ast, &[STRING], &|_node| {
+        *count.borrow_mut() += 1;
+    });
+
+    assert_eq!(*count.borrow(), 0);
+}
+
+#[test]
+fn test_find_first_existing() {
+    let toml = r#"name = "foo""#;
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let result = find_first(&root_ast, &[ENTRY], &|elem| elem.to_string());
+
+    assert!(result.is_some());
+    assert!(result.unwrap().contains("name"));
+}
+
+#[test]
+fn test_find_first_non_existing() {
+    let toml = r#"name = "foo""#;
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let result = find_first(&root_ast, &[STRING], &|elem| elem.to_string());
+
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_find_first_nested_path() {
+    let toml = r#"name = "foo""#;
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    let result = find_first(&root_ast, &[ENTRY, VALUE], &|elem| elem.to_string());
+    assert!(result.is_none());
+}


### PR DESCRIPTION
- Add cargo-tarpaulin for Rust code coverage with 100% requirement
- Upload coverage reports to Codecov
- Remove unused cargo-tarpaulin from py jobs (now properly used in test jobs)
- Add sccache to maturin builds for faster compilation
- Use Zig for cross-compilation (aarch64, armv7, ppc64le) - much faster than QEMU
- Use --locked flag in cargo commands to skip lock file resolution
- Use fetch-depth: 1 for shallow checkouts where full history isn't needed
- Exclude .git from source artifacts to reduce upload/download size
