### PR TITLE
🐛 fix(ci): enable full git history for changelog generation

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -41,6 +41,8 @@ jobs:
           crate: cargo-edit
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: 🔖 Bump version
         run: cargo set-version -p pyproject-fmt --bump '${{ github.event.inputs.release == 'no' || github.event.inputs.release == null && 'patch' || github.event.inputs.release }}'
       - name: 📦 Setup uv

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -41,6 +41,8 @@ jobs:
           crate: cargo-edit
       - name: 📥 Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: 🔖 Bump version
         run: cargo set-version -p tox-toml-fmt --bump '${{ github.event.inputs.release == 'no' || github.event.inputs.release == null && 'patch' || github.event.inputs.release }}'
       - name: 📦 Setup uv

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -179,7 +179,7 @@ def entries(
     if pr:
         pull = gh_repo.get_pull(pr)
         yield pull.title, str(pr), pull.user.login
-    tags = {tag.commit.hexsha for tag in git_repo.tags}
+    tags = {tag.commit.hexsha for tag in git_repo.tags if tag.name.startswith(f"{project}/")}
     pr_re = re.compile(r"(?P<title>.*)[(]#(?P<pr>\d+)[)]")
     found_base = not base
     for change in git_repo.iter_commits():


### PR DESCRIPTION
Changelog generation was failing in CI because `commit.stats.files` requires access to parent commits to determine which files changed. GitHub Actions uses shallow clones by default, which don't include this history. 🔧 Additionally, in this monorepo the changelog script was incorrectly stopping at any release tag rather than only tags for the specific project being released.

The fix uses deep clones (`fetch-depth: 0`) in the bump job and filters release tags by project prefix. This ensures `pyproject-fmt` releases only consider `pyproject-fmt/*` tags as boundaries, and likewise for `tox-toml-fmt`.

Both changes are required together—deep clones provide the commit stats needed for project filtering, while tag filtering ensures correct changelog boundaries in a monorepo with interleaved release tags.