### PR TITLE
Normalize SPDX operators in license expressions

### DIFF
--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -37,6 +37,14 @@ pub fn fix(
         "version" | "readme" | "license-files" | "scripts" | "entry-points" | "gui-scripts" => {
             update_content(entry, |s| String::from(s));
         }
+        "license" => {
+            static LICENSE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)\b(and|or|with)\b").unwrap());
+            update_content(entry, |s| {
+                LICENSE_RE
+                    .replace_all(s, |caps: &regex::Captures| caps[1].to_uppercase())
+                    .to_string()
+            });
+        }
         "description" => {
             update_content(entry, |s| {
                 RE.replace_all(

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -219,6 +219,23 @@ fn evaluate(
         (3, 9),
         true,
 )]
+#[case::project_license_normalize(
+        indoc ! {r#"
+    [project]
+    license = "mit or apache-2.0 with llvm-exception and gpl-3.0-only"
+    "#},
+        indoc ! {r#"
+    [project]
+    license = "mit OR apache-2.0 WITH llvm-exception AND gpl-3.0-only"
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.9",
+    ]
+    "#},
+        true,
+        (3, 9),
+        true,
+)]
 #[case::project_name_literal(
         indoc ! {r"
     [project]


### PR DESCRIPTION
Normalize SPDX operators (`AND`, `OR`, `WITH`) to uppercase in license expressions.

```toml
# before
[project]
license = "mit or apache-2.0 with llvm-exception and gpl-3.0-only"

# after
[project]
license = "mit OR apache-2.0 WITH llvm-exception AND gpl-3.0-only"
```