### PR TITLE
✨ feat(github): add issue templates for pyproject-fmt and tox-toml-fmt

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/pyproject-fmt-bug.yml
+++ b/.github/ISSUE_TEMPLATE/pyproject-fmt-bug.yml
@@ -1,0 +1,57 @@
+name: "🐛 pyproject-fmt: Bug Report"
+description: Report a bug in pyproject-fmt
+labels: ["bug", "pyproject-fmt"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug in pyproject-fmt.
+        Please fill out the sections below to help us understand and reproduce the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the issue you encountered...
+    validations:
+      required: true
+
+  - type: textarea
+    id: input
+    attributes:
+      label: 📄 Input pyproject.toml
+      description: The pyproject.toml content that triggers the bug.
+      placeholder: Paste the relevant portion of your pyproject.toml here
+      render: toml
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: ✅ Expected output
+      description: What you expected the formatted output to look like.
+      render: toml
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: ❌ Actual output
+      description: What actually happened (formatted output or error message).
+      render: toml
+
+  - type: input
+    id: version
+    attributes:
+      label: 🏷️ Version
+      description: Output of `pyproject-fmt --version`
+      placeholder: "pyproject-fmt 2.x.x"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 📎 Additional context
+      description: Any other relevant context (OS, Python version, configuration options used).

--- a/.github/ISSUE_TEMPLATE/pyproject-fmt-feature.yml
+++ b/.github/ISSUE_TEMPLATE/pyproject-fmt-feature.yml
@@ -1,0 +1,40 @@
+name: "✨ pyproject-fmt: Feature Request"
+description: Suggest an enhancement for pyproject-fmt
+labels: ["enhancement", "pyproject-fmt"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an improvement to pyproject-fmt.
+        Please describe your idea so we can understand the use case and potential implementation.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description
+      description: A clear and concise description of the feature you'd like.
+      placeholder: Describe the feature or improvement...
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: 🎯 Use case
+      description: Explain the problem this would solve or the workflow it would improve.
+      placeholder: This would help when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: 📄 Example
+      description: If applicable, show an example of the desired input/output behavior.
+      render: toml
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 🔄 Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.

--- a/.github/ISSUE_TEMPLATE/tox-toml-fmt-bug.yml
+++ b/.github/ISSUE_TEMPLATE/tox-toml-fmt-bug.yml
@@ -1,0 +1,57 @@
+name: "🐛 tox-toml-fmt: Bug Report"
+description: Report a bug in tox-toml-fmt
+labels: ["bug", "tox-toml-fmt"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug in tox-toml-fmt.
+        Please fill out the sections below to help us understand and reproduce the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Describe the issue you encountered...
+    validations:
+      required: true
+
+  - type: textarea
+    id: input
+    attributes:
+      label: 📄 Input tox.toml
+      description: The tox.toml content that triggers the bug.
+      placeholder: Paste the relevant portion of your tox.toml here
+      render: toml
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: ✅ Expected output
+      description: What you expected the formatted output to look like.
+      render: toml
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: ❌ Actual output
+      description: What actually happened (formatted output or error message).
+      render: toml
+
+  - type: input
+    id: version
+    attributes:
+      label: 🏷️ Version
+      description: Output of `tox-toml-fmt --version`
+      placeholder: "tox-toml-fmt 1.x.x"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 📎 Additional context
+      description: Any other relevant context (OS, Python version, configuration options used).

--- a/.github/ISSUE_TEMPLATE/tox-toml-fmt-feature.yml
+++ b/.github/ISSUE_TEMPLATE/tox-toml-fmt-feature.yml
@@ -1,0 +1,40 @@
+name: "✨ tox-toml-fmt: Feature Request"
+description: Suggest an enhancement for tox-toml-fmt
+labels: ["enhancement", "tox-toml-fmt"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an improvement to tox-toml-fmt.
+        Please describe your idea so we can understand the use case and potential implementation.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description
+      description: A clear and concise description of the feature you'd like.
+      placeholder: Describe the feature or improvement...
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: 🎯 Use case
+      description: Explain the problem this would solve or the workflow it would improve.
+      placeholder: This would help when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: 📄 Example
+      description: If applicable, show an example of the desired input/output behavior.
+      render: toml
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 🔄 Alternatives considered
+      description: Any alternative solutions or workarounds you've considered.


### PR DESCRIPTION
This monorepo lacked structured issue reporting, making it harder to triage bugs and feature requests across two distinct formatters. 📋 Users now get guided forms that collect the right information upfront: input file content, expected vs actual output, and version info.

Each template automatically applies the appropriate project label (`pyproject-fmt` or `tox-toml-fmt`) along with the issue type (`bug` or `enhancement`), ensuring proper categorization without manual effort. The pre-commit mirror repos (`tox-dev/pyproject-fmt` and `tox-dev/tox-toml-fmt`) redirect users here since all development happens in this monorepo.

Blank issues are disabled to guide users toward the appropriate template. Unused default labels have been cleaned up to keep the label set minimal and meaningful.