### PR TITLE
Add authors and maintainers sorting

### DIFF
--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -236,6 +236,31 @@ fn evaluate(
         (3, 9),
         true,
 )]
+#[case::project_sort_authors(
+        indoc ! {r#"
+    [project]
+    authors = [
+      {name = "Zoe", email = "zoe@example.com"},
+      {name = "Alice", email = "alice@example.com"},
+      {name = "Alice", email = "a@example.com"},
+    ]
+    "#},
+        indoc ! {r#"
+    [project]
+    authors = [
+      { name = "Alice", email = "a@example.com" },
+      { name = "Alice", email = "alice@example.com" },
+      { name = "Zoe", email = "zoe@example.com" },
+    ]
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.9",
+    ]
+    "#},
+        true,
+        (3, 9),
+        true,
+)]
 #[case::project_requires_gt_old(
         indoc ! {r#"
     [project]


### PR DESCRIPTION
Sort `authors` and `maintainers` arrays by `name`, then by `email` (case-insensitive).

```toml
# before
[project]
authors = [
  {name = "Zoe", email = "zoe@example.com"},
  {name = "Alice", email = "alice@example.com"},
  {name = "Alice", email = "a@example.com"},
]

# after
[project]
authors = [
  { name = "Alice", email = "a@example.com" },
  { name = "Alice", email = "alice@example.com" },
  { name = "Zoe", email = "zoe@example.com" },
]
```