### PR TITLE
Generate README.rst dynamically from docs at build time

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -60,6 +60,8 @@ jobs:
       - name: 🎨 Run pre-commit
         uses: tox-dev/action-pre-commit-uv@v1
         continue-on-error: true
+      - name: 📝 Generate README.rst
+        run: python tasks/generate_readme.py pyproject-fmt
       - name: 👀 Show changes
         run: git diff HEAD -u
       - name: 📤 Upload source

--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -112,6 +112,9 @@ jobs:
           cache-base: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 📝 Generate README.rst
+        run: tox run -e readme
+        working-directory: pyproject-fmt
       - name: 🔧 Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.py }}
       - name: ✅ Run tests
@@ -142,6 +145,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 🔧 Install tox
         run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv
+      - name: 🦀 Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: 📝 Generate README.rst
+        run: tox run -e readme
+        working-directory: pyproject-fmt
       - name: 🔧 Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.env }}
       - name: ✅ Run tests

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -60,6 +60,8 @@ jobs:
       - name: 🎨 Run pre-commit
         uses: tox-dev/action-pre-commit-uv@v1
         continue-on-error: true
+      - name: 📝 Generate README.rst
+        run: python tasks/generate_readme.py tox-toml-fmt
       - name: 👀 Show changes
         run: git diff HEAD -u
       - name: 📤 Upload source

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -112,6 +112,9 @@ jobs:
           cache-base: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 📝 Generate README.rst
+        run: tox run -e readme
+        working-directory: tox-toml-fmt
       - name: 🔧 Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.py }}
       - name: ✅ Run tests
@@ -142,6 +145,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 🔧 Install tox
         run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv
+      - name: 🦀 Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: 📝 Generate README.rst
+        run: tox run -e readme
+        working-directory: tox-toml-fmt
       - name: 🔧 Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.env }}
       - name: ✅ Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target
 dist
 __pycache__
 _lib.abi3.*
+# Generated files
+pyproject-fmt/README.rst
+tox-toml-fmt/README.rst

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ configuration sections. Similarly, `tox-toml-fmt/` is another Python package (al
 
 ```
 toml-fmt/                       # Workspace root
+├── tasks/                      # Development scripts
+│   └── generate_readme.py     # Generates README.rst from docs
 ├── common/                     # Shared Rust library
 │   ├── src/
 │   │   ├── lib.rs             # Module exports
@@ -329,6 +331,22 @@ let new_entry = make_entry_of_string(&"key".to_string(), &"value".to_string());
 ```
 
 ## Development Workflow
+
+After cloning the repository, you need to generate README.rst files before using maturin or `uv build`. The README.rst
+files for PyPI are dynamically generated from docs/index.rst and CHANGELOG.md. Without this step, maturin will fail with
+"Failed to read readme... No such file or directory" since pyproject.toml references README.rst.
+
+```bash
+# Required once after cloning (generates README.rst files)
+cd pyproject-fmt && tox run -e readme
+cd tox-toml-fmt && tox run -e readme
+
+# Now maturin/uv build will work
+cd pyproject-fmt && uv build .
+```
+
+The generated README.rst files are git-ignored and persist until you run `git clean -fdx`. You only need to regenerate
+if you modify docs/index.rst or CHANGELOG.md and want the README.rst updated.
 
 The typical development workflow starts with making changes in the Rust code, then running the test suite with
 `cargo test`. Check coverage using `cargo llvm-cov report` to ensure your changes are well-tested. Format your code with

--- a/pyproject-fmt/.readthedocs.yaml
+++ b/pyproject-fmt/.readthedocs.yaml
@@ -6,5 +6,6 @@ build:
     rust: "latest"
   commands:
     - pip install tox-uv
+    - tox -c pyproject-fmt/tox.toml run -e readme
     - tox -c pyproject-fmt/tox.toml run -e docs -vv --notest
     - tox -c pyproject-fmt/tox.toml run -e docs --skip-pkg-install --

--- a/pyproject-fmt/Cargo.toml
+++ b/pyproject-fmt/Cargo.toml
@@ -3,7 +3,6 @@ name = "pyproject-fmt"
 version = "2.11.1"
 description = "Format pyproject.toml files"
 repository = "https://github.com/tox-dev/pyproject-fmt"
-readme = "README.md"
 license = "MIT"
 edition = "2021"
 

--- a/pyproject-fmt/docs/index.rst
+++ b/pyproject-fmt/docs/index.rst
@@ -14,6 +14,14 @@ predictability, and smaller diffs.
 Formatting Principles
 ---------------------
 
+``pyproject-fmt`` is an opinionated formatter, much like `black <https://github.com/psf/black>`_ is for Python code.
+The tool intentionally provides minimal configuration options because the goal is to establish a single standard format
+that all ``pyproject.toml`` files follow. Rather than spending time debating formatting preferences, teams can simply
+run ``pyproject-fmt`` and have consistent, predictable results. This opinionated approach has benefits: less time
+configuring tools, smaller diffs when committing changes, and easier code reviews since formatting is never a question.
+While a few key options exist (``column_width``, ``indent``, ``table_format``, etc.), the tool does not expose dozens of
+toggles. You get what the maintainers have chosen to be the right balance of readability, consistency, and usability.
+
 ``pyproject-fmt`` applies the following formatting rules to your ``pyproject.toml`` file:
 
 **Table Organization** - Tables are reordered into a consistent structure. The ``[build-system]`` section appears

--- a/pyproject-fmt/pyproject.toml
+++ b/pyproject-fmt/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 [project]
 name = "pyproject-fmt"
 description = "Format your pyproject.toml file"
-readme = "README.md"
+readme = { file = "README.rst", content-type = "text/x-rst" }
 keywords = [
   "format",
   "pyproject",
@@ -84,6 +84,9 @@ python-source = "src"
 strip = true
 include = [
   "rust-toolchain.toml",
+  "docs/",
+  "CHANGELOG.md",
+  "README.rst",
 ]
 
 [tool.cibuildwheel]

--- a/pyproject-fmt/tox.toml
+++ b/pyproject-fmt/tox.toml
@@ -95,6 +95,13 @@ commands = [
     ],
 ]
 
+[env.readme]
+description = "generate README.rst from docs"
+skip_install = true
+dependency_groups = []
+change_dir = "{tox_root}{/}.."
+commands = [["python", "tasks{/}generate_readme.py", "pyproject-fmt"]]
+
 [env.dev]
 description = "dev environment with all deps at {envdir}"
 package = "editable"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ lint.select = [
   "ALL",
 ]
 lint.ignore = [
-  "ANN101", # no type annotation for self
   "ANN401", # allow Any as type annotation
   "COM812", # Conflict with formatter
   "CPY",    # No copyright statements

--- a/tasks/generate_readme.py
+++ b/tasks/generate_readme.py
@@ -1,0 +1,116 @@
+"""Generate README.rst from docs/index.rst and CHANGELOG.md for PyPI."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def main(package: str) -> None:
+    pkg = Path(package)
+    if not (docs_path := pkg / "docs" / "index.rst").exists():
+        return
+    processed = process_rst_for_pypi(docs_path.read_text())
+    changelog_rst = ""
+    if (changelog_path := pkg / "CHANGELOG.md").exists() and (
+        extracted := extract_latest_changelog_as_rst(changelog_path.read_text())
+    ):
+        changelog_rst = extracted
+    if changelog_rst:
+        if (pos := processed.find("\nPhilosophy")) != -1:
+            result = processed[:pos] + f"\n{changelog_rst}\n" + processed[pos:]
+        else:
+            result = processed + "\n\n" + changelog_rst
+    else:
+        result = processed
+    (pkg / "README.rst").write_text(result)
+
+
+def process_rst_for_pypi(content: str) -> str:
+    content = re.sub(r":pypi:`([^`]+)`", r"`\1 <https://pypi.org/project/\1>`_", content)
+    content = re.sub(r":gh:`([^`]+)`", r"`\1 <https://github.com/\1>`_", content)
+    result: list[str] = []
+    skip_section = False
+    skip_tab = False
+    lines = content.splitlines()
+    for i, line in enumerate(lines):
+        if (
+            any(s in line for s in ("Command line interface", "Configuration via file"))
+            and i + 1 < len(lines)
+            and (next_line := lines[i + 1])
+            and all(c in "-~=" for c in next_line)
+        ):
+            skip_section = True
+            continue
+        if skip_section:
+            if line and all(c in "-~=" for c in line):
+                skip_section = False
+            continue
+        if line.startswith(".. tab:: uv"):
+            continue
+        if line.startswith((".. tab::", ".. automodule::", ".. toctree::", ".. sphinx_argparse_cli::")):
+            skip_tab = True
+            continue
+        if skip_tab:
+            if line and not line.startswith(" ") and not line.startswith("\t"):
+                skip_tab = False
+            else:
+                continue
+        result.append(line)
+    return "\n".join(result).rstrip()
+
+
+def extract_latest_changelog_as_rst(content: str) -> str | None:
+    if (match := re.search(r"^## .+$", content, re.MULTILINE)) is None:
+        return None
+    rest = content[match.start() :]
+    version_end = rest.find("\n") if "\n" in rest else len(rest)
+    content_start = version_end + 1
+    content_end = (
+        content_start + next_match.start() if (next_match := re.search(r"\n## ", rest[content_start:])) else len(rest)
+    )
+    rst_result = "Recent Changes\n~~~~~~~~~~~~~~~~\n\n"
+    for line in rest[content_start:content_end].strip().splitlines():
+        if line.startswith("<a id="):
+            continue
+        if line.startswith("- "):
+            rst_result += f"- {convert_md_to_rst_inline(line[2:])}\n"
+        elif line:
+            rst_result += f"{convert_md_to_rst_inline(line)}\n"
+        else:
+            rst_result += "\n"
+    return rst_result.rstrip()
+
+
+def convert_md_to_rst_inline(line: str) -> str:
+    result = ""
+    in_backtick = False
+    for ch in line:
+        if ch == "`":
+            result += "``"
+            in_backtick = not in_backtick
+        else:
+            result += ch
+    if in_backtick:
+        result += "``"
+    while (start := result.find("[")) != -1:
+        if (bracket_end := result.find("]", start)) == -1:
+            break
+        if (
+            bracket_end + 1 < len(result)
+            and result[bracket_end + 1] == "("
+            and (paren_end := result.find(")", bracket_end + 2)) != -1
+        ):
+            link = f"`{result[start + 1 : bracket_end]} <{result[bracket_end + 2 : paren_end]}>`_"
+            result = f"{result[:start]}{link}{result[paren_end + 1 :]}"
+            continue
+        break
+    return result
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:  # noqa: PLR2004
+        print("Usage: generate_readme.py <package>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/tox-toml-fmt/.readthedocs.yaml
+++ b/tox-toml-fmt/.readthedocs.yaml
@@ -6,5 +6,6 @@ build:
     rust: "latest"
   commands:
     - pip install tox-uv
+    - tox -c tox-toml-fmt/tox.toml run -e readme
     - tox -c tox-toml-fmt/tox.toml run -e docs -vv --notest
     - tox -c tox-toml-fmt/tox.toml run -e docs --skip-pkg-install --

--- a/tox-toml-fmt/Cargo.toml
+++ b/tox-toml-fmt/Cargo.toml
@@ -3,7 +3,6 @@ name = "tox-toml-fmt"
 version = "1.2.2"
 description = "Format pyproject.toml files"
 repository = "https://github.com/tox-dev/tox-toml-fmt"
-readme = "README.md"
 license = "MIT"
 edition = "2021"
 

--- a/tox-toml-fmt/docs/index.rst
+++ b/tox-toml-fmt/docs/index.rst
@@ -14,6 +14,14 @@ predictability, and smaller diffs.
 Formatting Principles
 ---------------------
 
+``tox-toml-fmt`` is an opinionated formatter, much like `black <https://github.com/psf/black>`_ is for Python code.
+The tool intentionally provides minimal configuration options because the goal is to establish a single standard format
+that all ``tox.toml`` files follow. Rather than spending time debating formatting preferences, teams can simply run
+``tox-toml-fmt`` and have consistent, predictable results. This opinionated approach has benefits: less time configuring
+tools, smaller diffs when committing changes, and easier code reviews since formatting is never a question. While a few
+key options exist (``column_width``, ``indent``), the tool does not expose dozens of toggles. You get what the
+maintainers have chosen to be the right balance of readability, consistency, and usability.
+
 ``tox-toml-fmt`` applies the following formatting rules to your ``tox.toml`` file:
 
 **Table Organization** - Tables are reordered into a consistent structure, ensuring that your tox configuration follows

--- a/tox-toml-fmt/pyproject.toml
+++ b/tox-toml-fmt/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 [project]
 name = "tox-toml-fmt"
 description = "Format your pyproject.toml file"
-readme = "README.md"
+readme = { file = "README.rst", content-type = "text/x-rst" }
 keywords = [
   "format",
   "pyproject",
@@ -84,6 +84,9 @@ python-source = "src"
 strip = true
 include = [
   "rust-toolchain.toml",
+  "docs/",
+  "CHANGELOG.md",
+  "README.rst",
 ]
 
 [tool.cibuildwheel]

--- a/tox-toml-fmt/tox.toml
+++ b/tox-toml-fmt/tox.toml
@@ -95,6 +95,13 @@ commands = [
     ],
 ]
 
+[env.readme]
+description = "generate README.rst from docs"
+skip_install = true
+dependency_groups = []
+change_dir = "{tox_root}{/}.."
+commands = [["python", "tasks{/}generate_readme.py", "tox-toml-fmt"]]
+
 [env.dev]
 description = "dev environment with all deps at {envdir}"
 package = "editable"


### PR DESCRIPTION
This PR converts from static README.md files to dynamically generated README.rst files at build time. The README is now generated using a Python script in `tasks/generate_readme.py` that extracts content from docs/index.rst and appends the latest changelog entry.

The generated README includes the latest changelog entry positioned before the Philosophy section, providing users with immediate visibility into recent changes when viewing the package on PyPI. HTML anchor tags from the changelog are filtered out, and the auto-generated CLI documentation sections are excluded since they're only relevant for the Sphinx documentation site.

Both pyproject-fmt and tox-toml-fmt have a `tox run -e readme` target that runs the script. The CI workflows and ReadTheDocs configs call this target before building. The generated README.rst files are excluded from version control via .gitignore.