### PR TITLE
Trigger pre-commit mirror sync after release

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -239,3 +239,7 @@ jobs:
           ${{ needs.bump.outputs.changelog }}
           EOM
           )"
+      - name: 🔄 Trigger pre-commit mirror sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: gh workflow run main.yaml --repo tox-dev/pyproject-fmt

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -239,3 +239,7 @@ jobs:
           ${{ needs.bump.outputs.changelog }}
           EOM
           )"
+      - name: 🔄 Trigger pre-commit mirror sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: gh workflow run main.yaml --repo tox-dev/tox-toml-fmt


### PR DESCRIPTION
After publishing a new release to PyPI and creating the GitHub release, we now trigger the mirror workflow in the respective pre-commit hook repositories. This ensures the pre-commit hooks are updated immediately when a new version is released, rather than waiting for the scheduled daily sync.

For pyproject-fmt releases, the workflow at `tox-dev/pyproject-fmt` is triggered. For tox-toml-fmt releases, the workflow at `tox-dev/tox-toml-fmt` is triggered. Both use the existing `RELEASE_TOKEN` PAT which has permissions to dispatch workflows in the tox-dev organization.