### PR TITLE
Fix comments before table headers staying with correct table

### DIFF
--- a/pyproject-fmt/rust/src/tests/global_tests.rs
+++ b/pyproject-fmt/rust/src/tests/global_tests.rs
@@ -84,10 +84,10 @@ use common::table::Tables;
 
     [tool.coverage]
     aa = "bb"
-    [tool.coverage.report]
-    cd = "de"
     [tool.coverage.paths]
     ab = "bc"
+    [tool.coverage.report]
+    cd = "de"
     [tool.coverage.run]
     ef = "fg"
 

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -106,10 +106,10 @@ use crate::{format_toml, Settings};
 
     [tool.coverage]
     a = 0
-    [tool.coverage.report]
-    a = 2
     [tool.coverage.paths]
     a = 1
+    [tool.coverage.report]
+    a = 2
     [tool.coverage.run]
     a = 3
     "#},

--- a/tox-toml-fmt/rust/src/tests/global_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/global_tests.rs
@@ -32,11 +32,11 @@ use common::table::Tables;
         [env_run_base]
         description = "base"
 
-        [env.type]
-        description = "type"
-
         [env.docs]
         description = "docs"
+
+        [env.type]
+        description = "type"
 
         [demo]
         desc = "demo"


### PR DESCRIPTION
When reordering tables, comments that appear immediately before a table header now correctly stay with that table instead of being left behind with the previous table.

For example, given:
```toml
[project]
name = "test"

# comment for build-system
[build-system]
requires = ["hatchling"]
```

When reordering to put `[build-system]` first, the comment now moves with it:
```toml
# comment for build-system
[build-system]
requires = ["hatchling"]

[project]
name = "test"
```

Previously, the comment would incorrectly stay with `[project]`.

Fixes #124