### PR TITLE
Remove testpaths config to fix sdist warning

### DIFF
--- a/pyproject-fmt/pyproject.toml
+++ b/pyproject-fmt/pyproject.toml
@@ -95,7 +95,6 @@ skip = [
 [tool.pyproject-fmt]
 max_supported_python = "3.14"
 
-
 [tool.coverage]
 html.show_contexts = true
 html.skip_covered = false

--- a/pyproject-fmt/pyproject.toml
+++ b/pyproject-fmt/pyproject.toml
@@ -95,10 +95,6 @@ skip = [
 [tool.pyproject-fmt]
 max_supported_python = "3.14"
 
-[tool.pytest]
-ini_options.testpaths = [
-  "tests",
-]
 
 [tool.coverage]
 html.show_contexts = true

--- a/tox-toml-fmt/pyproject.toml
+++ b/tox-toml-fmt/pyproject.toml
@@ -95,11 +95,6 @@ skip = [
 [tool.pyproject-fmt]
 max_supported_python = "3.14"
 
-[tool.pytest]
-ini_options.testpaths = [
-  "tests",
-]
-
 [tool.coverage]
 html.show_contexts = true
 html.skip_covered = false


### PR DESCRIPTION
Fixes #120 where testing from sdist shows `PytestConfigWarning: No files were found in testpaths`.

The `testpaths = ["tests"]` configuration causes a warning when running from sdist since the tests directory is not included. Removed the config from both pyproject-fmt and tox-toml-fmt since pytest searches from current directory by default.