### PR TITLE
Bump toml-fmt-common to 1.2

### DIFF
--- a/pyproject-fmt/pyproject.toml
+++ b/pyproject-fmt/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "toml-fmt-common==1.1",
+  "toml-fmt-common==1.2",
 ]
 urls."Bug Tracker" = "https://github.com/tox-dev/toml-fmt/issues"
 urls."Changelog" = "https://github.com/tox-dev/toml-fmt/blob/main/pyproject-fmt/CHANGELOG.md"

--- a/tox-toml-fmt/pyproject.toml
+++ b/tox-toml-fmt/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "toml-fmt-common==1.1",
+  "toml-fmt-common==1.2",
 ]
 urls."Bug Tracker" = "https://github.com/tox-dev/toml-fmt/issues"
 urls."Changelog" = "https://github.com/tox-dev/toml-fmt/blob/main/tox-toml-fmt/CHANGELOG.md"


### PR DESCRIPTION
Includes fix for CRLF line endings on Windows (fixes #99).