### PR TITLE
🐛 fix(tasks): fix Windows encoding and changelog generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,30 @@
 
 This project includes the following TOML formatters for the Python ecosystem:
 
-- [`pyproject-fmt`](./pyproject-fmt),
-- [`tox-toml-fmt`](./tox-toml-fmt).
+## pyproject-fmt
+
+[![PyPI](https://img.shields.io/pypi/v/pyproject-fmt?style=flat-square)](https://pypi.org/project/pyproject-fmt)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyproject-fmt?style=flat-square)](https://pypi.org/project/pyproject-fmt)
+[![Downloads](https://img.shields.io/pypi/dm/pyproject-fmt?style=flat-square)](https://pypistats.org/packages/pyproject-fmt)
+[![pre-commit mirror](https://github.com/tox-dev/pyproject-fmt/actions/workflows/main.yaml/badge.svg)](https://github.com/tox-dev/pyproject-fmt)
+
+Apply a consistent format to your `pyproject.toml` file with comment support.
+
+- 📦 [PyPI](https://pypi.org/project/pyproject-fmt)
+- 📖 [Documentation](https://pyproject-fmt.readthedocs.io)
+- 🔧 [pre-commit hook](https://github.com/tox-dev/pyproject-fmt)
+- 📝 [Source & Changelog](./pyproject-fmt)
+
+## tox-toml-fmt
+
+[![PyPI](https://img.shields.io/pypi/v/tox-toml-fmt?style=flat-square)](https://pypi.org/project/tox-toml-fmt)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/tox-toml-fmt?style=flat-square)](https://pypi.org/project/tox-toml-fmt)
+[![Downloads](https://img.shields.io/pypi/dm/tox-toml-fmt?style=flat-square)](https://pypistats.org/packages/tox-toml-fmt)
+[![pre-commit mirror](https://github.com/tox-dev/tox-toml-fmt/actions/workflows/main.yaml/badge.svg)](https://github.com/tox-dev/tox-toml-fmt)
+
+Apply a consistent format to your `tox.toml` file with comment support.
+
+- 📦 [PyPI](https://pypi.org/project/tox-toml-fmt)
+- 📖 [Documentation](https://tox-toml-fmt.readthedocs.io)
+- 🔧 [pre-commit hook](https://github.com/tox-dev/tox-toml-fmt)
+- 📝 [Source & Changelog](./tox-toml-fmt)

--- a/pyproject-fmt/CHANGELOG.md
+++ b/pyproject-fmt/CHANGELOG.md
@@ -3,14 +3,14 @@
 ## 2.13.0 - 2026-02-07
 
 - 📝 docs(formatting): restructure docs and fix array formatting behavior by
-  [@gaborbernat](https://github.com/gaborbernat) in [#$164](https://github.com/tox-dev/toml-fmt/pull/164)
+  [@gaborbernat](https://github.com/gaborbernat) in [#164](https://github.com/tox-dev/toml-fmt/pull/164)
 
 <a id="2.12.1"></a>
 
 ## 2.12.1 - 2026-01-31
 
 - Fix expand_tables setting for specific sub-tables by [@gaborbernat](https://github.com/gaborbernat) in
-  [#$148](https://github.com/tox-dev/toml-fmt/pull/148)
+  [#148](https://github.com/tox-dev/toml-fmt/pull/148)
 
 <a id="2.12.0"></a>
 
@@ -24,62 +24,62 @@
 ## 2.11.1 - 2026-01-07
 
 - Fix parsing of versions in parentheses by [@jamesbursa](https://github.com/jamesbursa) in
-  [#$122](https://github.com/tox-dev/toml-fmt/pull/122)
+  [#122](https://github.com/tox-dev/toml-fmt/pull/122)
 
 <a id="2.11.0"></a>
 
 ## 2.11.0 - 2025-10-15
 
 - Allow to opt out of the Python version classifier generation by [@gaborbernat](https://github.com/gaborbernat) in
-  [#$102](https://github.com/tox-dev/toml-fmt/pull/102)
+  [#102](https://github.com/tox-dev/toml-fmt/pull/102)
 
 <a id="2.10.0"></a>
 
 ## 2.10.0 - 2025-10-09
 
 - Add a few more type checkers to top level tables by [@browniebroke](https://github.com/browniebroke) in
-  [#$98](https://github.com/tox-dev/toml-fmt/pull/98)
+  [#98](https://github.com/tox-dev/toml-fmt/pull/98)
 
 <a id="2.9.0"></a>
 
 ## 2.9.0 - 2025-10-08
 
 - Sort [tool.uv] higher in the pyproject.toml by [@browniebroke](https://github.com/browniebroke) in
-  [#$97](https://github.com/tox-dev/toml-fmt/pull/97)
+  [#97](https://github.com/tox-dev/toml-fmt/pull/97)
 
 <a id="2.8.0"></a>
 
 ## 2.8.0 - 2025-10-08
 
 - Fix parsing of version pre labels by [@adamchainz](https://github.com/adamchainz) in
-  [#$89](https://github.com/tox-dev/toml-fmt/pull/89)
+  [#89](https://github.com/tox-dev/toml-fmt/pull/89)
 
 <a id="2.7.0"></a>
 
 ## 2.7.0 - 2025-10-01
 
 - Macos 26 is not yet ready for wide usage by [@gaborbernat](https://github.com/gaborbernat) in
-  [#$86](https://github.com/tox-dev/toml-fmt/pull/86)
+  [#86](https://github.com/tox-dev/toml-fmt/pull/86)
 
 <a id="2.6.0"></a>
 
 ## 2.6.0 - 2025-05-19
 
-- Use abi3-py39 by [@gaborbernat](https://github.com/gaborbernat) in [#$58](https://github.com/tox-dev/toml-fmt/pull/58)
+- Use abi3-py39 by [@gaborbernat](https://github.com/gaborbernat) in [#58](https://github.com/tox-dev/toml-fmt/pull/58)
 
 <a id="2.5.0"></a>
 
 ## 2.5.0 - 2024-10-30
 
 - Add support for PEP 735 dependency-groups by [@browniebroke](https://github.com/browniebroke) in
-  [#$16](https://github.com/tox-dev/toml-fmt/pull/16)
+  [#16](https://github.com/tox-dev/toml-fmt/pull/16)
 
 <a id="2.4.3"></a>
 
 ## 2.4.3 - 2024-10-17
 
 - Fix tomli not present for Python<3.11 by [@gaborbernat](https://github.com/gaborbernat) in
-  [#$9](https://github.com/tox-dev/toml-fmt/pull/9)
+  [#9](https://github.com/tox-dev/toml-fmt/pull/9)
 
 <a id="2.4.2"></a>
 
@@ -92,7 +92,7 @@
 ## 2.4.1 - 2024-10-17
 
 - Fix release script by [@gaborbernat](https://github.com/gaborbernat) in
-  [#$8](https://github.com/tox-dev/toml-fmt/pull/8)
+  [#8](https://github.com/tox-dev/toml-fmt/pull/8)
 
 <a id="2.4.0"></a>
 

--- a/tasks/generate_readme.py
+++ b/tasks/generate_readme.py
@@ -13,11 +13,11 @@ def main(package: str) -> None:
     if not (index_path := docs_dir / "index.rst").exists():
         return
 
-    processed = process_rst_for_pypi(index_path.read_text())
+    processed = process_rst_for_pypi(index_path.read_text(encoding="utf-8"))
 
     changelog_rst = ""
     if (changelog_path := pkg / "CHANGELOG.md").exists() and (
-        extracted := extract_latest_changelog_as_rst(changelog_path.read_text())
+        extracted := extract_latest_changelog_as_rst(changelog_path.read_text(encoding="utf-8"))
     ):
         changelog_rst = extracted
     if changelog_rst:
@@ -27,12 +27,12 @@ def main(package: str) -> None:
             processed = processed + "\n\n" + changelog_rst
 
     if (config_path := docs_dir / "configuration.rst").exists():
-        processed += "\n\n" + process_rst_for_pypi(strip_main_title(config_path.read_text()))
+        processed += "\n\n" + process_rst_for_pypi(strip_main_title(config_path.read_text(encoding="utf-8")))
 
     if (formatting_path := docs_dir / "formatting.rst").exists():
-        processed += "\n\n" + process_rst_for_pypi(strip_main_title(formatting_path.read_text()))
+        processed += "\n\n" + process_rst_for_pypi(strip_main_title(formatting_path.read_text(encoding="utf-8")))
 
-    (pkg / "README.rst").write_text(processed)
+    (pkg / "README.rst").write_text(processed, encoding="utf-8")
 
 
 def strip_main_title(content: str) -> str:

--- a/tox-toml-fmt/CHANGELOG.md
+++ b/tox-toml-fmt/CHANGELOG.md
@@ -3,36 +3,94 @@
 ## 1.4.0 - 2026-02-07
 
 - 📝 docs(formatting): restructure docs and fix array formatting behavior by
-  [@gaborbernat](https://github.com/gaborbernat) in [#$164](https://github.com/tox-dev/toml-fmt/pull/164)
+  [@gaborbernat](https://github.com/gaborbernat) in [#164](https://github.com/tox-dev/toml-fmt/pull/164)
+- ♻️ refactor(parser): migrate from taplo to tombi by [@gaborbernat](https://github.com/gaborbernat) in
+  [#159](https://github.com/tox-dev/toml-fmt/pull/159)
+- Fix expand_tables setting for deeply nested tables by [@gaborbernat](https://github.com/gaborbernat) in
+  [#160](https://github.com/tox-dev/toml-fmt/pull/160)
+- Prefer double quotes, use single quotes to avoid escaping by [@gaborbernat](https://github.com/gaborbernat) in
+  [#162](https://github.com/tox-dev/toml-fmt/pull/162)
+- Fix comment before table moving incorrectly when table has comments by [@gaborbernat](https://github.com/gaborbernat)
+  in [#158](https://github.com/tox-dev/toml-fmt/pull/158)
+- Fix expand_tables setting for specific sub-tables by [@gaborbernat](https://github.com/gaborbernat) in
+  [#148](https://github.com/tox-dev/toml-fmt/pull/148)
+
+<a id="1.3.0"></a>
+
+## 1.3.0 - 2026-01-31
+
+- Generate README.rst dynamically from docs at build time by [@gaborbernat](https://github.com/gaborbernat) in
+  [#145](https://github.com/tox-dev/toml-fmt/pull/145)
+- 📚 Document formatting principles and normalizations by [@gaborbernat](https://github.com/gaborbernat) in
+  [#144](https://github.com/tox-dev/toml-fmt/pull/144)
+- Add configurable table formatting with table_format, expand_tables, and collapse_tables options by
+  [@gaborbernat](https://github.com/gaborbernat) in [#142](https://github.com/tox-dev/toml-fmt/pull/142)
+- Order tox env tables according to env_list by [@gaborbernat](https://github.com/gaborbernat) in
+  [#141](https://github.com/tox-dev/toml-fmt/pull/141)
+- Fix comments before table headers staying with correct table by [@gaborbernat](https://github.com/gaborbernat) in
+  [#140](https://github.com/tox-dev/toml-fmt/pull/140)
+- Sort subtables alphabetically within the same tool by [@gaborbernat](https://github.com/gaborbernat) in
+  [#139](https://github.com/tox-dev/toml-fmt/pull/139)
+- Collapse [[project.authors]] array of tables to inline format by [@gaborbernat](https://github.com/gaborbernat) in
+  [#137](https://github.com/tox-dev/toml-fmt/pull/137)
+- Bump toml-fmt-common to 1.2 by [@gaborbernat](https://github.com/gaborbernat) in
+  [#138](https://github.com/tox-dev/toml-fmt/pull/138)
+- Add keyword and classifier deduplication by [@gaborbernat](https://github.com/gaborbernat) in
+  [#133](https://github.com/tox-dev/toml-fmt/pull/133)
+- Fix crash on multi-line strings with line continuation by [@gaborbernat](https://github.com/gaborbernat) in
+  [#132](https://github.com/tox-dev/toml-fmt/pull/132)
+- Add PEP 794 private dependency support by [@gaborbernat](https://github.com/gaborbernat) in
+  [#131](https://github.com/tox-dev/toml-fmt/pull/131)
+- Fix literal strings with invalid escapes being corrupted by [@gaborbernat](https://github.com/gaborbernat) in
+  [#130](https://github.com/tox-dev/toml-fmt/pull/130)
+- Fix build requirements with duplicate package names being removed by [@gaborbernat](https://github.com/gaborbernat) in
+  [#127](https://github.com/tox-dev/toml-fmt/pull/127)
 
 <a id="1.2.2"></a>
 
 ## 1.2.2 - 2026-01-07
 
-- Release pyproject-fmt 2.11.1 by [@gaborbernat](https://github.com/gaborbernat)
+- Fix parsing of versions in parentheses by [@jamesbursa](https://github.com/jamesbursa) in
+  [#122](https://github.com/tox-dev/toml-fmt/pull/122)
 
 <a id="1.2.1"></a>
 
 ## 1.2.1 - 2025-11-12
 
+- Fix tool names in documentation by [@gaborbernat](https://github.com/gaborbernat) in
+  [#106](https://github.com/tox-dev/toml-fmt/pull/106)
+- Fix documentation links and bump deps by [@gaborbernat](https://github.com/gaborbernat) in
+  [#105](https://github.com/tox-dev/toml-fmt/pull/105)
+- Fix too aggressive parsing suffix versions by [@gaborbernat](https://github.com/gaborbernat) in
+  [#101](https://github.com/tox-dev/toml-fmt/pull/101)
 - perf: only compile regexes once by [@henryiii](https://github.com/henryiii) in
-  [#$110](https://github.com/tox-dev/toml-fmt/pull/110)
+  [#110](https://github.com/tox-dev/toml-fmt/pull/110)
 
 <a id="1.2.0"></a>
 
 ## 1.2.0 - 2025-10-08
 
 - Drop 3.9 and add 3.14 by [@gaborbernat](https://github.com/gaborbernat) in
-  [#$96](https://github.com/tox-dev/toml-fmt/pull/96)
+  [#96](https://github.com/tox-dev/toml-fmt/pull/96)
+- Fix parsing of version pre labels by [@gaborbernat](https://github.com/gaborbernat) in
+  [#89](https://github.com/tox-dev/toml-fmt/pull/89)
 
 <a id="1.1.0"></a>
 
 ## 1.1.0 - 2025-10-01
 
-- Release pyproject-fmt 2.7.0 by [@gaborbernat](https://github.com/gaborbernat)
+- Replace upstream pep508 that's deprecated with our own by [@gaborbernat](https://github.com/gaborbernat) in
+  [#84](https://github.com/tox-dev/toml-fmt/pull/84)
+- Fix empty lines placed within a sorted table by [@gaborbernat](https://github.com/gaborbernat) in
+  [#63](https://github.com/tox-dev/toml-fmt/pull/63)
+- Use abi3-py39 by [@gaborbernat](https://github.com/gaborbernat) in [#58](https://github.com/tox-dev/toml-fmt/pull/58)
+- Bump rust and versions by [@gaborbernat](https://github.com/gaborbernat) in
+  [#56](https://github.com/tox-dev/toml-fmt/pull/56)
+- Include all ident parts in keys by [@gaborbernat](https://github.com/gaborbernat) in
+  [#31](https://github.com/tox-dev/toml-fmt/pull/31)
 
 <a id="1.0.0"></a>
 
 ## 1.0.0 - 2024-10-31
 
-- Update Cargo.toml by [@gaborbernat](https://github.com/gaborbernat)
+- Initial release


### PR DESCRIPTION
The README generation script was failing on Windows CI because `Path.read_text()` defaults to the system encoding (cp1252) rather than UTF-8. 🪟 This caused `UnicodeDecodeError` when processing CHANGELOG.md files containing non-ASCII characters.

The changelog generation was also including commits from unrelated projects. When releasing tox-toml-fmt, entries like "Release pyproject-fmt 2.11.1" would incorrectly appear because the script didn't filter by which files each commit actually touched. The PR link format also had an errant `$` producing `[#$164]` instead of `[#164]`.

This PR adds explicit `encoding="utf-8"` to all file operations in both task scripts, and enhances `changelog.py` with several improvements:

- Added `--regenerate` flag to rebuild the entire changelog from git history 📋
- Fixed commit iteration to use git range syntax for proper scoping between releases
- Filtered out release commits and bot contributions (pre-commit-ci, dependabot)
- Made GitHub API access optional with graceful fallback to git data

Both project changelogs have been regenerated with the fixed script to ensure consistency and verify the generation logic works correctly across all historical releases.