### PR TITLE
Fix comment before table moving incorrectly when table has comments

### DIFF
--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -75,12 +75,14 @@ impl Tables {
 
                 // Find the first COMMENT after the last ENTRY - that's where we split
                 let last_entry_pos = borrow.iter().rposition(|x| x.kind() == ENTRY);
-                let first_comment_pos = borrow.iter().position(|x| x.kind() == COMMENT);
 
-                let comments_start = match (last_entry_pos, first_comment_pos) {
-                    (Some(entry_pos), Some(comment_pos)) if comment_pos > entry_pos => comment_pos,
-                    (None, Some(comment_pos)) => comment_pos, // No entries, but has comments
-                    _ => borrow.len(),                        // No comments to move
+                let comments_start = match last_entry_pos {
+                    Some(entry_pos) => borrow
+                        .iter()
+                        .skip(entry_pos + 1)
+                        .position(|x| x.kind() == COMMENT)
+                        .map_or(borrow.len(), |p| entry_pos + 1 + p),
+                    None => borrow.iter().position(|x| x.kind() == COMMENT).unwrap_or(borrow.len()),
                 };
 
                 // Split: keep elements for previous table, extract comments for new table

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -177,6 +177,53 @@ use crate::{format_toml, Settings};
         true,
         (3, 9)
 )]
+#[case::issue_124_comment_before_table(
+        indoc ! {r#"
+    [project]
+    name = "test"
+    requires-python = ">=3.10"
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.11",
+      "Programming Language :: Python :: 3.12",
+      "Programming Language :: Python :: 3.13",
+      "Programming Language :: Python :: 3.14",
+    ]
+    urls."Repository" = "https://github.com/example/test"
+
+    scripts.gha-utils = "gha_utils.__main__:main"
+
+    # Non-runtime development dependency groups.
+    [dependency-groups]
+    test = ["pytest"]
+    "#},
+        indoc ! {r#"
+    [project]
+    name = "test"
+    requires-python = ">=3.10"
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.11",
+      "Programming Language :: Python :: 3.12",
+      "Programming Language :: Python :: 3.13",
+      "Programming Language :: Python :: 3.14",
+    ]
+    urls."Repository" = "https://github.com/example/test"
+
+    scripts.gha-utils = "gha_utils.__main__:main"
+
+    # Non-runtime development dependency groups.
+    [dependency-groups]
+    test = [
+      "pytest",
+    ]
+    "#},
+        2,
+        true,
+        (3, 14)
+)]
 fn test_format_toml(
     #[case] start: &str,
     #[case] expected: &str,


### PR DESCRIPTION
When a table has comments inside (before entries), the trailing comment before the next table header was incorrectly included in the current table. For example, with:

```toml
[project]
name = "test"
# Comment before requires-python
requires-python = ">=3.10"

scripts.main = "app:main"

# Comment for dependency-groups
[dependency-groups]
test = ["pytest"]
```

The comment `# Comment for dependency-groups` would incorrectly be moved before `scripts.main` instead of staying with `[dependency-groups]`.

The issue was that the code searched for the first COMMENT in the entire table, rather than searching for the first COMMENT after the last ENTRY. The fix searches for comments only after the last entry, ensuring that inline comments stay with their entries while trailing comments are correctly associated with the following table.

Fixes #124