### PR TITLE
Fix build requirements with duplicate package names being removed

### DIFF
--- a/common/src/array.rs
+++ b/common/src/array.rs
@@ -44,8 +44,13 @@ where
         let mut add_to_order_sets = |entry: T| {
             let mut entry_set_borrow = current_set.borrow_mut();
             if !entry_set_borrow.is_empty() {
-                key_to_order_set.insert(entry, order_sets.len());
-                order_sets.push(entry_set_borrow.clone());
+                if let Some(&existing_idx) = key_to_order_set.get(&entry) {
+                    // Append to existing order set for duplicate keys (e.g., same package with different markers)
+                    order_sets[existing_idx].extend(entry_set_borrow.clone());
+                } else {
+                    key_to_order_set.insert(entry, order_sets.len());
+                    order_sets.push(entry_set_borrow.clone());
+                }
                 entry_set_borrow.clear();
             }
         };

--- a/pyproject-fmt/rust/src/tests/build_systems_tests.rs
+++ b/pyproject-fmt/rust/src/tests/build_systems_tests.rs
@@ -85,6 +85,27 @@ fn evaluate(start: &str, keep_full_version: bool) -> String {
     "#},
         false
 )]
+#[case::issue_2_python_version_marker(
+        indoc ! {r#"
+    [build-system]
+    requires = [
+      "cython==3.0.11",
+      "numpy==1.22.2; python_version<'3.9'",
+      "numpy>=2; python_version>='3.9'",
+      "setuptools",
+    ]
+    "#},
+        indoc ! {r#"
+    [build-system]
+    requires = [
+      "cython==3.0.11",
+      "numpy==1.22.2; python_version<'3.9'",
+      "numpy>=2; python_version>='3.9'",
+      "setuptools",
+    ]
+    "#},
+        true
+)]
 fn test_format_build_systems(#[case] start: &str, #[case] expected: &str, #[case] keep_full_version: bool) {
     assert_eq!(evaluate(start, keep_full_version), expected);
 }


### PR DESCRIPTION
Fixes #2 where build requirements with the same package name but different markers (e.g., `numpy==1.22.2; python_version<'3.9'` and `numpy>=2; python_version>='3.9'`) would have the first entry removed.

When sorting array entries, duplicate keys in the `key_to_order_set` HashMap overwrote previous entries. Fixed by appending to existing order sets when duplicate keys are found.