### PR TITLE
Prefer double quotes, use single quotes to avoid escaping

### DIFF
--- a/common/src/tests/create_tests.rs
+++ b/common/src/tests/create_tests.rs
@@ -1,8 +1,8 @@
-use taplo::syntax::SyntaxKind::{COMMA, ENTRY, KEY, NEWLINE, STRING, VALUE};
+use taplo::syntax::SyntaxKind::{COMMA, ENTRY, KEY, NEWLINE, STRING, STRING_LITERAL, VALUE};
 
 use crate::create::{
-    make_array, make_array_entry, make_comma, make_empty_newline, make_entry_of_string, make_key, make_newline,
-    make_string_node, make_table_entry,
+    make_array, make_array_entry, make_comma, make_empty_newline, make_entry_of_string, make_key,
+    make_literal_string_node, make_newline, make_string_node, make_table_entry,
 };
 
 #[test]
@@ -122,4 +122,39 @@ fn test_make_table_entry_dotted() {
         }
     }
     assert!(has_table);
+}
+
+#[test]
+fn test_make_string_node_with_backslash() {
+    let node = make_string_node("path\\to\\file");
+    assert_eq!(node.kind(), STRING);
+    assert_eq!(node.to_string(), "\"path\\\\to\\\\file\"");
+}
+
+#[test]
+fn test_make_string_node_with_newline() {
+    let node = make_string_node("hello\nworld");
+    assert_eq!(node.kind(), STRING);
+    assert_eq!(node.to_string(), "\"hello\\nworld\"");
+}
+
+#[test]
+fn test_make_literal_string_node_simple() {
+    let node = make_literal_string_node("hello");
+    assert_eq!(node.kind(), STRING_LITERAL);
+    assert_eq!(node.to_string(), "'hello'");
+}
+
+#[test]
+fn test_make_literal_string_node_with_backslash() {
+    let node = make_literal_string_node("path\\to\\file");
+    assert_eq!(node.kind(), STRING_LITERAL);
+    assert_eq!(node.to_string(), "'path\\to\\file'");
+}
+
+#[test]
+fn test_make_literal_string_node_with_regex() {
+    let node = make_literal_string_node("MPL-2\\.0");
+    assert_eq!(node.kind(), STRING_LITERAL);
+    assert_eq!(node.to_string(), "'MPL-2\\.0'");
 }

--- a/pyproject-fmt/docs/index.rst
+++ b/pyproject-fmt/docs/index.rst
@@ -46,6 +46,10 @@ Normalizations and Transformations
 
 In addition to the formatting principles above, ``pyproject-fmt`` performs the following normalizations:
 
+**String Quotes** - All strings are normalized to use double quotes (``""``) by default. Single-quoted literal strings
+(``''``) are only used when the content contains double quotes, avoiding the need for escape sequences. For example,
+``'hello'`` becomes ``"hello"``, while ``"say \"hello\""`` becomes ``'say "hello"'``.
+
 **Version Specifiers** - All PEP 508 version specifiers are normalized by removing spaces around operators
 (e.g., ``package >= 1.0`` becomes ``package>=1.0``), optionally removing redundant trailing zeros (e.g., ``1.0``
 becomes ``1``) unless ``keep_full_version = true``, and validating against PEP 508 standards.

--- a/pyproject-fmt/rust/src/data/ruff-order.expected.toml
+++ b/pyproject-fmt/rust/src/data/ruff-order.expected.toml
@@ -146,7 +146,7 @@ lint.flake8-builtins.builtins-ignorelist = [
 ]
 lint.flake8-comprehensions.allow-dict-calls-with-keyword-arguments = true
 lint.flake8-copyright.author = "Ruff"
-lint.flake8-copyright.notice-rgx = "(?i)Copyright \\(C\\) \\d{4}"
+lint.flake8-copyright.notice-rgx = "(?i)Copyright \\\\(C\\\\) \\\\d{4}"
 lint.flake8-errmsg.max-string-length = 20
 lint.flake8-gettext.extend-function-names = [
   "ALPHA",

--- a/tox-toml-fmt/docs/index.rst
+++ b/tox-toml-fmt/docs/index.rst
@@ -43,6 +43,10 @@ Normalizations and Transformations
 
 In addition to the formatting principles above, ``tox-toml-fmt`` performs the following normalizations:
 
+**String Quotes** - All strings are normalized to use double quotes (``""``) by default. Single-quoted literal strings
+(``''``) are only used when the content contains double quotes, avoiding the need for escape sequences. For example,
+``'hello'`` becomes ``"hello"``, while ``"say \"hello\""`` becomes ``'say "hello"'``.
+
 **Table Ordering** - The ``tox.toml`` file follows a standard table ordering where root level keys and
 ``[env_run_base]`` appear first, environment-specific sections (``[env.NAME]``) are ordered according to the
 ``env_list`` configuration if present, any additional environments not in ``env_list`` follow at the end, and this

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -5,7 +5,7 @@ use common::taplo::parser::parse;
 use pyo3::prelude::{PyModule, PyModuleMethods};
 use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult};
 
-use crate::global::reorder_tables;
+use crate::global::{normalize_strings, reorder_tables};
 use common::table::Tables;
 mod global;
 #[cfg(test)]
@@ -33,6 +33,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     let root_ast = parse(content).into_syntax().clone_for_update();
     let tables = Tables::from_ast(&root_ast);
 
+    normalize_strings(&tables);
     reorder_tables(&root_ast, &tables);
 
     let options = Options {

--- a/tox-toml-fmt/rust/src/tests/main_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/main_tests.rs
@@ -82,3 +82,45 @@ fn test_column_width() {
     let second = format_toml(got.as_str(), &settings);
     assert_eq!(second, got);
 }
+
+#[test]
+fn test_string_quote_normalization() {
+    let start = indoc! {r#"
+        requires = ['tox>=4.22']
+        env_list = ['test']
+
+        [env_run_base]
+        description = 'run tests'
+        "#};
+    let settings = Settings {
+        column_width: 80,
+        indent: 2,
+    };
+    let got = format_toml(start, &settings);
+    let expected = indoc! {r#"
+        requires = [ "tox>=4.22" ]
+        env_list = [ "test" ]
+
+        [env_run_base]
+        description = "run tests"
+        "#};
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn test_string_with_double_quote_uses_literal() {
+    let start = indoc! {r#"
+        [env_run_base]
+        description = "run \"tests\""
+        "#};
+    let settings = Settings {
+        column_width: 80,
+        indent: 2,
+    };
+    let got = format_toml(start, &settings);
+    let expected = indoc! {r#"
+        [env_run_base]
+        description = 'run "tests"'
+        "#};
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
The formatter now prefers double-quoted strings (`""`) and only uses single-quoted literal strings (`''`) when the content contains double quotes that would require escaping in a basic string.

In TOML, literal strings (`''`) cannot contain single quotes and have no escape mechanism. Basic strings (`""`) support escaping with backslash. The new behavior:

```toml
# Simple strings use double quotes (preferred)
name = "hello"

# Strings with double quotes use single quotes (avoids \")
msg = 'say "hello"'

# Strings with backslashes use double quotes with escaping
regex = "MPL-2\\.0"

# Strings with single quotes must use double quotes
text = "it's fine"

# Strings with both quotes use double quotes (only option)
mixed = "it's a \"test\""
```

This applies to both pyproject-fmt and tox-toml-fmt. The tox-toml-fmt now also normalizes strings in arrays and inline tables.

Fixes #150