### PR TITLE
Fix crash on multi-line strings with line continuation

### DIFF
--- a/common/src/string.rs
+++ b/common/src/string.rs
@@ -55,7 +55,35 @@ pub fn load_text(value: &str, kind: SyntaxKind) -> String {
     if kind == STRING {
         res = res.replace("\\\"", "\"");
     }
+    if kind == MULTI_LINE_STRING {
+        // Handle line continuation: backslash followed by newline and any whitespace
+        res = process_line_continuations(&res);
+    }
     res
+}
+
+fn process_line_continuations(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            if chars.peek() == Some(&'\n') || chars.peek() == Some(&'\r') {
+                // Skip the backslash and consume newlines/whitespace
+                while let Some(&next) = chars.peek() {
+                    if next == '\n' || next == '\r' || next == ' ' || next == '\t' {
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+            } else {
+                result.push(c);
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
 }
 
 pub fn update_content<F>(entry: &SyntaxNode, transform: F)

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -153,3 +153,79 @@ fn test_literal_string_escape_handling(#[case] input: &str, #[case] expected: &s
     let result = root_ast.to_string();
     assert!(result.contains(expected), "Expected {expected}, got: {result}");
 }
+
+#[test]
+fn test_issue_36_line_continuation() {
+    let toml = "desc = \"\"\"\\\n    hello\\\n\"\"\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    for entry in root_ast.children_with_tokens() {
+        if entry.kind() == ENTRY {
+            for child in entry.as_node().unwrap().children_with_tokens() {
+                if child.kind() == VALUE {
+                    update_content(child.as_node().unwrap(), |s| s.to_string());
+                }
+            }
+        }
+    }
+
+    let result = root_ast.to_string();
+    assert!(result.contains("\"hello\""), "Got: {}", result);
+}
+
+#[test]
+fn test_line_continuation_with_crlf() {
+    let toml = "desc = \"\"\"\\\r\n    hello\"\"\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    for entry in root_ast.children_with_tokens() {
+        if entry.kind() == ENTRY {
+            for child in entry.as_node().unwrap().children_with_tokens() {
+                if child.kind() == VALUE {
+                    update_content(child.as_node().unwrap(), |s| s.to_string());
+                }
+            }
+        }
+    }
+
+    let result = root_ast.to_string();
+    assert!(result.contains("\"hello\""), "Got: {}", result);
+}
+
+#[test]
+fn test_multiline_with_regular_escapes() {
+    let toml = "desc = \"\"\"hello\\nworld\"\"\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    for entry in root_ast.children_with_tokens() {
+        if entry.kind() == ENTRY {
+            for child in entry.as_node().unwrap().children_with_tokens() {
+                if child.kind() == VALUE {
+                    update_content(child.as_node().unwrap(), |s| s.to_string());
+                }
+            }
+        }
+    }
+
+    let result = root_ast.to_string();
+    assert!(result.contains("\"hello\\nworld\""), "Got: {}", result);
+}
+
+#[test]
+fn test_multiline_with_tabs_after_continuation() {
+    let toml = "desc = \"\"\"\\\n\t\thello\"\"\"";
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+
+    for entry in root_ast.children_with_tokens() {
+        if entry.kind() == ENTRY {
+            for child in entry.as_node().unwrap().children_with_tokens() {
+                if child.kind() == VALUE {
+                    update_content(child.as_node().unwrap(), |s| s.to_string());
+                }
+            }
+        }
+    }
+
+    let result = root_ast.to_string();
+    assert!(result.contains("\"hello\""), "Got: {}", result);
+}

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -350,6 +350,27 @@ fn evaluate(
         (3, 13),
         true,
 )]
+#[case::project_description_line_continuation(
+        indoc ! {r#"
+    [project]
+    requires-python = "==3.12"
+    description = """\
+        FlexGet is a program aimed to automate downloading.\
+    """
+    "#},
+        indoc ! {r#"
+    [project]
+    description = "FlexGet is a program aimed to automate downloading."
+    requires-python = "==3.12"
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.12",
+    ]
+    "#},
+        true,
+        (3, 13),
+        true,
+)]
 #[case::project_dependencies_with_double_quotes(
         indoc ! {r#"
     [project]


### PR DESCRIPTION
Fixes #36 where multi-line basic strings with backslash line continuation (e.g., `"""\<newline>    text"""`) caused a panic. The `load_text` function now properly processes line continuations by removing `\<newline><whitespace>*` sequences as per TOML spec.