### PR TITLE
Collapse [[project.authors]] array of tables to inline format

### DIFF
--- a/common/src/create.rs
+++ b/common/src/create.rs
@@ -128,3 +128,14 @@ pub fn make_table_entry(key: &str) -> Vec<SyntaxElement> {
         .children_with_tokens()
         .collect()
 }
+
+pub fn make_entry_with_array_of_inline_tables(key: &str, inline_tables: &[String]) -> SyntaxElement {
+    let tables_str = inline_tables.join(", ");
+    let txt = format!("{key} = [{tables_str}]\n");
+    parse(txt.as_str())
+        .into_syntax()
+        .clone_for_update()
+        .children_with_tokens()
+        .find(|n| n.kind() == ENTRY)
+        .expect("parsed entry has ENTRY")
+}

--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -1,7 +1,7 @@
 use common::array::{dedupe_strings, sort, sort_strings, transform};
 use common::create::{
-    make_array, make_array_entry, make_comma, make_entry_of_string, make_entry_with_array_of_inline_tables,
-    make_key, make_newline,
+    make_array, make_array_entry, make_comma, make_entry_of_string, make_entry_with_array_of_inline_tables, make_key,
+    make_newline,
 };
 use common::pep508::Requirement;
 use common::string::{load_text, update_content};

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -243,6 +243,33 @@ fn evaluate(
         (3, 9),
         true,
 )]
+#[case::project_collapse_authors_array_of_tables(
+        indoc ! {r#"
+    [project]
+    name = "my-app"
+    [[project.authors]]
+    name = "Joe Blogs"
+    email = "joe@example.com"
+    [[project.authors]]
+    name = "Jane Doe"
+    email = "jane@example.com"
+    "#},
+        indoc ! {r#"
+    [project]
+    name = "my-app"
+    authors = [
+      { name = "Jane Doe", email = "jane@example.com" },
+      { name = "Joe Blogs", email = "joe@example.com" },
+    ]
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.9",
+    ]
+    "#},
+        true,
+        (3, 9),
+        true,
+)]
 #[case::project_name_norm(
         indoc ! {r#"
     [project]


### PR DESCRIPTION
Converts `[[project.authors]]` and `[[project.maintainers]]` array of tables syntax into the inline array format. For example, a pyproject.toml with:

```toml
[project]
name = "my-app"
[[project.authors]]
name = "Joe Blogs"
email = "joe@example.com"
[[project.authors]]
name = "Jane Doe"
email = "jane@example.com"
```

Will be formatted as:

```toml
[project]
name = "my-app"
authors = [
  { name = "Jane Doe", email = "jane@example.com" },
  { name = "Joe Blogs", email = "joe@example.com" },
]
```

Within inline tables, keys are ordered with `name` first, then `email`, then any others alphabetically. Authors are sorted alphabetically by name, then by email.

Fixes #41