### PR TITLE
Fix expand_tables setting for deeply nested tables

### DIFF
--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::{PyModule, PyModuleMethods};
 use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult};
 
 use crate::global::reorder_tables;
-use common::table::Tables;
+use common::table::{apply_table_formatting, Tables};
 
 mod build_system;
 mod dependency_groups;
@@ -110,6 +110,18 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     let mut tables = Tables::from_ast(&root_ast);
     let table_config = TableFormatConfig::from_settings(opt);
 
+    let mut prefixes: Vec<String> = vec![String::from("build-system"), String::from("project")];
+    for key in tables.header_to_pos.keys() {
+        if let Some(tool_name) = key.strip_prefix("tool.") {
+            let tool_prefix = format!("tool.{}", tool_name.split('.').next().unwrap_or(tool_name));
+            if !prefixes.contains(&tool_prefix) {
+                prefixes.push(tool_prefix);
+            }
+        }
+    }
+    let prefix_refs: Vec<&str> = prefixes.iter().map(|s| s.as_str()).collect();
+    apply_table_formatting(&mut tables, |name| table_config.should_collapse(name), &prefix_refs);
+
     build_system::fix(&tables, opt.keep_full_version);
     project::fix(
         &mut tables,
@@ -120,7 +132,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
         &table_config,
     );
     dependency_groups::fix(&mut tables, opt.keep_full_version);
-    ruff::fix(&mut tables, &table_config);
+    ruff::fix(&mut tables);
     reorder_tables(&root_ast, &tables);
 
     let options = Options {

--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -5,9 +5,7 @@ use common::create::{
 };
 use common::pep508::Requirement;
 use common::string::{load_text, update_content};
-use common::table::{
-    collapse_sub_table, collect_all_sub_tables, expand_sub_table, for_entries, reorder_table_keys, Tables,
-};
+use common::table::{for_entries, reorder_table_keys, Tables};
 use common::taplo::syntax::SyntaxKind::{
     ARRAY, BRACKET_END, BRACKET_START, COMMA, ENTRY, IDENT, INLINE_TABLE, KEY, NEWLINE, STRING, VALUE,
 };
@@ -32,7 +30,6 @@ pub fn fix(
 ) {
     let key_order = &["name", "email"];
 
-    // Handle array of tables (authors/maintainers)
     if table_config.should_collapse("project.authors") {
         collapse_array_of_tables(tables, "project.authors", key_order);
     } else {
@@ -44,21 +41,6 @@ pub fn fix(
         expand_array_of_tables(tables, "project.maintainers", key_order);
     }
 
-    // Handle sub-tables (urls, scripts, gui-scripts, optional-dependencies, entry-points)
-    // Process nested sub-tables first (e.g., project.entry-points.tox before project.entry-points)
-    let mut all_sub_tables: Vec<String> = Vec::new();
-    collect_all_sub_tables(tables, "project", &mut all_sub_tables);
-    all_sub_tables.sort_by_key(|b| std::cmp::Reverse(count_unquoted_dots(b)));
-
-    for full_name in all_sub_tables {
-        if let Some((parent, sub)) = split_table_name(&full_name) {
-            if table_config.should_collapse(&full_name) {
-                collapse_sub_table(tables, parent, sub);
-            } else {
-                expand_sub_table(tables, parent, sub);
-            }
-        }
-    }
     let table_element = tables.get("project");
     if table_element.is_none() {
         return;
@@ -245,32 +227,6 @@ pub fn fix(
             "entry-points",
         ],
     );
-}
-
-fn count_unquoted_dots(s: &str) -> usize {
-    let mut count = 0;
-    let mut in_quotes = false;
-    for c in s.chars() {
-        match c {
-            '"' => in_quotes = !in_quotes,
-            '.' if !in_quotes => count += 1,
-            _ => {}
-        }
-    }
-    count
-}
-
-fn split_table_name(full_name: &str) -> Option<(&str, &str)> {
-    let mut last_unquoted_dot = None;
-    let mut in_quotes = false;
-    for (i, c) in full_name.char_indices() {
-        match c {
-            '"' => in_quotes = !in_quotes,
-            '.' if !in_quotes => last_unquoted_dot = Some(i),
-            _ => {}
-        }
-    }
-    last_unquoted_dot.map(|i| (&full_name[..i], &full_name[i + 1..]))
 }
 
 fn expand_entry_points_inline_tables(table: &mut RefMut<Vec<SyntaxElement>>) {

--- a/pyproject-fmt/rust/src/ruff.rs
+++ b/pyproject-fmt/rust/src/ruff.rs
@@ -1,17 +1,10 @@
 use common::array::{sort_strings, transform};
 use common::string::update_content;
-use common::table::{collapse_sub_tables, expand_sub_tables, for_entries, reorder_table_keys, Tables};
+use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-use crate::TableFormatConfig;
-
 #[allow(clippy::too_many_lines)]
-pub fn fix(tables: &mut Tables, table_config: &TableFormatConfig) {
-    if table_config.should_collapse("tool.ruff") {
-        collapse_sub_tables(tables, "tool.ruff");
-    } else {
-        expand_sub_tables(tables, "tool.ruff");
-    }
+pub fn fix(tables: &mut Tables) {
     let table_element = tables.get("tool.ruff");
     if table_element.is_none() {
         return;

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -106,12 +106,9 @@ use crate::{format_toml, Settings};
 
     [tool.coverage]
     a = 0
-    [tool.coverage.paths]
-    a = 1
-    [tool.coverage.report]
-    a = 2
-    [tool.coverage.run]
-    a = 3
+    paths.a = 1
+    report.a = 2
+    run.a = 3
     "#},
         2,
         true,
@@ -1141,4 +1138,29 @@ fn test_default_collapse_fallback() {
     assert!(config.should_collapse("project"));
     assert!(config.should_collapse("project.urls"));
     assert!(config.should_collapse("tool.ruff.lint"));
+}
+
+/// Test issue 146 with deeply nested ruff table: expand_tables works for deep paths
+#[rstest]
+fn test_issue_146_deeply_nested_ruff_table() {
+    let start = indoc! {r#"
+        [tool.ruff.lint.flake8-tidy-imports.banned-api]
+        "collections.namedtuple".msg = "Use typing.NamedTuple instead"
+        "#};
+    let settings = Settings {
+        column_width: 120,
+        indent: 4,
+        keep_full_version: true,
+        max_supported_python: (3, 14),
+        min_supported_python: (3, 14),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        expand_tables: vec![String::from("tool.ruff.lint.flake8-tidy-imports.banned-api")],
+        collapse_tables: vec![],
+    };
+    let got = format_toml(start, &settings);
+    assert!(
+        got.contains("[tool.ruff.lint.flake8-tidy-imports.banned-api]"),
+        "deeply nested ruff table should stay expanded. Got:\n{got}"
+    );
 }

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -1,13 +1,14 @@
+use std::collections::HashSet;
+
+use common::table::{apply_table_formatting, Tables};
 use common::taplo::formatter::{format_syntax, Options};
 use common::taplo::parser::parse;
 use common::taplo::syntax::SyntaxElement;
 use indoc::indoc;
 use rstest::rstest;
-use std::collections::HashSet;
 
 use crate::project::fix;
 use crate::TableFormatConfig;
-use common::table::Tables;
 
 fn evaluate(
     start: &str,
@@ -23,6 +24,7 @@ fn evaluate(
         expand_tables: HashSet::new(),
         collapse_tables: HashSet::new(),
     };
+    apply_table_formatting(&mut tables, |name| table_config.should_collapse(name), &["project"]);
     fix(
         &mut tables,
         keep_full_version,

--- a/pyproject-fmt/rust/src/tests/ruff_tests.rs
+++ b/pyproject-fmt/rust/src/tests/ruff_tests.rs
@@ -1,26 +1,20 @@
-use std::collections::HashSet;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
+use common::table::{apply_table_formatting, Tables};
 use common::taplo::formatter::{format_syntax, Options};
 use common::taplo::parser::parse;
 use common::taplo::syntax::SyntaxElement;
 use rstest::{fixture, rstest};
 
 use crate::ruff::fix;
-use crate::TableFormatConfig;
-use common::table::Tables;
 
 fn evaluate(start: &str) -> String {
     let root_ast = parse(start).into_syntax().clone_for_update();
     let count = root_ast.children_with_tokens().count();
     let mut tables = Tables::from_ast(&root_ast);
-    let table_config = TableFormatConfig {
-        default_collapse: true,
-        expand_tables: HashSet::new(),
-        collapse_tables: HashSet::new(),
-    };
-    fix(&mut tables, &table_config);
+    apply_table_formatting(&mut tables, |_| true, &["tool.ruff"]);
+    fix(&mut tables);
     let entries = tables
         .table_set
         .iter()


### PR DESCRIPTION
Fixes #146 where the expand_tables setting wasn't working for deeply nested tables like tool.ruff.lint.flake8-tidy-imports.banned-api.

The fix introduces a generic apply_table_formatting function that processes all sub-tables under build-system, project, and dynamically discovered tool.* prefixes. Tables are processed from most-nested to least-nested (by dot count), ensuring that deeply nested tables are handled before their parents. The function also handles intermediate parent tables and prevents collapsing tables that have array of tables children.

Before this fix, with table_format = "short" and expand_tables = ["tool.ruff.lint.flake8-tidy-imports.banned-api"]:

```toml
[tool.ruff]
lint.flake8-tidy-imports.banned-api."collections.namedtuple".msg = "Use typing.NamedTuple instead"
```

After this fix, the table correctly stays expanded:

```toml
[tool.ruff.lint.flake8-tidy-imports.banned-api]
"collections.namedtuple".msg = "Use typing.NamedTuple instead"
```