### PR TITLE
Add keyword and classifier deduplication

### DIFF
--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -1,4 +1,4 @@
-use common::array::{sort, sort_strings, transform};
+use common::array::{dedupe_strings, sort, sort_strings, transform};
 use common::create::{make_array, make_array_entry, make_comma, make_entry_of_string, make_newline};
 use common::pep508::Requirement;
 use common::string::{load_text, update_content};
@@ -83,8 +83,13 @@ pub fn fix(
                 },
             );
         }
-        "dynamic" | "keywords" => {
+        "dynamic" => {
             transform(entry, &|s| String::from(s));
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+        "keywords" => {
+            transform(entry, &|s| String::from(s));
+            dedupe_strings(entry, |s| s.to_lowercase());
             sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
         }
         "import-names" | "import-namespaces" => {
@@ -96,6 +101,7 @@ pub fn fix(
         }
         "classifiers" => {
             transform(entry, &|s| String::from(s));
+            dedupe_strings(entry, |s| s.to_lowercase());
             sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
         }
         _ => {}
@@ -110,6 +116,7 @@ pub fn fix(
 
     for_entries(table, &mut |key, entry| {
         if key.as_str() == "classifiers" {
+            dedupe_strings(entry, |s| s.to_lowercase());
             sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
         }
     });

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -178,6 +178,47 @@ fn evaluate(
         (3, 9),
         true,
 )]
+#[case::project_dedupe_keywords(
+        indoc ! {r#"
+    [project]
+    keywords = ["Python", "python", "PYTHON", "toml", "Toml"]
+    "#},
+        indoc ! {r#"
+    [project]
+    keywords = [
+      "Python",
+      "toml",
+    ]
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.9",
+    ]
+    "#},
+        true,
+        (3, 9),
+        true,
+)]
+#[case::project_dedupe_classifiers(
+        indoc ! {r#"
+    [project]
+    classifiers = [
+      "License :: OSI Approved :: MIT License",
+      "Topic :: Software Development",
+      "license :: osi approved :: mit license",
+      "TOPIC :: SOFTWARE DEVELOPMENT",
+    ]
+    "#},
+        indoc ! {r#"
+    [project]
+    classifiers = [
+      "License :: OSI Approved :: MIT License",
+      "Topic :: Software Development",
+    ]
+    "#},
+        true,
+        (3, 9),
+        false,
+)]
 #[case::project_sort_dynamic(
         indoc ! {r#"
     [project]


### PR DESCRIPTION
Add `dedupe_strings` function to `common/src/array.rs` for case-insensitive deduplication of array string entries. Apply deduplication to `keywords` and `classifiers` in `pyproject-fmt` before sorting, keeping the first occurrence.

```toml
# before
[project]
keywords = ["testing", "Testing", "pytest", "TESTING", "automation"]
classifiers = [
  "Development Status :: 5 - Production/Stable",
  "License :: OSI Approved :: MIT License",
  "development status :: 5 - production/stable",
]

# after
[project]
keywords = ["automation", "pytest", "testing"]
classifiers = [
  "Development Status :: 5 - Production/Stable",
  "License :: OSI Approved :: MIT License",
]
```