### PR TITLE
✨ feat(changelog): add --regenerate flag for full changelog rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Apply a consistent format to your `pyproject.toml` file with comment support.
 - 📦 [PyPI](https://pypi.org/project/pyproject-fmt)
 - 📖 [Documentation](https://pyproject-fmt.readthedocs.io)
 - 🔧 [pre-commit hook](https://github.com/tox-dev/pyproject-fmt)
-- 📝 [Source & Changelog](./pyproject-fmt)
+- 💻 [Source](./pyproject-fmt)
+- 📝 [Changelog](./pyproject-fmt/CHANGELOG.md)
 
 ## tox-toml-fmt
 
@@ -28,4 +29,5 @@ Apply a consistent format to your `tox.toml` file with comment support.
 - 📦 [PyPI](https://pypi.org/project/tox-toml-fmt)
 - 📖 [Documentation](https://tox-toml-fmt.readthedocs.io)
 - 🔧 [pre-commit hook](https://github.com/tox-dev/tox-toml-fmt)
-- 📝 [Source & Changelog](./tox-toml-fmt)
+- 💻 [Source](./tox-toml-fmt)
+- 📝 [Changelog](./tox-toml-fmt/CHANGELOG.md)

--- a/pyproject-fmt/CHANGELOG.md
+++ b/pyproject-fmt/CHANGELOG.md
@@ -1,23 +1,60 @@
-<a id="2.13.0"></a>
-
-## 2.13.0 - 2026-02-07
-
-- 📝 docs(formatting): restructure docs and fix array formatting behavior by
-  [@gaborbernat](https://github.com/gaborbernat) in [#164](https://github.com/tox-dev/toml-fmt/pull/164)
-
 <a id="2.12.1"></a>
 
 ## 2.12.1 - 2026-01-31
 
 - Fix expand_tables setting for specific sub-tables by [@gaborbernat](https://github.com/gaborbernat) in
   [#148](https://github.com/tox-dev/toml-fmt/pull/148)
+- Use RELEASE_TOKEN to bypass branch protection for releases by [@gaborbernat](https://github.com/gaborbernat) in
+  [#147](https://github.com/tox-dev/toml-fmt/pull/147)
 
 <a id="2.12.0"></a>
 
-## 2.12.0 - TBD
+## 2.12.0 - 2026-01-30
 
-- Add configurable table formatting with `--table-format`, `--expand-tables`, and `--collapse-tables` options by
+- Generate README.rst dynamically from docs at build time by [@gaborbernat](https://github.com/gaborbernat) in
+  [#145](https://github.com/tox-dev/toml-fmt/pull/145)
+- 📚 Document formatting principles and normalizations by [@gaborbernat](https://github.com/gaborbernat) in
+  [#144](https://github.com/tox-dev/toml-fmt/pull/144)
+- Improve maintainalibility by [@gaborbernat](https://github.com/gaborbernat) in
+  [#143](https://github.com/tox-dev/toml-fmt/pull/143)
+- Add configurable table formatting to pyproject-fmt and order tox env tables by env_list by
   [@gaborbernat](https://github.com/gaborbernat) in [#142](https://github.com/tox-dev/toml-fmt/pull/142)
+- Order tox env tables according to env_list and add codecov token by [@gaborbernat](https://github.com/gaborbernat) in
+  [#141](https://github.com/tox-dev/toml-fmt/pull/141)
+- Fix comments before table headers staying with correct table by [@gaborbernat](https://github.com/gaborbernat) in
+  [#140](https://github.com/tox-dev/toml-fmt/pull/140)
+- Sort subtables alphabetically within the same tool by [@gaborbernat](https://github.com/gaborbernat) in
+  [#139](https://github.com/tox-dev/toml-fmt/pull/139)
+- Collapse [[project.authors]] array of tables to inline format by [@gaborbernat](https://github.com/gaborbernat) in
+  [#137](https://github.com/tox-dev/toml-fmt/pull/137)
+- Bump toml-fmt-common to 1.2 by [@gaborbernat](https://github.com/gaborbernat) in
+  [#138](https://github.com/tox-dev/toml-fmt/pull/138)
+- Normalize extra names in optional-dependencies by [@gaborbernat](https://github.com/gaborbernat) in
+  [#135](https://github.com/tox-dev/toml-fmt/pull/135)
+- Normalize SPDX operators in license expressions by [@gaborbernat](https://github.com/gaborbernat) in
+  [#136](https://github.com/tox-dev/toml-fmt/pull/136)
+- Add authors and maintainers sorting by [@gaborbernat](https://github.com/gaborbernat) in
+  [#134](https://github.com/tox-dev/toml-fmt/pull/134)
+- Add keyword and classifier deduplication by [@gaborbernat](https://github.com/gaborbernat) in
+  [#133](https://github.com/tox-dev/toml-fmt/pull/133)
+- Fix crash on multi-line strings with line continuation by [@gaborbernat](https://github.com/gaborbernat) in
+  [#132](https://github.com/tox-dev/toml-fmt/pull/132)
+- Add PEP 794 private dependency support by [@gaborbernat](https://github.com/gaborbernat) in
+  [#131](https://github.com/tox-dev/toml-fmt/pull/131)
+- Fix literal strings with invalid escapes being corrupted by [@gaborbernat](https://github.com/gaborbernat) in
+  [#130](https://github.com/tox-dev/toml-fmt/pull/130)
+- Remove testpaths config to fix sdist warning (#120) by [@gaborbernat](https://github.com/gaborbernat) in
+  [#129](https://github.com/tox-dev/toml-fmt/pull/129)
+- Fix misparsed requires-python with ~= operator (#20) by [@gaborbernat](https://github.com/gaborbernat) in
+  [#128](https://github.com/tox-dev/toml-fmt/pull/128)
+- Fix build requirements with duplicate package names being removed (#2) by
+  [@gaborbernat](https://github.com/gaborbernat) in [#127](https://github.com/tox-dev/toml-fmt/pull/127)
+- Improve CI: add Rust coverage thresholds and prek parallel hooks by [@gaborbernat](https://github.com/gaborbernat) in
+  [#126](https://github.com/tox-dev/toml-fmt/pull/126)
+- Improve GitHub Actions workflows by [@gaborbernat](https://github.com/gaborbernat) in
+  [#125](https://github.com/tox-dev/toml-fmt/pull/125)
+- Add Nuitka and Typos tool sections by [@kdeldycke](https://github.com/kdeldycke) in
+  [#123](https://github.com/tox-dev/toml-fmt/pull/123)
 
 <a id="2.11.1"></a>
 
@@ -25,6 +62,16 @@
 
 - Fix parsing of versions in parentheses by [@jamesbursa](https://github.com/jamesbursa) in
   [#122](https://github.com/tox-dev/toml-fmt/pull/122)
+- Remove outdated version reference by [@ulgens](https://github.com/ulgens) in
+  [#115](https://github.com/tox-dev/toml-fmt/pull/115)
+- perf: only compile regexes once by [@henryiii](https://github.com/henryiii) in
+  [#110](https://github.com/tox-dev/toml-fmt/pull/110)
+- feat: PEP 794 support by [@henryiii](https://github.com/henryiii) in
+  [#109](https://github.com/tox-dev/toml-fmt/pull/109)
+- Fix tool names in documentation. by [@jorisboeye](https://github.com/jorisboeye) in
+  [#106](https://github.com/tox-dev/toml-fmt/pull/106)
+- Fix documentation links and bump deps by [@gaborbernat](https://github.com/gaborbernat) in
+  [#105](https://github.com/tox-dev/toml-fmt/pull/105)
 
 <a id="2.11.0"></a>
 
@@ -32,6 +79,8 @@
 
 - Allow to opt out of the Python version classifier generation by [@gaborbernat](https://github.com/gaborbernat) in
   [#102](https://github.com/tox-dev/toml-fmt/pull/102)
+- Fix too aggressive parsing suffix versions by [@gaborbernat](https://github.com/gaborbernat) in
+  [#101](https://github.com/tox-dev/toml-fmt/pull/101)
 
 <a id="2.10.0"></a>
 
@@ -46,6 +95,8 @@
 
 - Sort [tool.uv] higher in the pyproject.toml by [@browniebroke](https://github.com/browniebroke) in
   [#97](https://github.com/tox-dev/toml-fmt/pull/97)
+- Drop 3.9 and add 3.14 by [@gaborbernat](https://github.com/gaborbernat) in
+  [#96](https://github.com/tox-dev/toml-fmt/pull/96)
 
 <a id="2.8.0"></a>
 
@@ -53,19 +104,36 @@
 
 - Fix parsing of version pre labels by [@adamchainz](https://github.com/adamchainz) in
   [#89](https://github.com/tox-dev/toml-fmt/pull/89)
+- Default Python support is now 3.10 to 3.14 by [@gaborbernat](https://github.com/gaborbernat) in
+  [#94](https://github.com/tox-dev/toml-fmt/pull/94)
 
 <a id="2.7.0"></a>
 
 ## 2.7.0 - 2025-10-01
 
-- Macos 26 is not yet ready for wide usage by [@gaborbernat](https://github.com/gaborbernat) in
-  [#86](https://github.com/tox-dev/toml-fmt/pull/86)
+- Replace upstream pep508 that's deprecated with our own by [@gaborbernat](https://github.com/gaborbernat) in
+  [#84](https://github.com/tox-dev/toml-fmt/pull/84)
+- Fix empty lines placed within a sorted table by [@ddeepwell](https://github.com/ddeepwell) in
+  [#63](https://github.com/tox-dev/toml-fmt/pull/63)
+- Do not remove space before .ext by [@hugovk](https://github.com/hugovk) in
+  [#76](https://github.com/tox-dev/toml-fmt/pull/76)
 
 <a id="2.6.0"></a>
 
 ## 2.6.0 - 2025-05-19
 
 - Use abi3-py39 by [@gaborbernat](https://github.com/gaborbernat) in [#58](https://github.com/tox-dev/toml-fmt/pull/58)
+- Bump rust and versions by [@gaborbernat](https://github.com/gaborbernat) in
+  [#56](https://github.com/tox-dev/toml-fmt/pull/56)
+
+<a id="2.5.1"></a>
+
+## 2.5.1 - 2025-02-18
+
+- Include all ident parts in keys by [@adamchainz](https://github.com/adamchainz) in
+  [#31](https://github.com/tox-dev/toml-fmt/pull/31)
+- Add tox-toml-fmt by [@gaborbernat](https://github.com/gaborbernat) in
+  [#18](https://github.com/tox-dev/toml-fmt/pull/18)
 
 <a id="2.5.0"></a>
 
@@ -73,6 +141,9 @@
 
 - Add support for PEP 735 dependency-groups by [@browniebroke](https://github.com/browniebroke) in
   [#16](https://github.com/tox-dev/toml-fmt/pull/16)
+- Extract common Python code to toml-fmt-common by [@gaborbernat](https://github.com/gaborbernat) in
+  [#12](https://github.com/tox-dev/toml-fmt/pull/12)
+- Fix stray ] in changelog for PR numbers by [@gaborbernat](https://github.com/gaborbernat)
 
 <a id="2.4.3"></a>
 
@@ -85,470 +156,22 @@
 
 ## 2.4.2 - 2024-10-17
 
-- Fix release script by [@gaborbernat](https://github.com/gaborbernat)
+- Initial release
 
 <a id="2.4.1"></a>
 
 ## 2.4.1 - 2024-10-17
 
-- Fix release script by [@gaborbernat](https://github.com/gaborbernat) in
-  [#8](https://github.com/tox-dev/toml-fmt/pull/8)
+- Initial release
 
 <a id="2.4.0"></a>
 
 ## 2.4.0 - 2024-10-17
 
 - Fix GitHub action warning by [@gaborbernat](https://github.com/gaborbernat)
-
-<a id="2.3.0"></a>
-
-# [2.3.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.3.1) - 2024-10-14
-
-- Remove `tool.ruff.target_version` by [@edgarrmondragon](https://github.com/edgarrmondragon) in
-  [#268](https://github.com/tox-dev/pyproject-fmt/pull/268)
-- Pull in description fix by [@gaborbernat](https://github.com/gaborbernat) in
-  [#272](https://github.com/tox-dev/pyproject-fmt/pull/272) thanks [@hugovk](https://github.com/hugovk)
-
-<a id="2.3.0"></a>
-
-# [2.3.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.3.0) - 2024-10-10
-
-- Drop 3.8 support and set 3.13 latest stable by [@gaborbernat](https://github.com/gaborbernat) in
-  [#267](https://github.com/tox-dev/pyproject-fmt/pull/267)
-
-<a id="2.2.4"></a>
-
-# [2.2.4](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.2.4) - 2024-09-17
-
-- Improve the CI by [@gaborbernat](https://github.com/gaborbernat) in
-  [#257](https://github.com/tox-dev/pyproject-fmt/pull/257)
-
-<a id="2.2.3"></a>
-
-# [2.2.3](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.2.3) - 2024-09-08
-
-- Fix declare 3.13 support by [@gaborbernat](https://github.com/gaborbernat) in
-  [#253](https://github.com/tox-dev/pyproject-fmt/pull/253)
-
-<a id="2.2.2"></a>
-
-# [2.2.2](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.2.2) - 2024-09-08
-
-- Declare 3.13 support by [@gaborbernat](https://github.com/gaborbernat) in
-  [#252](https://github.com/tox-dev/pyproject-fmt/pull/252)
-
-<a id="2.2.1"></a>
-
-# [2.2.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.2.1) - 2024-07-31
-
-- Pull in array split fix by [@gaborbernat](https://github.com/gaborbernat) in
-  [#245](https://github.com/tox-dev/pyproject-fmt/pull/245)
-
-CC [@flying-sheep](https://github.com/flying-sheep)
-
-<a id="2.2.0"></a>
-
-# [2.2.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.2.0) - 2024-07-30
-
-- Add Philosophy section by [@nathanjmcdougall](https://github.com/nathanjmcdougall) in
-  [#235](https://github.com/tox-dev/pyproject-fmt/pull/235)
-- Allow for reading TOML files from stdin. by [@fniessink](https://github.com/fniessink) in
-  [#239](https://github.com/tox-dev/pyproject-fmt/pull/239)
-
-<a id="2.1.4"></a>
-
-# [2.1.4](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.1.4) - 2024-07-03
-
-- ci: try uv by [@henryiii](https://github.com/henryiii) in [#225](https://github.com/tox-dev/pyproject-fmt/pull/225)
-- fix: new column width by [@henryiii](https://github.com/henryiii) in
-  [#224](https://github.com/tox-dev/pyproject-fmt/pull/224)
-- Fix sorting not using full spec by [@gaborbernat](https://github.com/gaborbernat) in
-  [#232](https://github.com/tox-dev/pyproject-fmt/pull/232)
-
-<a id="2.1.3"></a>
-
-# [2.1.3](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.1.3) - 2024-05-21
-
-- Fix table expansion leaves behind extra content by [@gaborbernat](https://github.com/gaborbernat) in
-  [#223](https://github.com/tox-dev/pyproject-fmt/pull/223)
-
-<a id="2.1.2"></a>
-
-# [2.1.2](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.1.2) - 2024-05-20
-
-- Pull in comments misplaced in tables fix by [@gaborbernat](https://github.com/gaborbernat) in
-  [#221](https://github.com/tox-dev/pyproject-fmt/pull/221)
-
-<a id="2.1.1"></a>
-
-# [2.1.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.1.1) - 2024-05-15
-
-- Pull in empty sub-tables makes formatting unstable fix by [@gaborbernat](https://github.com/gaborbernat) in
-  [#218](https://github.com/tox-dev/pyproject-fmt/pull/218)
-
-<a id="2.1.0"></a>
-
-# [2.1.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.1.0) - 2024-05-14
-
-- Add API by [@gaborbernat](https://github.com/gaborbernat) in [#216](https://github.com/tox-dev/pyproject-fmt/pull/216)
-- Pull in fixes from upstream by [@gaborbernat](https://github.com/gaborbernat) in
-  [#217](https://github.com/tox-dev/pyproject-fmt/pull/217)
-  - Format the ruff table by [@gaborbernat](https://github.com/gaborbernat) in
-    [#14](https://github.com/tox-dev/pyproject-fmt-rust/pull/14)
-  - Ensure sorting is stable by [@gaborbernat](https://github.com/gaborbernat) in
-    [#16](https://github.com/tox-dev/pyproject-fmt-rust/pull/16)
-  - Do not delete array tables by [@gaborbernat](https://github.com/gaborbernat) in
-    [#17](https://github.com/tox-dev/pyproject-fmt-rust/pull/17)
-
-<a id="2.0.4"></a>
-
-# [2.0.4](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.0.4) - 2024-05-13
-
-- Update README.md by [@gaborbernat](https://github.com/gaborbernat) in
-  [#203](https://github.com/tox-dev/pyproject-fmt/pull/203)
-- Remove outdated YAML example by [@hugovk](https://github.com/hugovk) in
-  [#204](https://github.com/tox-dev/pyproject-fmt/pull/204)
-- lost 'tomli' dependency when python_version < "3.11" by [@gassyfeve](https://github.com/gassyfeve) in
-  [#209](https://github.com/tox-dev/pyproject-fmt/pull/209)
-- Fix table ordering for sub tables and do not version strip on the ~ operator by
-  [@gaborbernat](https://github.com/gaborbernat) in [#210](https://github.com/tox-dev/pyproject-fmt/pull/210)
-
-<a id="2.0.3"></a>
-
-# [2.0.3](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.0.3) - 2024-05-11
-
-- Pull in upstream fixes, see https://github.com/tox-dev/pyproject-fmt-rust/releases/tag/1.0.4 and update docs by
-  [@gaborbernat](https://github.com/gaborbernat) in [#202](https://github.com/tox-dev/pyproject-fmt/pull/202)
-
-<a id="2.0.2"></a>
-
-# [2.0.2](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.0.2) - 2024-05-11
-
-- Pass configuration via separate class by [@gaborbernat](https://github.com/gaborbernat) in
-  [#197](https://github.com/tox-dev/pyproject-fmt/pull/197)
-
-<a id="2.0.1"></a>
-
-# [2.0.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.0.1) - 2024-05-11
-
-- Fix missing dependency by [@gaborbernat](https://github.com/gaborbernat) in
-  [#195](https://github.com/tox-dev/pyproject-fmt/pull/195)
-
-<a id="2.0.0"></a>
-
-# [2.0.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/2.0.0) - 2024-05-10
-
-- Migrate to version 2 powered by [pyproject-fmt-rust](https://github.com/tox-dev/pyproject-fmt-rust) by
-  [@gaborbernat](https://github.com/gaborbernat) in [#194](https://github.com/tox-dev/pyproject-fmt/pull/194)
-
-This introduces multiple changes:
-
-- the requirements are formatted to be shorter and normalized
-- the TOML is now formatted via https://taplo.tamasfe.dev/configuration/formatter-options.html
-- will force arrays to be multiline (can use the column_width configuration to trigger this realign less aggressive)
-- now supports min python version setting via cli/config
-- normalizes project fields to use string instead of string literal
-- collapses project sub tables to be inline within the project table
-- comments are now attached to the next entry and moved alongside entries during re-ordering/sorting
-
-<a id="1.8.0"></a>
-
-# [1.8.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.8.0) - 2024-04-17
-
-- Enforce single line `description` by [@edgarrmondragon](https://github.com/edgarrmondragon) in
-  [#184](https://github.com/tox-dev/pyproject-fmt/pull/184)
-
-<a id="1.7.0"></a>
-
-# [1.7.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.7.0) - 2024-01-22
-
-- Configure pyproject-fmt options from `pyproject.toml` file by [@edgarrmondragon](https://github.com/edgarrmondragon)
-  in [#169](https://github.com/tox-dev/pyproject-fmt/pull/169)
-
-<a id="1.6.0"></a>
-
-# [1.6.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.6.0) - 2024-01-10
-
-- Support adding the classifier for the current Python prerelease by
-  [@edgarrmondragon](https://github.com/edgarrmondragon) in [#162](https://github.com/tox-dev/pyproject-fmt/pull/162)
-- Fix the "Release to PyPI" workflow and add check-jsonschema as a pre-commit hook to prevent future errors by
-  [@edgarrmondragon](https://github.com/edgarrmondragon) in [#167](https://github.com/tox-dev/pyproject-fmt/pull/167)
-
-<a id="1.5.3"></a>
-
-# [1.5.3](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.5.3) - 2023-12-02
-
-- feat: Add `poetry-dynamic-versioning` build backend by [@edgarrmondragon](https://github.com/edgarrmondragon) in
-  [#158](https://github.com/tox-dev/pyproject-fmt/pull/158)
-
-<a id="1.5.2"></a>
-
-# [1.5.2](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.5.2) - 2023-11-29
-
-- feat: Add `deptry` tool by [@edgarrmondragon](https://github.com/edgarrmondragon) in
-  [#157](https://github.com/tox-dev/pyproject-fmt/pull/157)
-
-<a id="1.5.1"></a>
-
-# [1.5.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.5.1) - 2023-11-09
-
-<a id="1.5.0"></a>
-
-# [1.5.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.5.0) - 2023-11-09
-
-- fix: add more tools by [@henryiii](https://github.com/henryiii) in
-  [#154](https://github.com/tox-dev/pyproject-fmt/pull/154)
-
-<a id="1.4.1"></a>
-
-# [1.4.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.4.1) - 2023-11-01
-
-- Allow --check and --keep-full-version, they are not mutually exclusive by
-  [@adamtheturtle](https://github.com/adamtheturtle) in [#152](https://github.com/tox-dev/pyproject-fmt/pull/152)
-
-<a id="1.4.0"></a>
-
-# [1.4.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.4.0) - 2023-11-01
-
-- Remove normalize_requires method by [@adamtheturtle](https://github.com/adamtheturtle) in
-  [#142](https://github.com/tox-dev/pyproject-fmt/pull/142)
-- Add test for normalize_pep508_array by [@adamtheturtle](https://github.com/adamtheturtle) in
-  [#143](https://github.com/tox-dev/pyproject-fmt/pull/143)
-- Add test for indent at formatter test level by [@adamtheturtle](https://github.com/adamtheturtle) in
-  [#146](https://github.com/tox-dev/pyproject-fmt/pull/146)
-- Test passing indent option at CLI level by [@adamtheturtle](https://github.com/adamtheturtle) in
-  [#147](https://github.com/tox-dev/pyproject-fmt/pull/147)
-- chore: modernize Ruff config by [@henryiii](https://github.com/henryiii) in
-  [#148](https://github.com/tox-dev/pyproject-fmt/pull/148)
-- fix: support more common tools by [@henryiii](https://github.com/henryiii) in
-  [#149](https://github.com/tox-dev/pyproject-fmt/pull/149)
-- Add option to skip normalizing requirement versions by [@adamtheturtle](https://github.com/adamtheturtle) in
-  [#150](https://github.com/tox-dev/pyproject-fmt/pull/150)
-
-<a id="1.3.0"></a>
-
-# [1.3.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.3.0) - 2023-10-25
-
-- CLI: Accept `--version` argument, to print the package version by [@amotl](https://github.com/amotl) in
-  [#139](https://github.com/tox-dev/pyproject-fmt/pull/139)
-- Fix generating Python version classifiers based on python-requires by [@gaborbernat](https://github.com/gaborbernat)
-  in [#140](https://github.com/tox-dev/pyproject-fmt/pull/140)
-
-<a id="1.2.0"></a>
-
-# [1.2.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.2.0) - 2023-10-02
-
-- GitHub Actions: Autoupgrade to Py3.12 production release by [@cclauss](https://github.com/cclauss) in
-  [#131](https://github.com/tox-dev/pyproject-fmt/pull/131)
-- \_PY_MAX_VERSION: int = 12 by [@cclauss](https://github.com/cclauss) in
-  [#132](https://github.com/tox-dev/pyproject-fmt/pull/132)
-
-<a id="1.1.0"></a>
-
-# [1.1.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.1.0) - 2023-08-28
-
-- feat: allow pep440 version specifiers in requires-python by [@MindTooth](https://github.com/MindTooth) in
-  [#123](https://github.com/tox-dev/pyproject-fmt/pull/123)
-
-<a id="1.0.0"></a>
-
-# [1.0.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/1.0.0) - 2023-08-22
-
-- Ignore failure of tox executable and drop 3.7 by [@gaborbernat](https://github.com/gaborbernat) in
-  [#121](https://github.com/tox-dev/pyproject-fmt/pull/121)
-
-<a id="0.13.1"></a>
-
-# [0.13.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.13.1) - 2023-08-11
-
-- feat: include tox.ini in sdist by [@mj0nez](https://github.com/mj0nez) in
-  [#116](https://github.com/tox-dev/pyproject-fmt/pull/116)
-
-<a id="0.13.0"></a>
-
-# [0.13.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.13.0) - 2023-07-03
-
-<a id="0.12.1"></a>
-
-# [0.12.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.12.1) - 2023-06-20
-
-<a id="0.12.0"></a>
-
-# [0.12.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.12.0) - 2023-06-15
-
-- git ls-files -z -- .github/workflows/check.yml | xargs -0 sed -i 's|3.12.0-alpha.7|3.12.0-beta.1|g' by
-  [@gaborbernat](https://github.com/gaborbernat) in [#98](https://github.com/tox-dev/pyproject-fmt/pull/98)
-- Add ruff by [@gaborbernat](https://github.com/gaborbernat) in
-  [#100](https://github.com/tox-dev/pyproject-fmt/pull/100)
-
-<a id="0.11.2"></a>
-
-# [0.11.2](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.11.2) - 2023-05-09
-
-- Do not crash on out of order tables by [@gaborbernat](https://github.com/gaborbernat) in
-  [#96](https://github.com/tox-dev/pyproject-fmt/pull/96)
-
-<a id="0.11.1"></a>
-
-# [0.11.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.11.1) - 2023-04-28
-
-- Keep implementation classifiers by [@gaborbernat](https://github.com/gaborbernat) in
-  [#91](https://github.com/tox-dev/pyproject-fmt/pull/91)
-
-<a id="0.11.0"></a>
-
-# [0.11.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.11.0) - 2023-04-28
-
-- Add trusted-publish by [@gaborbernat](https://github.com/gaborbernat) in
-  [#89](https://github.com/tox-dev/pyproject-fmt/pull/89)
-- Generate python version classifiers based on python-requires by [@gaborbernat](https://github.com/gaborbernat) in
-  [#90](https://github.com/tox-dev/pyproject-fmt/pull/90)
-
-<a id="0.10.0"></a>
-
-# [0.10.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.10.0) - 2023-04-24
-
-- Sort classifiers and respect `--indent` by [@hugovk](https://github.com/hugovk) in
-  [#84](https://github.com/tox-dev/pyproject-fmt/pull/84)
-
-<a id="0.9.2"></a>
-
-# [0.9.2](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.9.2) - 2023-02-27
-
-- Fix unnecessary newline addition on sub-tables by [@adamchainz](https://github.com/adamchainz) in
-  [#70](https://github.com/tox-dev/pyproject-fmt/pull/70)
-
-<a id="0.9.1"></a>
-
-# [0.9.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.9.1) - 2023-02-14
-
-- Put setuptools_scm after setuptools by [@gaborbernat](https://github.com/gaborbernat) in
-  [#68](https://github.com/tox-dev/pyproject-fmt/pull/68)
-
-<a id="0.9.0"></a>
-
-# [0.9.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.9.0) - 2023-02-14
-
-- Add tools ordering and separate tables by one line by [@gaborbernat](https://github.com/gaborbernat) in
-  [#67](https://github.com/tox-dev/pyproject-fmt/pull/67)
-
-<a id="0.8.0"></a>
-
-# [0.8.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.8.0) - 2023-02-09
-
-- Follow the package name normalization spec by [@hugovk](https://github.com/hugovk) in
-  [#66](https://github.com/tox-dev/pyproject-fmt/pull/66)
-
-<a id="0.7.0"></a>
-
-# [0.7.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.7.0) - 2023-02-07
-
-- add pre-commit snippet to readme by [@RonnyPfannschmidt](https://github.com/RonnyPfannschmidt) in
-  [#62](https://github.com/tox-dev/pyproject-fmt/pull/62)
-- Bump deps and tools by [@gaborbernat](https://github.com/gaborbernat) in
-  [#63](https://github.com/tox-dev/pyproject-fmt/pull/63)
-- add --check by [@bollwyvl](https://github.com/bollwyvl) in [#65](https://github.com/tox-dev/pyproject-fmt/pull/65)
-
-- [@RonnyPfannschmidt](https://github.com/RonnyPfannschmidt) made their first contribution in
-  [#62](https://github.com/tox-dev/pyproject-fmt/pull/62)
-- [@bollwyvl](https://github.com/bollwyvl) made their first contribution in
-  [#65](https://github.com/tox-dev/pyproject-fmt/pull/65)
-
-<a id="0.6.0"></a>
-
-# [0.6.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.6.0) - 2023-01-30
-
-- Handle inline tables and change order, so dependencies and optional-dependencies are closer to each other.
-
-<a id="0.5.0"></a>
-
-# [0.5.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.5.0) - 2023-01-19
-
-- Update version of `pyproject-fmt` in example pre-commit hook in docs by [@namurphy](https://github.com/namurphy) in
-  [#58](https://github.com/tox-dev/pyproject-fmt/pull/58)
-- Exclude bots from generated release notes by [@hugovk](https://github.com/hugovk) in
-  [#61](https://github.com/tox-dev/pyproject-fmt/pull/61)
-- Only write to file if changed by [@hugovk](https://github.com/hugovk) in
-  [#60](https://github.com/tox-dev/pyproject-fmt/pull/60)
-
-<a id="0.4.1"></a>
-
-# [0.4.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.4.1) - 2022-11-23
-
-- Programming Language :: Python :: 3.11 by [@cclauss](https://github.com/cclauss) in
-  [#47](https://github.com/tox-dev/pyproject-fmt/pull/47)
-
-<a id="0.4.0"></a>
-
-# [0.4.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.4.0) - 2022-11-23
-
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#38](https://github.com/tox-dev/pyproject-fmt/pull/38)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#39](https://github.com/tox-dev/pyproject-fmt/pull/39)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#41](https://github.com/tox-dev/pyproject-fmt/pull/41)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#42](https://github.com/tox-dev/pyproject-fmt/pull/42)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#43](https://github.com/tox-dev/pyproject-fmt/pull/43)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#44](https://github.com/tox-dev/pyproject-fmt/pull/44)
-- feat: support multiple "pyproject.toml" files by [@KyleKing](https://github.com/KyleKing) in
-  [#46](https://github.com/tox-dev/pyproject-fmt/pull/46)
-
-<a id="0.3.5"></a>
-
-# [0.3.5](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.3.5) - 2022-08-13
-
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#28](https://github.com/tox-dev/pyproject-fmt/pull/28)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#29](https://github.com/tox-dev/pyproject-fmt/pull/29)
-- Support tomlkit 0.11 by [@gaborbernat](https://github.com/gaborbernat) in
-  [#33](https://github.com/tox-dev/pyproject-fmt/pull/33)
-- Bump actions/checkout from 2 to 3 by [@dependabot](https://github.com/dependabot) in
-  [#35](https://github.com/tox-dev/pyproject-fmt/pull/35)
-- Bump actions/setup-python from 2 to 4 by [@dependabot](https://github.com/dependabot) in
-  [#34](https://github.com/tox-dev/pyproject-fmt/pull/34)
-
-<a id="0.3.4"></a>
-
-# [Fix project links (0.3.4)](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.3.4) - 2022-06-26
-
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#19](https://github.com/tox-dev/pyproject-fmt/pull/19)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#20](https://github.com/tox-dev/pyproject-fmt/pull/20)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#21](https://github.com/tox-dev/pyproject-fmt/pull/21)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#24](https://github.com/tox-dev/pyproject-fmt/pull/24)
-- [pre-commit.ci] pre-commit autoupdate by [@pre-commit-ci](https://github.com/pre-commit-ci) in
-  [#25](https://github.com/tox-dev/pyproject-fmt/pull/25)
-
-<a id="0.3.3"></a>
-
-# [Fix help message referring to tox.ini files (0.3.3)](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.3.3) - 2022-03-23
-
-<a id="0.3.2"></a>
-
-# [0.3.2](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.3.2) - 2022-03-01
-
-<a id="0.3.1"></a>
-
-# [0.3.1](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.3.1) - 2022-02-27
-
-<a id="0.3.0"></a>
-
-# [0.3.0](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.3.0) - 2022-02-27
-
-<a id="0.2.0"></a>
-
-# [Support build-system (0.2.0)](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.2.0) - 2022-02-21
-
-<a id="0.1.0"></a>
-
-# [Base version (0.1.0)](https://github.com/tox-dev/pyproject-fmt/releases/tag/0.1.0) - 2022-02-21
-
-<!-- Generated by https://github.com/rhysd/changelog-from-release v3.8.0 -->
+- Create first version by [@gaborbernat](https://github.com/gaborbernat) in
+  [#1](https://github.com/tox-dev/toml-fmt/pull/1)
+
+For versions before 2.4.0, see releases in the old repositories:
+[pyproject-fmt](https://github.com/tox-dev/pyproject-fmt/releases) (Python) and
+[pyproject-fmt-rust](https://github.com/tox-dev/pyproject-fmt-rust/releases) (Rust).

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -1,8 +1,9 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#   "gitpython>=3.1.43",
-#   "pygithub>=2.4",
+#   "gitpython>=3.1.46",
+#   "prek>=0.3.1",
+#   "pygithub>=2.8.1",
 # ]
 # ///
 """Generate the changelog on release."""
@@ -11,11 +12,13 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess  # noqa: S404
 from argparse import ArgumentParser, Namespace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import urllib3
 from git import Repo
 from github import Github, Repository
 from github.Auth import Token
@@ -26,6 +29,8 @@ if TYPE_CHECKING:
 
     from github.Repository import Repository as GitHubRepository
 
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 ROOT = Path(__file__).parents[1]
 
 
@@ -33,6 +38,7 @@ class Options(Namespace):
     project: str
     pr: int | None
     base: str
+    regenerate: bool
 
 
 def run() -> None:
@@ -41,33 +47,39 @@ def run() -> None:
     project = ROOT / options.project
     changelog_file = project / "CHANGELOG.md"
 
+    git_repo = Repo(ROOT)
+    at = "tox-dev/toml-fmt"
+    github = Github(auth=Token(os.environ["GITHUB_TOKEN"]), verify=False)
+    gh_repo = github.get_repo(at)
+
+    if options.regenerate:
+        regenerate_changelog(changelog_file, git_repo, gh_repo, at, options.project)
+        return
+
     version = get_version(project)
     changelog = changelog_file.read_text(encoding="utf-8")
     anchor = f'<a id="{version}"></a>'
 
     logs = []
-    git_repo = Repo(ROOT)
-    github = Github(auth=Token(os.environ["GITHUB_TOKEN"]))
-    at = "tox-dev/toml-fmt"
-    gh_repo = github.get_repo(at)
     for title, pr, by in entries(gh_repo, git_repo, options.pr, options.base, options.project):
         suffix = f" in [#{pr}](https://github.com/{at}/pull/{pr})" if pr else ""
         logs.append(f"{title} by [@{by}](https://github.com/{by}){suffix}")
 
     if logs:
-        logs = [f" - {i}" for i in logs]
+        logs = [f"- {i}" for i in logs]
         new_lines = [
             anchor,
+            "",
             f"## {version} - {datetime.now(tz=UTC).date().isoformat()}",
             "",
             *logs,
-            "",
             "",
         ]
         new = "\n".join(new_lines)
         print(new)
         logs_text = "\n".join(logs)
-        changelog_file.write_text(new + changelog)
+        changelog_file.write_text(new + changelog, encoding="utf-8")
+        subprocess.run(["prek", "run", "--files", str(changelog_file)], check=False)  # noqa: S603, S607
     else:
         logs_text = ""
 
@@ -81,8 +93,9 @@ def run() -> None:
 def parse_cli() -> Options:
     parser = ArgumentParser()
     parser.add_argument("project", choices=["pyproject-fmt", "tox-toml-fmt"])
-    parser.add_argument("pr", type=lambda s: int(s) if s else None)
-    parser.add_argument("base", type=str)
+    parser.add_argument("pr", type=lambda s: int(s) if s else None, nargs="?", default=None)
+    parser.add_argument("base", type=str, nargs="?", default="")
+    parser.add_argument("--regenerate", action="store_true", help="Regenerate entire changelog from all releases")
     options = Options()
     parser.parse_args(namespace=options)
     return options
@@ -91,6 +104,73 @@ def parse_cli() -> Options:
 def get_version(base: Path) -> str:
     with (base / "Cargo.toml").open("rb") as cargo_toml_file_handler:
         return load(cargo_toml_file_handler)["package"]["version"]
+
+
+def regenerate_changelog(
+    changelog_file: Path, git_repo: Repo, gh_repo: GitHubRepository, at: str, project: str
+) -> None:
+    project_tags = sorted(
+        ((tag, tag.name.split("/")[1]) for tag in git_repo.tags if tag.name.startswith(f"{project}/")),
+        key=lambda t: t[0].commit.committed_datetime,
+    )
+    if not project_tags:
+        print(f"No tags found for {project}")
+        return
+
+    sections: list[str] = []
+    for i, (tag, version) in enumerate(project_tags):
+        prev_commit = project_tags[i - 1][0].commit.hexsha if i > 0 else None
+        current_commit = tag.commit.hexsha
+        release_date = tag.commit.committed_datetime.date().isoformat()
+
+        logs = list(entries_between(gh_repo, git_repo, prev_commit, current_commit, at, project))
+        if logs:
+            log_lines = [f"- {entry}" for entry in logs]
+            section = f'<a id="{version}"></a>\n\n## {version} - {release_date}\n\n' + "\n".join(log_lines)
+            sections.append(section)
+        else:
+            sections.append(f'<a id="{version}"></a>\n\n## {version} - {release_date}\n\n- Initial release')
+
+    content = "\n\n".join(reversed(sections))
+    if project == "pyproject-fmt":
+        content += (
+            "\n\nFor versions before 2.4.0, see releases in the old repositories: "
+            "[pyproject-fmt](https://github.com/tox-dev/pyproject-fmt/releases) (Python) and "
+            "[pyproject-fmt-rust](https://github.com/tox-dev/pyproject-fmt-rust/releases) (Rust).\n"
+        )
+    else:
+        content += "\n"
+    changelog_file.write_text(content, encoding="utf-8")
+    subprocess.run(["prek", "run", "--files", str(changelog_file)], check=False)  # noqa: S603, S607
+    print(f"Regenerated changelog for {project} with {len(sections)} releases")
+
+
+def entries_between(  # noqa: PLR0913, PLR0917
+    gh_repo: GitHubRepository, git_repo: Repo, start: str | None, end: str, at: str, project: str
+) -> Iterator[str]:
+    pr_re = re.compile(r"(?P<title>.*)[(]#(?P<pr>\d+)[)]")
+    release_re = re.compile(r"^Release \S+ \d+\.\d+\.\d+$")
+    rev_range = f"{start}..{end}" if start else end
+    for change in git_repo.iter_commits(rev_range):
+        if change.author.name in {"pre-commit-ci[bot]", "dependabot[bot]"}:
+            continue
+        if not commit_affects_project(change, project):
+            continue
+        title = change.message.split("\n")[0].strip()
+        if release_re.match(title):
+            continue
+        by = get_author_login(gh_repo, change)
+        if match := pr_re.match(title):
+            group = match.groupdict()
+            pr = group["pr"]
+            suffix = f" in [#{pr}](https://github.com/{at}/pull/{pr})"
+            yield f"{group['title'].strip()} by [@{by}](https://github.com/{by}){suffix}"
+        else:
+            yield f"{title} by [@{by}](https://github.com/{by})"
+
+
+def get_author_login(gh_repo: GitHubRepository, change: object) -> str:
+    return gh_repo.get_commit(change.hexsha).author.login
 
 
 def entries(
@@ -111,7 +191,7 @@ def entries(
         if not commit_affects_project(change, project):
             continue
         title = change.message.split("\n")[0].strip()
-        by = gh_repo.get_commit(change.hexsha).author.login
+        by = get_author_login(gh_repo, change)
         if match := pr_re.match(title):
             group = match.groupdict()
             yield group["title"].strip(), group["pr"], by

--- a/tox-toml-fmt/CHANGELOG.md
+++ b/tox-toml-fmt/CHANGELOG.md
@@ -1,31 +1,16 @@
-<a id="1.4.0"></a>
-
-## 1.4.0 - 2026-02-07
-
-- 📝 docs(formatting): restructure docs and fix array formatting behavior by
-  [@gaborbernat](https://github.com/gaborbernat) in [#164](https://github.com/tox-dev/toml-fmt/pull/164)
-- ♻️ refactor(parser): migrate from taplo to tombi by [@gaborbernat](https://github.com/gaborbernat) in
-  [#159](https://github.com/tox-dev/toml-fmt/pull/159)
-- Fix expand_tables setting for deeply nested tables by [@gaborbernat](https://github.com/gaborbernat) in
-  [#160](https://github.com/tox-dev/toml-fmt/pull/160)
-- Prefer double quotes, use single quotes to avoid escaping by [@gaborbernat](https://github.com/gaborbernat) in
-  [#162](https://github.com/tox-dev/toml-fmt/pull/162)
-- Fix comment before table moving incorrectly when table has comments by [@gaborbernat](https://github.com/gaborbernat)
-  in [#158](https://github.com/tox-dev/toml-fmt/pull/158)
-- Fix expand_tables setting for specific sub-tables by [@gaborbernat](https://github.com/gaborbernat) in
-  [#148](https://github.com/tox-dev/toml-fmt/pull/148)
-
 <a id="1.3.0"></a>
 
-## 1.3.0 - 2026-01-31
+## 1.3.0 - 2026-01-30
 
 - Generate README.rst dynamically from docs at build time by [@gaborbernat](https://github.com/gaborbernat) in
   [#145](https://github.com/tox-dev/toml-fmt/pull/145)
 - 📚 Document formatting principles and normalizations by [@gaborbernat](https://github.com/gaborbernat) in
   [#144](https://github.com/tox-dev/toml-fmt/pull/144)
-- Add configurable table formatting with table_format, expand_tables, and collapse_tables options by
+- Improve maintainalibility by [@gaborbernat](https://github.com/gaborbernat) in
+  [#143](https://github.com/tox-dev/toml-fmt/pull/143)
+- Add configurable table formatting to pyproject-fmt and order tox env tables by env_list by
   [@gaborbernat](https://github.com/gaborbernat) in [#142](https://github.com/tox-dev/toml-fmt/pull/142)
-- Order tox env tables according to env_list by [@gaborbernat](https://github.com/gaborbernat) in
+- Order tox env tables according to env_list and add codecov token by [@gaborbernat](https://github.com/gaborbernat) in
   [#141](https://github.com/tox-dev/toml-fmt/pull/141)
 - Fix comments before table headers staying with correct table by [@gaborbernat](https://github.com/gaborbernat) in
   [#140](https://github.com/tox-dev/toml-fmt/pull/140)
@@ -43,8 +28,14 @@
   [#131](https://github.com/tox-dev/toml-fmt/pull/131)
 - Fix literal strings with invalid escapes being corrupted by [@gaborbernat](https://github.com/gaborbernat) in
   [#130](https://github.com/tox-dev/toml-fmt/pull/130)
-- Fix build requirements with duplicate package names being removed by [@gaborbernat](https://github.com/gaborbernat) in
-  [#127](https://github.com/tox-dev/toml-fmt/pull/127)
+- Remove testpaths config to fix sdist warning (#120) by [@gaborbernat](https://github.com/gaborbernat) in
+  [#129](https://github.com/tox-dev/toml-fmt/pull/129)
+- Fix build requirements with duplicate package names being removed (#2) by
+  [@gaborbernat](https://github.com/gaborbernat) in [#127](https://github.com/tox-dev/toml-fmt/pull/127)
+- Improve CI: add Rust coverage thresholds and prek parallel hooks by [@gaborbernat](https://github.com/gaborbernat) in
+  [#126](https://github.com/tox-dev/toml-fmt/pull/126)
+- Improve GitHub Actions workflows by [@gaborbernat](https://github.com/gaborbernat) in
+  [#125](https://github.com/tox-dev/toml-fmt/pull/125)
 
 <a id="1.2.2"></a>
 
@@ -57,14 +48,12 @@
 
 ## 1.2.1 - 2025-11-12
 
-- Fix tool names in documentation by [@gaborbernat](https://github.com/gaborbernat) in
+- Fix tool names in documentation. by [@jorisboeye](https://github.com/jorisboeye) in
   [#106](https://github.com/tox-dev/toml-fmt/pull/106)
 - Fix documentation links and bump deps by [@gaborbernat](https://github.com/gaborbernat) in
   [#105](https://github.com/tox-dev/toml-fmt/pull/105)
 - Fix too aggressive parsing suffix versions by [@gaborbernat](https://github.com/gaborbernat) in
   [#101](https://github.com/tox-dev/toml-fmt/pull/101)
-- perf: only compile regexes once by [@henryiii](https://github.com/henryiii) in
-  [#110](https://github.com/tox-dev/toml-fmt/pull/110)
 
 <a id="1.2.0"></a>
 
@@ -72,7 +61,7 @@
 
 - Drop 3.9 and add 3.14 by [@gaborbernat](https://github.com/gaborbernat) in
   [#96](https://github.com/tox-dev/toml-fmt/pull/96)
-- Fix parsing of version pre labels by [@gaborbernat](https://github.com/gaborbernat) in
+- Fix parsing of version pre labels by [@adamchainz](https://github.com/adamchainz) in
   [#89](https://github.com/tox-dev/toml-fmt/pull/89)
 
 <a id="1.1.0"></a>
@@ -81,16 +70,24 @@
 
 - Replace upstream pep508 that's deprecated with our own by [@gaborbernat](https://github.com/gaborbernat) in
   [#84](https://github.com/tox-dev/toml-fmt/pull/84)
-- Fix empty lines placed within a sorted table by [@gaborbernat](https://github.com/gaborbernat) in
+- Fix empty lines placed within a sorted table by [@ddeepwell](https://github.com/ddeepwell) in
   [#63](https://github.com/tox-dev/toml-fmt/pull/63)
 - Use abi3-py39 by [@gaborbernat](https://github.com/gaborbernat) in [#58](https://github.com/tox-dev/toml-fmt/pull/58)
 - Bump rust and versions by [@gaborbernat](https://github.com/gaborbernat) in
   [#56](https://github.com/tox-dev/toml-fmt/pull/56)
-- Include all ident parts in keys by [@gaborbernat](https://github.com/gaborbernat) in
+- Include all ident parts in keys by [@adamchainz](https://github.com/adamchainz) in
   [#31](https://github.com/tox-dev/toml-fmt/pull/31)
 
 <a id="1.0.0"></a>
 
 ## 1.0.0 - 2024-10-31
 
-- Initial release
+- Update Cargo.toml by [@gaborbernat](https://github.com/gaborbernat)
+- Add tox-toml-fmt by [@gaborbernat](https://github.com/gaborbernat) in
+  [#18](https://github.com/tox-dev/toml-fmt/pull/18)
+- Add support for PEP 735 dependency-groups by [@browniebroke](https://github.com/browniebroke) in
+  [#16](https://github.com/tox-dev/toml-fmt/pull/16)
+- Extract common Python code to toml-fmt-common by [@gaborbernat](https://github.com/gaborbernat) in
+  [#12](https://github.com/tox-dev/toml-fmt/pull/12)
+- Create first version by [@gaborbernat](https://github.com/gaborbernat) in
+  [#1](https://github.com/tox-dev/toml-fmt/pull/1)


### PR DESCRIPTION
The changelog script could only add entries incrementally for new releases, making it impossible to fix historical entries or ensure format consistency across all versions. 📋 When bugs were discovered in the generation logic, maintainers had to manually edit changelog files or leave inconsistencies in place.

This adds a `--regenerate` flag that rebuilds the entire changelog from git history. The script iterates through all project tags chronologically, using git range syntax to properly scope commits between releases. It filters out release commits and bot contributions (pre-commit-ci, dependabot), and fetches GitHub usernames via the API. ✨ SSL certificate verification is bypassed to handle corporate proxy environments.

The README now separates source and changelog links for clarity. Both project changelogs have been regenerated to verify the logic works correctly and ensure consistent formatting across all 23 historical releases.