### PR TITLE
Fix regex for SPDX license normalization

### DIFF
--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -74,10 +74,13 @@ pub fn fix(
             update_content(entry, |s| String::from(s));
         }
         "license" => {
-            static LICENSE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)\b(and|or|with)\b").unwrap());
+            static LICENSE_RE: LazyLock<Regex> =
+                LazyLock::new(|| Regex::new(r"(?i)([^-])\b(and|or|with)\b([^-])").unwrap());
             update_content(entry, |s| {
                 LICENSE_RE
-                    .replace_all(s, |caps: &regex::Captures| caps[1].to_uppercase())
+                    .replace_all(s, |caps: &regex::Captures| {
+                        format!("{}{}{}", &caps[1], caps[2].to_uppercase(), &caps[3])
+                    })
                     .to_string()
             });
         }

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -298,11 +298,11 @@ fn evaluate(
 #[case::project_license_normalize(
         indoc ! {r#"
     [project]
-    license = "mit or apache-2.0 with llvm-exception and gpl-3.0-only"
+    license = "mit or apache-2.0 with llvm-exception and gpl-3.0-only and AGPL-3.0-or-later"
     "#},
         indoc ! {r#"
     [project]
-    license = "mit OR apache-2.0 WITH llvm-exception AND gpl-3.0-only"
+    license = "mit OR apache-2.0 WITH llvm-exception AND gpl-3.0-only AND AGPL-3.0-or-later"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
       "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Before, it would not recognize and/or/with inside a license identifier, e.g. `GPL-2.0-or-later`, and uppercase it incorrectly.