### PR TITLE
Fix misparsed requires-python with ~= operator

### DIFF
--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -400,7 +400,7 @@ fn get_python_requires_with_classifier(
     for_entries(table, &mut |key, entry| {
         if key == "requires-python" {
             static RE: LazyLock<Regex> =
-                LazyLock::new(|| Regex::new(r"^(?<op><|<=|==|!=|>=|>)3[.](?<minor>\d+)").unwrap());
+                LazyLock::new(|| Regex::new(r"^(?<op><|<=|==|!=|>=|>|~=)3[.](?<minor>\d+)").unwrap());
             for child in entry.children_with_tokens() {
                 if child.kind() == STRING {
                     let found_str_value = load_text(child.as_token().unwrap().text(), STRING);
@@ -408,7 +408,8 @@ fn get_python_requires_with_classifier(
                         if let Some(caps) = RE.captures(part) {
                             let minor = caps["minor"].parse::<u8>().unwrap();
                             match &caps["op"] {
-                                "==" => {
+                                "==" | "~=" => {
+                                    // ~= is compatible release: ~=3.12.7 means >=3.12.7,<3.13
                                     mins.push(minor);
                                     maxs.push(minor);
                                 }

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -670,6 +670,27 @@ fn evaluate(
     (3, 14),
     false,
 )]
+#[case::issue_20_compatible_release(
+    indoc! {r#"
+    [project]
+    requires-python = "~=3.12.7"
+    classifiers = [
+      "License :: OSI Approved :: MIT License",
+    ]
+    "#},
+    indoc! {r#"
+    [project]
+    requires-python = "~=3.12.7"
+    classifiers = [
+      "License :: OSI Approved :: MIT License",
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.12",
+    ]
+    "#},
+    true,
+    (3, 13),
+    true,
+)]
 fn test_format_project(
     #[case] start: &str,
     #[case] expected: &str,


### PR DESCRIPTION
Fixes #20 where \`requires-python = \"~=3.12.7\"\` was generating classifiers for Python 3.9-3.13 instead of just 3.12.

The regex for parsing \`requires-python\` didn't match \`~=\` (compatible release operator). Added \`~=\` to the regex and treat it like \`==\` since \`~=3.12.7\` means \`>=3.12.7,<3.13\`.