### PR TITLE
Sort subtables alphabetically within the same tool

### DIFF
--- a/pyproject-fmt/rust/src/tests/global_tests.rs
+++ b/pyproject-fmt/rust/src/tests/global_tests.rs
@@ -84,10 +84,10 @@ use common::table::Tables;
 
     [tool.coverage]
     aa = "bb"
-    [tool.coverage.report]
-    cd = "de"
     [tool.coverage.paths]
     ab = "bc"
+    [tool.coverage.report]
+    cd = "de"
     [tool.coverage.run]
     ef = "fg"
 

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -106,10 +106,10 @@ use crate::{format_toml, Settings};
 
     [tool.coverage]
     a = 0
-    [tool.coverage.report]
-    a = 2
     [tool.coverage.paths]
     a = 1
+    [tool.coverage.report]
+    a = 2
     [tool.coverage.run]
     a = 3
     "#},

--- a/tox-toml-fmt/rust/src/tests/global_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/global_tests.rs
@@ -32,11 +32,11 @@ use common::table::Tables;
         [env_run_base]
         description = "base"
 
-        [env.type]
-        description = "type"
-
         [env.docs]
         description = "docs"
+
+        [env.type]
+        description = "type"
 
         [demo]
         desc = "demo"


### PR DESCRIPTION
For pyproject.toml, subtables under the same tool are now sorted alphabetically with shorter paths first. Given this input:

```toml
[tool.coverage.run]
source = ["src"]
[tool.coverage.report]
show_missing = true
[tool.coverage.paths]
source = ["src"]
```

The output becomes:
```toml
[tool.coverage.paths]
source = ["src"]
[tool.coverage.report]
show_missing = true
[tool.coverage.run]
source = ["src"]
```

Different tools still preserve their original file order - if `tool.ruff` appears before `tool.mypy` in the file, that order is maintained.

For tox.toml, `env.*` tables preserve file order rather than being sorted alphabetically, since environments should follow the order defined in `env_list`.

Fixes #3