### PR TITLE
Order tox env tables according to env_list and add codecov token

### DIFF
--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -76,5 +76,6 @@ jobs:
       - name: 📤 Upload coverage
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.json
           flags: rust

--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -76,6 +76,7 @@ jobs:
       - name: 📤 Upload coverage
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.json
           flags: rust
 

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -76,6 +76,7 @@ jobs:
       - name: 📤 Upload coverage
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.json
           flags: rust
 

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -201,7 +201,7 @@ fn test_tables_get_non_existing() {
 fn test_tables_reorder(#[case] start: &str, #[case] order: &[&str], #[case] expected: &str) {
     let root_ast = parse(start).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, order);
+    tables.reorder(&root_ast, order, &["tool"]); // tool.* uses two-part keys
 
     let res = format_syntax(root_ast, Options::default());
     assert_eq!(res, expected);
@@ -436,7 +436,7 @@ fn test_reorder_with_root_entries() {
 
     assert!(tables.header_to_pos.contains_key(""));
 
-    tables.reorder(&root_ast, &["", "project"]);
+    tables.reorder(&root_ast, &["", "project"], &[]);
     let res = format_syntax(root_ast, Options::default());
     assert!(res.contains("root_key"));
     assert!(res.contains("[project]"));
@@ -456,7 +456,7 @@ fn test_reorder_preserves_empty_lines_between_groups() {
     "#};
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["project", "tool"]);
+    tables.reorder(&root_ast, &["project", "tool"], &["tool"]);
 
     let res = format_syntax(root_ast, Options::default());
     assert!(res.contains("\n\n"));
@@ -546,7 +546,7 @@ fn test_reorder_only_newline_table() {
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
 
-    tables.reorder(&root_ast, &["", "project"]);
+    tables.reorder(&root_ast, &["", "project"], &[]);
     let res = format_syntax(root_ast, Options::default());
     assert!(res.contains("[project]"));
 }
@@ -672,7 +672,7 @@ fn test_reorder_same_tool_group() {
     "#};
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["tool"]);
+    tables.reorder(&root_ast, &["tool"], &["tool"]);
 
     let res = format_syntax(root_ast, Options::default());
     assert!(res.contains("[tool.black]"));
@@ -684,7 +684,7 @@ fn test_reorder_different_groups_no_trailing_newline() {
     let toml = "[tool.black]\nline-length = 120\n[project]\nname = \"foo\"";
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["project", "tool"]);
+    tables.reorder(&root_ast, &["project", "tool"], &["tool"]);
 
     let res = format_syntax(root_ast, Options::default());
     assert!(res.contains("[project]"));
@@ -728,7 +728,7 @@ fn test_comments_before_table_header_stay_with_that_table() {
     "#};
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["build-system", "project"]);
+    tables.reorder(&root_ast, &["build-system", "project"], &[]);
 
     let res = format_syntax(root_ast, Options::default());
     // The comment should stay with [build-system], not [project]
@@ -748,7 +748,7 @@ fn test_multiple_comments_before_table_header() {
     "#};
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["build-system", "project"]);
+    tables.reorder(&root_ast, &["build-system", "project"], &[]);
 
     let res = format_syntax(root_ast, Options::default());
     // Both comments should stay with [build-system]
@@ -767,7 +767,7 @@ fn test_comment_with_blank_line_before_table_header() {
     "#};
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["build-system", "project"]);
+    tables.reorder(&root_ast, &["build-system", "project"], &[]);
 
     let res = format_syntax(root_ast, Options::default());
     // Comment should stay with [build-system] even with blank line before it

--- a/pyproject-fmt/rust/src/global.rs
+++ b/pyproject-fmt/rust/src/global.rs
@@ -72,5 +72,6 @@ pub fn reorder_tables(root_ast: &SyntaxNode<Lang>, tables: &Tables) {
             "tool.ty",
             "tool.django-stubs",
         ],
+        &["tool"], // Treat tool.* as distinct base keys (e.g., tool.black != tool.ruff)
     );
 }

--- a/tox-toml-fmt/rust/src/global.rs
+++ b/tox-toml-fmt/rust/src/global.rs
@@ -1,8 +1,58 @@
+use common::string::load_text;
+use common::table::{for_entries, Tables};
 use common::taplo::rowan::SyntaxNode;
 use common::taplo::syntax::Lang;
+use common::taplo::syntax::SyntaxKind::{ARRAY, STRING, VALUE};
 
-use common::table::Tables;
+/// Extract environment names from env_list array in the root table
+fn get_env_list_order(tables: &Tables) -> Vec<String> {
+    let mut env_order = Vec::new();
+
+    if let Some(root_tables) = tables.get("") {
+        for table_ref in root_tables {
+            let table = table_ref.borrow();
+            for_entries(&table, &mut |key, entry| {
+                if key == "env_list" {
+                    // Iterate over the array to extract environment names
+                    for child in entry.children_with_tokens() {
+                        if child.kind() == ARRAY {
+                            for array_child in child.as_node().unwrap().children_with_tokens() {
+                                if array_child.kind() == VALUE {
+                                    for value_child in array_child.as_node().unwrap().children_with_tokens() {
+                                        if value_child.kind() == STRING {
+                                            let env_name = load_text(value_child.as_token().unwrap().text(), STRING);
+                                            env_order.push(format!("env.{env_name}"));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    env_order
+}
 
 pub fn reorder_tables(root_ast: &SyntaxNode<Lang>, tables: &Tables) {
-    tables.reorder(root_ast, &["", "env_run_base", "env"]);
+    // Build dynamic order based on env_list
+    let env_list_order = get_env_list_order(tables);
+    let has_env_list = !env_list_order.is_empty();
+
+    // Build the full order: root, env_run_base, then env.* from env_list, then generic env
+    let mut order: Vec<&str> = vec!["", "env_run_base"];
+
+    // Convert env_list_order to &str for the order slice
+    let env_refs: Vec<&str> = env_list_order.iter().map(|s| s.as_str()).collect();
+    order.extend(env_refs);
+
+    // Add generic "env" at the end for any env.* not explicitly listed
+    order.push("env");
+
+    // Only use multi_level_prefixes when we have specific env.* entries from env_list
+    // Without env_list, all env.* tables should match the generic "env" in ordering
+    let multi_level_prefixes: &[&str] = if has_env_list { &["env"] } else { &[] };
+    tables.reorder(root_ast, &order, multi_level_prefixes);
 }

--- a/tox-toml-fmt/rust/src/tests/global_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/global_tests.rs
@@ -161,6 +161,68 @@ fn test_reorder_root_table_no_env_list_key() {
 }
 
 #[test]
+fn test_reorder_env_list_not_array() {
+    // env_list is a string instead of an array - should be ignored (treated as no env_list)
+    let start = indoc! {r#"
+        env_list = "test"
+
+        [env.type]
+        description = "type"
+
+        [env.docs]
+        description = "docs"
+    "#};
+    let expected = indoc! {r#"
+        env_list = "test"
+
+        [env.docs]
+        description = "docs"
+        [env.type]
+        description = "type"
+    "#};
+    let root_ast = parse(start).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    reorder_tables(&root_ast, &tables);
+    let opt = Options {
+        column_width: 120,
+        ..Options::default()
+    };
+    let got = format_syntax(root_ast, opt);
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn test_reorder_empty_env_list() {
+    // Empty env_list - should behave like no env_list (alphabetical order)
+    let start = indoc! {r#"
+        env_list = []
+
+        [env.type]
+        description = "type"
+
+        [env.docs]
+        description = "docs"
+    "#};
+    let expected = indoc! {r#"
+        env_list = []
+
+        [env.docs]
+        description = "docs"
+        [env.type]
+        description = "type"
+    "#};
+    let root_ast = parse(start).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    reorder_tables(&root_ast, &tables);
+    let opt = Options {
+        column_width: 120,
+        ..Options::default()
+    };
+    let got = format_syntax(root_ast, opt);
+    assert_eq!(got, expected);
+}
+
+#[test]
 fn test_reorder_env_list_with_env_run_base() {
     // env_list with env_run_base - env_run_base should come before env.* tables
     let start = indoc! {r#"

--- a/tox-toml-fmt/rust/src/tests/global_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/global_tests.rs
@@ -7,8 +7,9 @@ use crate::global::reorder_tables;
 use common::table::Tables;
 
 #[rstest]
-#[case::reorder(
-        indoc ! {r#"
+#[case::reorder_no_env_list(
+    // Without env_list, env tables are sorted alphabetically (docs before type)
+    indoc ! {r#"
         # comment
         requires = ["tox>=4.22"]
 
@@ -25,7 +26,7 @@ use common::table::Tables;
         description = "base"
 
     "#},
-        indoc ! {r#"
+    indoc ! {r#"
         # comment
         requires = ["tox>=4.22"]
 
@@ -42,7 +43,144 @@ use common::table::Tables;
         desc = "demo"
     "#},
 )]
+#[case::reorder_with_env_list(
+    // With env_list, env tables follow env_list order
+    indoc ! {r#"
+        env_list = ["docs", "type", "lint"]
+
+        [env.type]
+        description = "type"
+
+        [env.docs]
+        description = "docs"
+
+        [env.lint]
+        description = "lint"
+
+    "#},
+    indoc ! {r#"
+        env_list = ["docs", "type", "lint"]
+
+        [env.docs]
+        description = "docs"
+
+        [env.type]
+        description = "type"
+
+        [env.lint]
+        description = "lint"
+    "#},
+)]
+#[case::reorder_env_list_partial(
+    // env tables in env_list come first in env_list order,
+    // then any not in env_list preserve file order
+    indoc ! {r#"
+        env_list = ["type"]
+
+        [env.lint]
+        description = "lint"
+
+        [env.docs]
+        description = "docs"
+
+        [env.type]
+        description = "type"
+
+    "#},
+    indoc ! {r#"
+        env_list = ["type"]
+
+        [env.type]
+        description = "type"
+
+        [env.lint]
+        description = "lint"
+
+        [env.docs]
+        description = "docs"
+    "#},
+)]
 fn test_reorder_table(#[case] start: &str, #[case] expected: &str) {
+    let root_ast = parse(start).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    reorder_tables(&root_ast, &tables);
+    let opt = Options {
+        column_width: 120,
+        ..Options::default()
+    };
+    let got = format_syntax(root_ast, opt);
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn test_reorder_no_root_table() {
+    // File with only sections, no root entries - should still work
+    let start = indoc! {r#"
+        [env.test]
+        description = "test"
+    "#};
+    let expected = indoc! {r#"
+        [env.test]
+        description = "test"
+    "#};
+    let root_ast = parse(start).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    reorder_tables(&root_ast, &tables);
+    let opt = Options {
+        column_width: 120,
+        ..Options::default()
+    };
+    let got = format_syntax(root_ast, opt);
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn test_reorder_root_table_no_env_list_key() {
+    // Root table exists but has other keys, not env_list
+    let start = indoc! {r#"
+        requires = ["tox>=4"]
+
+        [env.test]
+        description = "test"
+    "#};
+    let expected = indoc! {r#"
+        requires = ["tox>=4"]
+
+        [env.test]
+        description = "test"
+    "#};
+    let root_ast = parse(start).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+    reorder_tables(&root_ast, &tables);
+    let opt = Options {
+        column_width: 120,
+        ..Options::default()
+    };
+    let got = format_syntax(root_ast, opt);
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn test_reorder_env_list_with_env_run_base() {
+    // env_list with env_run_base - env_run_base should come before env.* tables
+    let start = indoc! {r#"
+        env_list = ["test"]
+
+        [env.test]
+        description = "test"
+
+        [env_run_base]
+        commands = ["pytest"]
+    "#};
+    let expected = indoc! {r#"
+        env_list = ["test"]
+
+        [env_run_base]
+        commands = ["pytest"]
+
+        [env.test]
+        description = "test"
+    "#};
     let root_ast = parse(start).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
     reorder_tables(&root_ast, &tables);


### PR DESCRIPTION
This PR enables tox-toml-fmt to order env.* tables according to the env_list definition. When a tox.toml file contains an env_list, the formatter will now reorder env.* sections to match that order.

For example, given a tox.toml with:
```toml
env_list = ["lint", "type", "test"]

[env.test]
description = "run tests"

[env.lint]
description = "run linters"

[env.type]
description = "run type checker"
```

The formatter will reorder the sections to match env_list order:
```toml
env_list = ["lint", "type", "test"]

[env.lint]
description = "run linters"

[env.type]
description = "run type checker"

[env.test]
description = "run tests"
```

When no env_list is present, env.* tables are sorted alphabetically (existing behavior). The implementation adds a multi_level_prefixes parameter to tables.reorder() in the common library, which allows callers to specify which prefixes should use two-part base keys for ordering purposes.

This PR also adds CODECOV_TOKEN to workflow files to fix the missing BASE report issue in codecov.