### PR TITLE
📚 Document formatting principles and normalizations

### DIFF
--- a/pyproject-fmt/docs/index.rst
+++ b/pyproject-fmt/docs/index.rst
@@ -11,16 +11,67 @@ This tool aims to be an *opinionated formatter*, with similar objectives to `bla
 This means it deliberately does not support a wide variety of configuration settings. In return, you get consistency,
 predictability, and smaller diffs.
 
+Formatting Principles
+---------------------
+
+``pyproject-fmt`` applies the following formatting rules to your ``pyproject.toml`` file:
+
+**Table Organization** - Tables are reordered into a consistent structure. The ``[build-system]`` section appears
+first, followed by ``[project]``, then ``[tool]`` sections in a defined order (e.g., ``tool.ruff`` before other tools),
+and finally other tables.
+
+**Comment Preservation** - All comments in your file are preserved during formatting, including inline comments and
+comments before entries. Comments are aligned for better readability.
+
+**Array and Dictionary Formatting** - Arrays and dictionaries are automatically expanded to multiple lines when they
+exceed the configured column width. Trailing commas are added to multi-line arrays for consistency. When within the
+column limit, they remain on a single line.
+
+**Indentation and Column Width** - Your entire file is reformatted with consistent indentation and respects the
+configured column width for line breaking decisions.
+
+**Table Formatting** - Sub-tables can be formatted as either collapsed dotted keys (``project.urls.homepage``) or
+expanded table headers (``[project.urls]``). You can configure global defaults and override specific tables.
+
+Normalizations and Transformations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the formatting principles above, ``pyproject-fmt`` performs the following normalizations:
+
+**Version Specifiers** - All PEP 508 version specifiers are normalized by removing spaces around operators
+(e.g., ``package >= 1.0`` becomes ``package>=1.0``), optionally removing redundant trailing zeros (e.g., ``1.0``
+becomes ``1``) unless ``keep_full_version = true``, and validating against PEP 508 standards.
+
+**Dependency Sorting** - Dependencies are sorted by their canonical package name. In ``[build-system]`` ``requires``
+arrays, dependencies are sorted alphabetically. In ``[dependency-groups]``, dependencies are sorted with regular
+requirements first, then include-group entries.
+
+**Python Version Classifiers** - Programming Language classifiers for Python versions are automatically generated
+based on the ``requires-python`` field (which sets the lower bound, defaults to oldest supported Python), the
+``max_supported_python`` configuration option (which sets the upper bound), and can be disabled with
+``generate_python_version_classifiers = false``.
+
+**Authors and Maintainers** - Contact information can be collapsed to inline tables on the ``project.authors`` or
+``project.maintainers`` line, or expanded to full ``[[project.authors]]`` array of tables format, and this is
+controlled by ``table_format``, ``expand_tables``, and ``collapse_tables`` configuration options.
+
+**Ruff Configuration** - The ``[tool.ruff]`` section receives special formatting where sub-tables (``tool.ruff.lint``,
+``tool.ruff.format``, etc.) can be collapsed or expanded based on configuration, and lists like ``exclude``,
+``include``, and rule selections are sorted.
+
+**Entry Points** - The ``[project.entry-points]`` section is formatted as inline tables for compactness unless
+expanded by configuration.
+
 Use
 ---
 
 Via ``CLI``
 ~~~~~~~~~~~
 
-:pypi:`pyproject-fmt` is a CLI tool that needs a Python interpreter (version 3.10 or higher) to run. We recommend either
-:pypi:`pipx` or :pypi:`uv` to install pyproject-fmt into an isolated environment. This has the added benefit that later you'll
-be able to upgrade pyproject-fmt without affecting other parts of the system. We provide method for ``pip`` too here but we
-discourage that path if you can:
+:pypi:`pyproject-fmt` is a CLI tool that needs a Python interpreter (version 3.10 or higher) to run. We recommend
+either :pypi:`pipx` or :pypi:`uv` to install pyproject-fmt into an isolated environment. This has the added benefit that
+later you will be able to upgrade pyproject-fmt without affecting other parts of the system. We provide a method for
+``pip`` too here, but we discourage that path if you can:
 
 .. tab:: uv
 
@@ -69,6 +120,18 @@ See :gh:`pre-commit/pre-commit` for instructions, sample ``.pre-commit-config.ya
 Via Python
 ~~~~~~~~~~
 
+You can use ``pyproject-fmt`` as a Python module to format TOML content programmatically.
+
+.. code-block:: python
+
+    from pyproject_fmt import run
+
+    # Format a pyproject.toml file and return the exit code
+    exit_code = run(["path/to/pyproject.toml"])
+
+The ``run`` function accepts command-line arguments as a list and returns an exit code (0 for success, non-zero for
+failure).
+
 .. automodule:: pyproject_fmt
    :members:
 
@@ -86,28 +149,32 @@ The ``tool.pyproject-fmt`` table is used when present in the ``pyproject.toml`` 
 
   [tool.pyproject-fmt]
 
-  # after how many column width split arrays/dicts into multiple lines, 1 will force always
+  # After how many columns split arrays/dicts into multiple lines (1 forces always)
   column_width = 120
 
-  # how many spaces use for indentation
+  # Number of spaces for indentation
   indent = 2
 
-  # if false will remove unnecessary trailing ``.0``'s from version specifiers
+  # Keep full version numbers (e.g., 1.0.0 instead of 1.0) in dependency specifiers
   keep_full_version = false
 
-  # maximum Python version to use when generating version specifiers
+  # Automatically generate Python version classifiers based on requires-python
+  # Set to false to disable automatic classifier generation
+  generate_python_version_classifiers = true
+
+  # Maximum Python version for generating version classifiers
   max_supported_python = "3.12"
 
-  # table format: "short" collapses sub-tables to dotted keys, "long" expands to [table.subtable] headers
+  # Table format: "short" collapses sub-tables to dotted keys, "long" expands to [table.subtable] headers
   table_format = "short"
 
-  # list of tables to force expand regardless of table_format setting
+  # List of tables to force expand regardless of table_format setting
   expand_tables = ["project.entry-points", "project.optional-dependencies"]
 
-  # list of tables to force collapse regardless of table_format or expand_tables settings
+  # List of tables to force collapse regardless of table_format or expand_tables settings
   collapse_tables = ["project.urls"]
 
-If not set they will default to values from the CLI, the example above shows the defaults.
+If not set they will default to values from the CLI. The example above shows the defaults.
 
 Command line interface
 ----------------------
@@ -131,9 +198,14 @@ needs to know the range of Python interpreter versions you support:
 Table formatting
 ----------------
 
+.. note::
+
+  Table formatting options are available in version 2.12.0 and later.
+
 You can control how sub-tables are formatted in your ``pyproject.toml`` file. There are two formatting styles:
 
-**Short format (collapsed)** - The default behavior where sub-tables are collapsed into dotted keys:
+**Short format (collapsed)** - The default behavior where sub-tables are collapsed into dotted keys. Use this for a
+compact representation:
 
 .. code-block:: toml
 
@@ -143,7 +215,8 @@ You can control how sub-tables are formatted in your ``pyproject.toml`` file. Th
   urls.repository = "https://github.com/example/myproject"
   scripts.mycli = "mypackage:main"
 
-**Long format (expanded)** - Sub-tables are expanded into separate ``[table.subtable]`` sections:
+**Long format (expanded)** - Sub-tables are expanded into separate ``[table.subtable]`` sections. Use this for
+readability when tables have many keys or complex values:
 
 .. code-block:: toml
 
@@ -160,13 +233,15 @@ You can control how sub-tables are formatted in your ``pyproject.toml`` file. Th
 Configuration priority
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The formatting behavior is determined by a priority system:
+The formatting behavior is determined by a priority system that allows you to set a global default while overriding
+specific tables:
 
-1. **collapse_tables** - Highest priority, forces specific tables to be collapsed
+1. **collapse_tables** - Highest priority, forces specific tables to be collapsed regardless of other settings
 2. **expand_tables** - Medium priority, forces specific tables to be expanded
-3. **table_format** - Lowest priority, sets the default behavior for all tables
+3. **table_format** - Lowest priority, sets the default behavior for all tables not explicitly configured
 
-This allows you to set a global default and override specific tables. For example:
+This three-tier approach lets you fine-tune formatting for specific tables while maintaining a consistent default.
+For example:
 
 .. code-block:: toml
 

--- a/pyproject-fmt/docs/index.rst
+++ b/pyproject-fmt/docs/index.rst
@@ -62,6 +62,33 @@ controlled by ``table_format``, ``expand_tables``, and ``collapse_tables`` confi
 **Entry Points** - The ``[project.entry-points]`` section is formatted as inline tables for compactness unless
 expanded by configuration.
 
+Handled Tables
+~~~~~~~~~~~~~~
+
+``pyproject-fmt`` applies intelligent formatting to the following tables and sections in your ``pyproject.toml`` file.
+
+The ``[build-system]`` table receives special attention: dependencies in the ``requires`` array are normalized and
+sorted alphabetically by canonical package name. The table keys are reordered to a consistent order: ``build-backend``,
+``requires``, then ``backend-path``.
+
+The ``[project]`` table is formatted with reorered keys in a logical order and receives transformations on several
+sub-sections. Authors and maintainers can be formatted as inline tables or expanded array of tables. Project URLs,
+scripts, GUI scripts, and entry points are formatted according to your ``table_format`` configuration and can be
+individually controlled via ``expand_tables`` and ``collapse_tables``. Python version classifiers are automatically
+maintained based on your ``requires-python`` setting.
+
+The ``[dependency-groups]`` table (introduced in PEP 735) is processed where all dependencies are normalized according
+to PEP 508 and sorted. Each dependency group is treated as an array, and entries can be simple strings or inline tables
+with include-group references, which are sorted appropriately.
+
+Tool-specific sections under ``[tool]`` follow a predefined order to ensure consistency across projects. The formatter
+recognizes over 50 tool sections (including poetry, pdm, setuptools, ruff, mypy, pytest, tox, coverage, and many others)
+and orders them in a standard sequence. The ``[tool.ruff]`` section receives special treatment where sub-sections like
+``lint``, ``format``, and others can be collapsed or expanded, and configuration lists are sorted.
+
+Any other tables in your file are preserved and reordered according to the standard table ordering rules, but receive
+minimal transformation unless they match one of the recognized patterns above.
+
 Use
 ---
 

--- a/tox-toml-fmt/docs/index.rst
+++ b/tox-toml-fmt/docs/index.rst
@@ -44,6 +44,30 @@ respects your configuration and ensures reproducible ordering.
 match the ``env_list`` order when specified, allowing you to control which test environments run first, and preserving
 the ordering across formatting operations.
 
+Handled Tables
+~~~~~~~~~~~~~~
+
+``tox-toml-fmt`` applies formatting to the following sections in your ``tox.toml`` file.
+
+The root-level configuration including keys like ``env_list``, ``min_version``, ``skip_missing_interpreters``, and
+other global tox settings appear at the top of your formatted file and are preserved in their original form.
+
+The ``[env_run_base]`` section, which defines base configuration inherited by all environments, is positioned after
+root-level settings. This is a special section that sets up shared behavior for test environments, like shared
+dependencies or common settings that apply across the board.
+
+Environment-specific sections follow the pattern ``[env.NAME]`` where ``NAME`` is the environment identifier (such as
+``py38``, ``py39``, ``lint``, ``type-check``, or any custom environment you define). These sections are ordered
+according to your ``env_list`` configuration if specified, ensuring that environments run in your preferred sequence.
+Any environments not explicitly listed in ``env_list`` are placed at the end, maintaining deterministic ordering across
+formatting operations.
+
+Within environment sections, configuration keys are preserved and arrays/dictionaries are formatted according to column
+width and indentation settings, just like in pyproject.toml. Comments are fully preserved and aligned for readability.
+
+Any other custom sections or keys in your tox.toml file are preserved and positioned according to the standard table
+ordering, ensuring your configuration remains valid and your custom settings are maintained.
+
 Use
 ---
 

--- a/tox-toml-fmt/docs/index.rst
+++ b/tox-toml-fmt/docs/index.rst
@@ -1,7 +1,7 @@
 tox-toml-fmt
 =============
 
-Apply a consistent format to your ``pyproject.toml`` file with comment support. See
+Apply a consistent format to your ``tox.toml`` file with comment support. See
 `changelog here <https://github.com/tox-dev/toml-fmt/blob/main/tox-toml-fmt/CHANGELOG.md>`_.
 
 
@@ -11,16 +11,49 @@ This tool aims to be an *opinionated formatter*, with similar objectives to `bla
 This means it deliberately does not support a wide variety of configuration settings. In return, you get consistency,
 predictability, and smaller diffs.
 
+Formatting Principles
+---------------------
+
+``tox-toml-fmt`` applies the following formatting rules to your ``tox.toml`` file:
+
+**Table Organization** - Tables are reordered into a consistent structure, ensuring that your tox configuration follows
+a standard order. This makes it easier to navigate and understand the file.
+
+**Comment Preservation** - All comments in your file are preserved during formatting, including inline comments and
+comments before entries. Inline comments are aligned for better readability.
+
+**Array and Dictionary Formatting** - Arrays and dictionaries are automatically expanded to multiple lines when they
+exceed the configured column width. Trailing commas are added to multi-line arrays for consistency and to minimize diff
+noise when adding new items. When within the column limit, they remain on a single line.
+
+**Indentation and Column Width** - Your entire file is reformatted with consistent indentation and respects the
+configured column width for line breaking decisions. The formatter maintains whitespace within inline tables and arrays
+to preserve readability.
+
+Normalizations and Transformations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the formatting principles above, ``tox-toml-fmt`` performs the following normalizations:
+
+**Table Ordering** - The ``tox.toml`` file follows a standard table ordering where root level keys and
+``[env_run_base]`` appear first, environment-specific sections (``[env.NAME]``) are ordered according to the
+``env_list`` configuration if present, any additional environments not in ``env_list`` follow at the end, and this
+respects your configuration and ensures reproducible ordering.
+
+**Environment List Respect** - The formatter respects the ``env_list`` configuration option by ordering environments to
+match the ``env_list`` order when specified, allowing you to control which test environments run first, and preserving
+the ordering across formatting operations.
+
 Use
 ---
 
 Via ``CLI``
 ~~~~~~~~~~~
 
-:pypi:`tox-toml-fmt` is a CLI tool that needs a Python interpreter (version 3.10 or higher) to run. We recommend either
-:pypi:`pipx` or :pypi:`uv` to install tox-toml-fmt into an isolated environment. This has the added benefit that later you'll
-be able to upgrade tox-toml-fmt without affecting other parts of the system. We provide method for ``pip`` too here but we
-discourage that path if you can:
+:pypi:`tox-toml-fmt` is a CLI tool that needs a Python interpreter (version 3.10 or higher) to run. We recommend
+either :pypi:`pipx` or :pypi:`uv` to install tox-toml-fmt into an isolated environment. This has the added benefit that
+later you will be able to upgrade tox-toml-fmt without affecting other parts of the system. We provide a method for
+``pip`` too here, but we discourage that path if you can:
 
 .. tab:: uv
 
@@ -67,6 +100,18 @@ See :gh:`pre-commit/pre-commit` for instructions, sample ``.pre-commit-config.ya
 Via Python
 ~~~~~~~~~~
 
+You can use ``tox-toml-fmt`` as a Python module to format TOML content programmatically.
+
+.. code-block:: python
+
+    from tox_toml_fmt import run
+
+    # Format a tox.toml file and return the exit code
+    exit_code = run(["path/to/tox.toml"])
+
+The ``run`` function accepts command-line arguments as a list and returns an exit code (0 for success, non-zero for
+failure).
+
 .. automodule:: tox_toml_fmt
    :members:
 
@@ -78,19 +123,19 @@ Via Python
 Configuration via file
 ----------------------
 
-The ``tox-toml-fmt`` table is used when present in the ``tox.toml`` file:
+The ``[tox-toml-fmt]`` table is used when present in the ``tox.toml`` file:
 
 .. code-block:: toml
 
   [tox-toml-fmt]
 
-  # after how many column width split arrays/dicts into multiple lines, 1 will force always
+  # After how many columns split arrays/dicts into multiple lines (1 forces always)
   column_width = 120
 
-  # how many spaces use for indentation
+  # Number of spaces for indentation
   indent = 2
 
-If not set they will default to values from the CLI, the example above shows the defaults.
+If not set they will default to values from the CLI. The example above shows the defaults.
 
 Command line interface
 ----------------------


### PR DESCRIPTION
Both `pyproject-fmt` and `tox-toml-fmt` now have comprehensive documentation explaining the formatting rules and transformations they apply to your configuration files. This makes it clearer for users to understand what changes the tools will make and why.

The documentation starts with an important design philosophy note: both tools are opinionated formatters in the spirit of Black for Python code. They intentionally provide minimal configuration because the goal is a single standard format, not maximum flexibility. This means teams spend less time debating formatting preferences and more time on actual development. While a few key options exist (column width, indentation, table formatting), the tools do not expose dozens of toggles—you get what the maintainers have carefully chosen as the right balance of readability and consistency.

The documentation now includes dedicated sections on formatting principles, covering how tables are organized, how comments are preserved and aligned, and how arrays and dictionaries are formatted based on column width constraints. Users can quickly understand the tool's opinionated approach and what to expect from the formatter.

✨ For pyproject-fmt specifically, the documentation details version specifier normalization (removing spaces, handling trailing zeros, and validating against PEP 508), dependency sorting by canonical package name, automatic Python version classifier generation based on project configuration, and how authors/maintainers and entry points are formatted. The documentation also explains how the powerful table formatting system works with `table_format`, `expand_tables`, and `collapse_tables` options. A new "Handled Tables" section explains all the tables pyproject-fmt processes, including build-system, project (with special handling for authors, maintainers, urls, scripts, and entry-points), dependency-groups, and over 50 recognized tool sections.

🔧 For tox-toml-fmt, the documentation explains how the tool respects your `env_list` configuration to order test environments and maintain reproducible formatting across operations. This is especially useful for teams wanting consistent tox.toml organization. A new "Handled Tables" section clarifies how root-level configuration, the `[env_run_base]` section, and environment-specific `[env.NAME]` sections are organized and formatted.

Both tools now have improved "Via Python" sections with concrete code examples showing how to use them as libraries, and all configuration options are documented with clear, helpful comments. All text is wrapped to 120 characters per line for consistency with the project's style guidelines.