### PR TITLE
Fix expand_tables setting for deeply nested tables

### DIFF
--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -513,15 +513,13 @@ pub fn expand_sub_tables(tables: &mut Tables, name: &str) {
 
 /// Collapse a single sub-table into dotted keys in the parent table.
 /// For example, `[project.urls]` with `homepage = "..."` becomes `urls.homepage = "..."` in `[project]`.
-pub fn collapse_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str) {
+/// For array of tables, converts to inline array if it fits within column_width.
+pub fn collapse_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str, column_width: usize) {
     let full_name = format!("{parent_name}.{sub_name}");
     let sub_positions = match tables.header_to_pos.get(&full_name) {
         Some(p) if !p.is_empty() => p.clone(),
         _ => return,
     };
-    if sub_positions.len() != 1 {
-        return;
-    }
 
     if !tables.header_to_pos.contains_key(parent_name) {
         tables
@@ -534,13 +532,21 @@ pub fn collapse_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str
         return;
     }
 
-    let mut main = tables.table_set[*main_positions.first().unwrap()].borrow_mut();
-    let mut sub = tables.table_set[*sub_positions.first().unwrap()].borrow_mut();
+    let first_sub = tables.table_set[*sub_positions.first().unwrap()].borrow();
+    let is_array_table = first_sub.iter().any(|child| child.kind() == TABLE_ARRAY_HEADER);
+    drop(first_sub);
 
-    let is_array_table = sub.iter().any(|child| child.kind() == TABLE_ARRAY_HEADER);
     if is_array_table {
+        collapse_array_of_tables(tables, parent_name, sub_name, &sub_positions, column_width);
         return;
     }
+
+    if sub_positions.len() != 1 {
+        return;
+    }
+
+    let mut main = tables.table_set[*main_positions.first().unwrap()].borrow_mut();
+    let mut sub = tables.table_set[*sub_positions.first().unwrap()].borrow_mut();
 
     let mut header = false;
     for child in sub.iter() {
@@ -576,6 +582,73 @@ pub fn collapse_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str
         main.push(child.clone());
     }
     sub.clear();
+}
+
+fn collapse_array_of_tables(
+    tables: &mut Tables,
+    parent_name: &str,
+    sub_name: &str,
+    sub_positions: &[usize],
+    column_width: usize,
+) {
+    let mut inline_tables: Vec<String> = Vec::new();
+
+    for pos in sub_positions {
+        let sub = tables.table_set[*pos].borrow();
+        let mut entries: Vec<String> = Vec::new();
+
+        for child in sub.iter() {
+            if child.kind() != ENTRY {
+                continue;
+            }
+            let entry_node = child.as_node().unwrap();
+            let key = entry_node
+                .children_with_tokens()
+                .find(|c| c.kind() == KEY)
+                .map(|c| c.as_node().unwrap().text().to_string().trim().to_string())
+                .unwrap_or_default();
+            let value = entry_node
+                .children_with_tokens()
+                .find(|c| c.kind() == VALUE)
+                .map(|c| c.as_node().unwrap().text().to_string().trim().to_string())
+                .unwrap_or_default();
+            if !key.is_empty() && !value.is_empty() {
+                entries.push(format!("{key} = {value}"));
+            }
+        }
+
+        if !entries.is_empty() {
+            let inline_table = format!("{{ {} }}", entries.join(", "));
+            if inline_table.len() > column_width {
+                return;
+            }
+            inline_tables.push(inline_table);
+        }
+    }
+
+    if inline_tables.is_empty() {
+        return;
+    }
+
+    let array_value = format!("[{}]", inline_tables.join(", "));
+    let entry_text = format!("{sub_name} = {array_value}\n");
+
+    let main_positions = &tables.header_to_pos[parent_name];
+    let mut main = tables.table_set[*main_positions.first().unwrap()].borrow_mut();
+
+    if main.last().is_some_and(|e| e.kind() != NEWLINE) {
+        main.push(make_newline());
+    }
+
+    let parsed = taplo::parser::parse(&entry_text);
+    let parsed_root = parsed.into_syntax().clone_for_update();
+    if let Some(entry) = parsed_root.children_with_tokens().find(|c| c.kind() == ENTRY) {
+        main.push(entry);
+    }
+
+    for pos in sub_positions {
+        tables.table_set[*pos].borrow_mut().clear();
+    }
 }
 
 /// Expand dotted keys with a specific prefix into a separate sub-table.
@@ -666,14 +739,73 @@ pub fn expand_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str) 
     tables.header_to_pos.entry(full_name).or_default().push(pos);
 }
 
+fn count_unquoted_dots(s: &str) -> usize {
+    let mut count = 0;
+    let mut in_quotes = false;
+    for c in s.chars() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            '.' if !in_quotes => count += 1,
+            _ => {}
+        }
+    }
+    count
+}
+
+fn split_table_name(full_name: &str) -> Option<(&str, &str)> {
+    let mut depth = 0;
+    for (i, c) in full_name.char_indices().rev() {
+        match c {
+            '"' => depth = 1 - depth,
+            '.' if depth == 0 => return Some((&full_name[..i], &full_name[i + 1..])),
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Apply table formatting (collapse/expand) to all sub-tables under specified prefixes.
+/// The `should_collapse` function determines whether each table should be collapsed.
+/// `column_width` is used to determine if array of tables can fit as inline arrays.
+pub fn apply_table_formatting<F>(tables: &mut Tables, should_collapse: F, prefixes: &[&str], column_width: usize)
+where
+    F: Fn(&str) -> bool,
+{
+    let mut all_sub_tables: Vec<String> = Vec::new();
+    for prefix in prefixes {
+        collect_all_sub_tables(tables, prefix, &mut all_sub_tables);
+    }
+    all_sub_tables.sort_by(|a, b| {
+        let depth_a = count_unquoted_dots(a);
+        let depth_b = count_unquoted_dots(b);
+        match depth_b.cmp(&depth_a) {
+            std::cmp::Ordering::Equal => a.cmp(b),
+            other => other,
+        }
+    });
+    for full_name in all_sub_tables {
+        if let Some((parent, sub)) = split_table_name(&full_name) {
+            if should_collapse(&full_name) {
+                collapse_sub_table(tables, parent, sub, column_width);
+            } else {
+                expand_sub_table(tables, parent, sub);
+            }
+        }
+    }
+}
+
 /// Recursively collect all sub-table full names under a parent.
 /// For "project", returns ["project.urls", "project.entry-points", "project.entry-points.tox", ...].
+/// Also includes intermediate parent tables that don't have explicit headers but are implied
+/// by deeper nested tables.
 pub fn collect_all_sub_tables(tables: &Tables, parent_name: &str, result: &mut Vec<String>) {
     let prefix = format!("{parent_name}.");
+    let prefix_dots = count_unquoted_dots(parent_name);
 
     for key in tables.header_to_pos.keys() {
         if key.starts_with(&prefix) && key != parent_name {
             result.push(key.clone());
+            add_intermediate_parents(key, prefix_dots, result);
         }
     }
 
@@ -696,5 +828,18 @@ pub fn collect_all_sub_tables(tables: &Tables, parent_name: &str, result: &mut V
                 result.push(full_name);
             }
         }
+    }
+}
+
+fn add_intermediate_parents(table_name: &str, prefix_dots: usize, result: &mut Vec<String>) {
+    let mut current = table_name;
+    while let Some((parent, _)) = split_table_name(current) {
+        if count_unquoted_dots(parent) <= prefix_dots {
+            break;
+        }
+        if !result.contains(&String::from(parent)) {
+            result.push(String::from(parent));
+        }
+        current = parent;
     }
 }

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -4,8 +4,8 @@ use taplo::formatter::{format_syntax, Options};
 use taplo::parser::parse;
 
 use crate::table::{
-    collapse_sub_table, collapse_sub_tables, collect_all_sub_tables, expand_sub_table, expand_sub_tables, find_key,
-    for_entries, get_table_name, reorder_table_keys, Tables,
+    apply_table_formatting, collapse_sub_table, collapse_sub_tables, collect_all_sub_tables, expand_sub_table,
+    expand_sub_tables, find_key, for_entries, get_table_name, reorder_table_keys, Tables,
 };
 
 #[test]
@@ -897,7 +897,7 @@ fn test_collapse_sub_table_single() {
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
 
-    collapse_sub_table(&mut tables, "project", "urls");
+    collapse_sub_table(&mut tables, "project", "urls", 120);
 
     let main = tables.get("project").unwrap();
     let table = main[0].borrow();
@@ -919,12 +919,12 @@ fn test_collapse_sub_table_creates_parent() {
     let mut tables = Tables::from_ast(&root_ast);
 
     assert!(!tables.header_to_pos.contains_key("project"));
-    collapse_sub_table(&mut tables, "project", "urls");
+    collapse_sub_table(&mut tables, "project", "urls", 120);
     assert!(tables.header_to_pos.contains_key("project"));
 }
 
 #[test]
-fn test_collapse_sub_table_skips_array_tables() {
+fn test_collapse_sub_table_converts_array_tables_to_inline() {
     let toml = indoc! {r#"
         [project]
         name = "foo"
@@ -935,11 +935,41 @@ fn test_collapse_sub_table_skips_array_tables() {
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
 
-    collapse_sub_table(&mut tables, "project", "authors");
+    collapse_sub_table(&mut tables, "project", "authors", 120);
 
     let authors = tables.get("project.authors").unwrap();
     let authors_table = authors[0].borrow();
-    assert!(!authors_table.is_empty(), "array tables should not be collapsed");
+    assert!(
+        authors_table.is_empty(),
+        "array tables should be collapsed to inline array"
+    );
+
+    let project = tables.get("project").unwrap();
+    let project_table = project[0].borrow();
+    let txt = project_table.iter().map(|e| e.to_string()).collect::<String>();
+    assert!(
+        txt.contains("authors = [{ name = \"Alice\" }]"),
+        "should have inline array"
+    );
+}
+
+#[test]
+fn test_collapse_sub_table_keeps_wide_array_tables() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+
+        [[project.authors]]
+        name = "This is a very long author name that will definitely exceed the column width limit"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    collapse_sub_table(&mut tables, "project", "authors", 80);
+
+    let authors = tables.get("project.authors").unwrap();
+    let authors_table = authors[0].borrow();
+    assert!(!authors_table.is_empty(), "wide array tables should not be collapsed");
 }
 
 #[test]
@@ -951,7 +981,7 @@ fn test_collapse_sub_table_non_existent() {
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
 
-    collapse_sub_table(&mut tables, "project", "nonexistent");
+    collapse_sub_table(&mut tables, "project", "nonexistent", 120);
 }
 
 #[test]
@@ -1095,7 +1125,7 @@ fn test_collapse_sub_table_multiple_main_positions() {
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
 
-    collapse_sub_table(&mut tables, "project", "urls");
+    collapse_sub_table(&mut tables, "project", "urls", 120);
 
     let urls = tables.get("project.urls").unwrap();
     assert!(
@@ -1142,7 +1172,7 @@ fn test_collapse_sub_table_multiple_sub_positions() {
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
 
-    collapse_sub_table(&mut tables, "project", "urls");
+    collapse_sub_table(&mut tables, "project", "urls", 120);
 }
 
 #[test]
@@ -1190,7 +1220,7 @@ fn test_collapse_sub_table_empty_sub_table() {
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
 
-    collapse_sub_table(&mut tables, "project", "urls");
+    collapse_sub_table(&mut tables, "project", "urls", 120);
 }
 
 #[test]
@@ -1237,7 +1267,7 @@ fn test_collapse_sub_table_with_comments() {
     let root_ast = parse(toml).into_syntax().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
 
-    collapse_sub_table(&mut tables, "project", "urls");
+    collapse_sub_table(&mut tables, "project", "urls", 120);
 
     let main = tables.get("project").unwrap();
     let table = main[0].borrow();
@@ -1301,4 +1331,118 @@ fn test_tables_from_ast_with_root_comments_only() {
     let tables = Tables::from_ast(&root_ast);
 
     assert!(tables.header_to_pos.contains_key("project"));
+}
+
+#[test]
+fn test_apply_table_formatting_collapse() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+
+        [project.urls]
+        homepage = "https://example.com"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    apply_table_formatting(&mut tables, |_| true, &["project"], 120);
+
+    let main = tables.get("project").unwrap();
+    let table = main[0].borrow();
+    let txt = table.iter().map(|e| e.to_string()).collect::<String>();
+    assert!(txt.contains("urls.homepage"));
+}
+
+#[test]
+fn test_apply_table_formatting_expand() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+        urls.homepage = "https://example.com"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    apply_table_formatting(&mut tables, |_| false, &["project"], 120);
+
+    assert!(tables.header_to_pos.contains_key("project.urls"));
+}
+
+#[test]
+fn test_apply_table_formatting_deeply_nested() {
+    let toml = indoc! {r#"
+        [tool.ruff]
+        line-length = 120
+
+        [tool.ruff.lint.flake8-tidy-imports.banned-api]
+        "collections.namedtuple".msg = "Use typing.NamedTuple"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    apply_table_formatting(
+        &mut tables,
+        |name| name != "tool.ruff.lint.flake8-tidy-imports.banned-api",
+        &["tool.ruff"],
+        120,
+    );
+
+    assert!(
+        tables
+            .header_to_pos
+            .contains_key("tool.ruff.lint.flake8-tidy-imports.banned-api"),
+        "deeply nested table should stay expanded"
+    );
+}
+
+#[test]
+fn test_apply_table_formatting_quoted_keys() {
+    let toml = indoc! {r#"
+        [tool.ruff.lint.flake8-tidy-imports."banned-api"]
+        "typing.Dict".msg = "use dict"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    apply_table_formatting(&mut tables, |_| false, &["tool.ruff"], 120);
+
+    assert!(tables
+        .header_to_pos
+        .contains_key("tool.ruff.lint.flake8-tidy-imports.\"banned-api\""));
+}
+
+#[test]
+fn test_apply_table_formatting_multiple_prefixes() {
+    let toml = indoc! {r#"
+        [project]
+        name = "foo"
+        urls.homepage = "https://example.com"
+
+        [build-system]
+        requires.build = "setuptools"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let mut tables = Tables::from_ast(&root_ast);
+
+    apply_table_formatting(&mut tables, |_| false, &["project", "build-system"], 120);
+
+    assert!(tables.header_to_pos.contains_key("project.urls"));
+    assert!(tables.header_to_pos.contains_key("build-system.requires"));
+}
+
+#[test]
+fn test_collect_all_sub_tables_includes_intermediate_parents() {
+    let toml = indoc! {r#"
+        [tool.ruff.lint.flake8-tidy-imports.banned-api]
+        "typing.Dict".msg = "use dict"
+    "#};
+    let root_ast = parse(toml).into_syntax().clone_for_update();
+    let tables = Tables::from_ast(&root_ast);
+
+    let mut result = Vec::new();
+    collect_all_sub_tables(&tables, "tool.ruff", &mut result);
+
+    assert!(result.contains(&String::from("tool.ruff.lint")));
+    assert!(result.contains(&String::from("tool.ruff.lint.flake8-tidy-imports")));
+    assert!(result.contains(&String::from("tool.ruff.lint.flake8-tidy-imports.banned-api")));
 }

--- a/pyproject-fmt/docs/index.rst
+++ b/pyproject-fmt/docs/index.rst
@@ -335,3 +335,23 @@ The following sub-tables can be formatted with this configuration:
 
 - ``project.authors`` - Can be inline tables or ``[[project.authors]]``
 - ``project.maintainers`` - Can be inline tables or ``[[project.maintainers]]``
+- Any ``[[table]]`` entries throughout the file
+
+Array of tables (``[[table]]``) are automatically collapsed to inline arrays when each inline table fits within the
+configured ``column_width``. For example:
+
+.. code-block:: toml
+
+  # Before
+  [[tool.commitizen.customize.questions]]
+  type = "list"
+
+  [[tool.commitizen.customize.questions]]
+  type = "input"
+
+  # After (with table_format = "short")
+  [tool.commitizen]
+  customize.questions = [{ type = "list" }, { type = "input" }]
+
+If any inline table exceeds ``column_width``, the array of tables remains in ``[[...]]`` format to maintain
+readability and TOML 1.0.0 compatibility (inline tables cannot span multiple lines).

--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -5,9 +5,7 @@ use common::create::{
 };
 use common::pep508::Requirement;
 use common::string::{load_text, update_content};
-use common::table::{
-    collapse_sub_table, collect_all_sub_tables, expand_sub_table, for_entries, reorder_table_keys, Tables,
-};
+use common::table::{for_entries, reorder_table_keys, Tables};
 use common::taplo::syntax::SyntaxKind::{
     ARRAY, BRACKET_END, BRACKET_START, COMMA, ENTRY, IDENT, INLINE_TABLE, KEY, NEWLINE, STRING, VALUE,
 };
@@ -32,7 +30,6 @@ pub fn fix(
 ) {
     let key_order = &["name", "email"];
 
-    // Handle array of tables (authors/maintainers)
     if table_config.should_collapse("project.authors") {
         collapse_array_of_tables(tables, "project.authors", key_order);
     } else {
@@ -44,21 +41,6 @@ pub fn fix(
         expand_array_of_tables(tables, "project.maintainers", key_order);
     }
 
-    // Handle sub-tables (urls, scripts, gui-scripts, optional-dependencies, entry-points)
-    // Process nested sub-tables first (e.g., project.entry-points.tox before project.entry-points)
-    let mut all_sub_tables: Vec<String> = Vec::new();
-    collect_all_sub_tables(tables, "project", &mut all_sub_tables);
-    all_sub_tables.sort_by_key(|b| std::cmp::Reverse(count_unquoted_dots(b)));
-
-    for full_name in all_sub_tables {
-        if let Some((parent, sub)) = split_table_name(&full_name) {
-            if table_config.should_collapse(&full_name) {
-                collapse_sub_table(tables, parent, sub);
-            } else {
-                expand_sub_table(tables, parent, sub);
-            }
-        }
-    }
     let table_element = tables.get("project");
     if table_element.is_none() {
         return;
@@ -245,32 +227,6 @@ pub fn fix(
             "entry-points",
         ],
     );
-}
-
-fn count_unquoted_dots(s: &str) -> usize {
-    let mut count = 0;
-    let mut in_quotes = false;
-    for c in s.chars() {
-        match c {
-            '"' => in_quotes = !in_quotes,
-            '.' if !in_quotes => count += 1,
-            _ => {}
-        }
-    }
-    count
-}
-
-fn split_table_name(full_name: &str) -> Option<(&str, &str)> {
-    let mut last_unquoted_dot = None;
-    let mut in_quotes = false;
-    for (i, c) in full_name.char_indices() {
-        match c {
-            '"' => in_quotes = !in_quotes,
-            '.' if !in_quotes => last_unquoted_dot = Some(i),
-            _ => {}
-        }
-    }
-    last_unquoted_dot.map(|i| (&full_name[..i], &full_name[i + 1..]))
 }
 
 fn expand_entry_points_inline_tables(table: &mut RefMut<Vec<SyntaxElement>>) {

--- a/pyproject-fmt/rust/src/ruff.rs
+++ b/pyproject-fmt/rust/src/ruff.rs
@@ -1,17 +1,10 @@
 use common::array::{sort_strings, transform};
 use common::string::update_content;
-use common::table::{collapse_sub_tables, expand_sub_tables, for_entries, reorder_table_keys, Tables};
+use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-use crate::TableFormatConfig;
-
 #[allow(clippy::too_many_lines)]
-pub fn fix(tables: &mut Tables, table_config: &TableFormatConfig) {
-    if table_config.should_collapse("tool.ruff") {
-        collapse_sub_tables(tables, "tool.ruff");
-    } else {
-        expand_sub_tables(tables, "tool.ruff");
-    }
+pub fn fix(tables: &mut Tables) {
     let table_element = tables.get("tool.ruff");
     if table_element.is_none() {
         return;

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -106,12 +106,9 @@ use crate::{format_toml, Settings};
 
     [tool.coverage]
     a = 0
-    [tool.coverage.paths]
-    a = 1
-    [tool.coverage.report]
-    a = 2
-    [tool.coverage.run]
-    a = 3
+    paths.a = 1
+    report.a = 2
+    run.a = 3
     "#},
         2,
         true,
@@ -134,9 +131,7 @@ use crate::{format_toml, Settings};
     [tool.commitizen]
     name = "cz_customize"
 
-    [tool.commitizen.customize]
-    message_template = ""
-
+    customize.message_template = ""
     [[tool.commitizen.customize.questions]]
     type = "list"
 
@@ -1141,4 +1136,29 @@ fn test_default_collapse_fallback() {
     assert!(config.should_collapse("project"));
     assert!(config.should_collapse("project.urls"));
     assert!(config.should_collapse("tool.ruff.lint"));
+}
+
+/// Test issue 146 with deeply nested ruff table: expand_tables works for deep paths
+#[rstest]
+fn test_issue_146_deeply_nested_ruff_table() {
+    let start = indoc! {r#"
+        [tool.ruff.lint.flake8-tidy-imports.banned-api]
+        "collections.namedtuple".msg = "Use typing.NamedTuple instead"
+        "#};
+    let settings = Settings {
+        column_width: 120,
+        indent: 4,
+        keep_full_version: true,
+        max_supported_python: (3, 14),
+        min_supported_python: (3, 14),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        expand_tables: vec![String::from("tool.ruff.lint.flake8-tidy-imports.banned-api")],
+        collapse_tables: vec![],
+    };
+    let got = format_toml(start, &settings);
+    assert!(
+        got.contains("[tool.ruff.lint.flake8-tidy-imports.banned-api]"),
+        "deeply nested ruff table should stay expanded. Got:\n{got}"
+    );
 }

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -1,13 +1,14 @@
+use std::collections::HashSet;
+
+use common::table::{apply_table_formatting, Tables};
 use common::taplo::formatter::{format_syntax, Options};
 use common::taplo::parser::parse;
 use common::taplo::syntax::SyntaxElement;
 use indoc::indoc;
 use rstest::rstest;
-use std::collections::HashSet;
 
 use crate::project::fix;
 use crate::TableFormatConfig;
-use common::table::Tables;
 
 fn evaluate(
     start: &str,
@@ -23,6 +24,12 @@ fn evaluate(
         expand_tables: HashSet::new(),
         collapse_tables: HashSet::new(),
     };
+    apply_table_formatting(
+        &mut tables,
+        |name| table_config.should_collapse(name),
+        &["project"],
+        120,
+    );
     fix(
         &mut tables,
         keep_full_version,

--- a/pyproject-fmt/rust/src/tests/ruff_tests.rs
+++ b/pyproject-fmt/rust/src/tests/ruff_tests.rs
@@ -1,26 +1,20 @@
-use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
+use common::table::{apply_table_formatting, Tables};
 use common::taplo::formatter::{format_syntax, Options};
 use common::taplo::parser::parse;
 use common::taplo::syntax::SyntaxElement;
 use rstest::{fixture, rstest};
 
 use crate::ruff::fix;
-use crate::TableFormatConfig;
-use common::table::Tables;
 
 fn evaluate(start: &str) -> String {
     let root_ast = parse(start).into_syntax().clone_for_update();
     let count = root_ast.children_with_tokens().count();
     let mut tables = Tables::from_ast(&root_ast);
-    let table_config = TableFormatConfig {
-        default_collapse: true,
-        expand_tables: HashSet::new(),
-        collapse_tables: HashSet::new(),
-    };
-    fix(&mut tables, &table_config);
+    apply_table_formatting(&mut tables, |_| true, &["tool.ruff"], 120);
+    fix(&mut tables);
     let entries = tables
         .table_set
         .iter()


### PR DESCRIPTION
The expand_tables setting now works correctly for deeply nested tables. Previously, tables like `tool.ruff.lint.flake8-tidy-imports.banned-api` were not respecting the expand_tables configuration.

This fix introduces a generic `apply_table_formatting` function that processes all collapsible table prefixes (`build-system`, `project`, and dynamically discovered `tool.x` prefixes). Tables are processed from most-nested to least-nested using dot count, and intermediate parent tables are handled automatically. The function uses CSS-like specificity for collapse/expand settings where the most specific matching selector wins.

Array of tables (`[[table]]`) are now collapsed to inline arrays when each inline table fits within the configured column_width. This maintains TOML 1.0.0 compatibility since inline tables must be single-line, but arrays can span multiple lines.

Example with `table_format = "short"` and `expand_tables = ["tool.ruff.lint.flake8-tidy-imports.banned-api"]`:

```toml
# Input
[tool.ruff.lint.flake8-tidy-imports.banned-api]
"typing.Dict".msg = "use dict instead"

# Output - table stays expanded because it's in expand_tables
[tool.ruff.lint.flake8-tidy-imports.banned-api]
"typing.Dict".msg = "use dict instead"
```

Example of array of tables collapsing with `table_format = "short"`:

```toml
# Input
[tool.commitizen.customize]
message_template = ""

[[tool.commitizen.customize.questions]]
type = "list"

[[tool.commitizen.customize.questions]]
type = "input"

# Output - parent table and array of tables both collapse
[tool.commitizen]
name = "cz_customize"
customize.message_template = ""
customize.questions = [{ type = "list" }, { type = "input" }]
```

If any inline table exceeds column_width, the array of tables remains in `[[...]]` format to maintain readability.

Fixes #146