### PR TITLE
Use RELEASE_TOKEN to bypass branch protection for releases

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -197,6 +197,8 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: 📥 Download source
         uses: actions/download-artifact@v7
         with:
@@ -226,7 +228,7 @@ jobs:
           args: --non-interactive --skip-existing dist/*
       - name: 📢 Create GitHub release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           git pull --rebase origin main
           git push

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -197,6 +197,8 @@ jobs:
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
       - name: 📥 Download source
         uses: actions/download-artifact@v7
         with:
@@ -226,7 +228,7 @@ jobs:
           args: --non-interactive --skip-existing dist/*
       - name: 📢 Create GitHub release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           git pull --rebase origin main
           git push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "pyproject-fmt"
-version = "2.11.1"
+version = "2.12.0"
 dependencies = [
  "common",
  "indoc",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "tox-toml-fmt"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "common",
  "indoc",

--- a/pyproject-fmt/Cargo.toml
+++ b/pyproject-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyproject-fmt"
-version = "2.11.1"
+version = "2.12.0"
 description = "Format pyproject.toml files"
 repository = "https://github.com/tox-dev/pyproject-fmt"
 license = "MIT"

--- a/tox-toml-fmt/Cargo.toml
+++ b/tox-toml-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tox-toml-fmt"
-version = "1.2.2"
+version = "1.3.0"
 description = "Format pyproject.toml files"
 repository = "https://github.com/tox-dev/tox-toml-fmt"
 license = "MIT"


### PR DESCRIPTION
- Use `RELEASE_TOKEN` secret (a PAT with bypass permissions) instead of `GITHUB_TOKEN` for release workflow
- Fixes release workflow failing due to branch protection blocking direct pushes to main