### PR TITLE
✨ feat(pyproject-fmt): add tool.uv section formatting

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -369,6 +369,62 @@ Plugin arrays:
   ``lint.pydocstyle.ignore-decorators``, ``lint.pydocstyle.property-decorators``, ``lint.pyflakes.extend-generics``,
   ``lint.pylint.allow-dunder-method-names``, ``lint.pylint.allow-magic-value-types``
 
+``[tool.uv]``
+~~~~~~~~~~~~~
+
+**Key ordering:**
+
+Keys are grouped by functionality:
+
+1. Version & Python: ``required-version`` → ``python-preference`` → ``python-downloads``
+2. Dependencies: ``dev-dependencies`` → ``default-groups`` → ``dependency-groups`` → ``constraint-dependencies`` →
+   ``override-dependencies`` → ``exclude-dependencies`` → ``dependency-metadata``
+3. Sources & indexes: ``sources`` → ``index`` → ``index-url`` → ``extra-index-url`` → ``find-links`` → ``no-index`` →
+   ``index-strategy`` → ``keyring-provider``
+4. Package handling: ``no-binary*`` → ``no-build*`` → ``no-sources*`` → ``reinstall*`` → ``upgrade*``
+5. Resolution: ``resolution`` → ``prerelease`` → ``fork-strategy`` → ``environments`` → ``required-environments`` →
+   ``exclude-newer*``
+6. Build & Install: ``compile-bytecode`` → ``link-mode`` → ``config-settings*`` → ``extra-build-*`` →
+   ``concurrent-builds`` → ``concurrent-downloads`` → ``concurrent-installs``
+7. Network & Security: ``allow-insecure-host`` → ``native-tls`` → ``offline`` → ``no-cache`` → ``cache-dir`` →
+   ``http-proxy`` → ``https-proxy`` → ``no-proxy``
+8. Publishing: ``publish-url`` → ``check-url`` → ``trusted-publishing``
+9. Python management: ``python-install-mirror`` → ``pypy-install-mirror`` → ``python-downloads-json-url``
+10. Workspace & Project: ``managed`` → ``package`` → ``workspace`` → ``conflicts`` → ``cache-keys`` → ``build-backend``
+11. Other: ``pip`` → ``preview`` → ``torch-backend``
+
+**Sorted arrays:**
+
+Package name arrays (sorted alphabetically):
+  ``constraint-dependencies``, ``override-dependencies``, ``dev-dependencies``, ``exclude-dependencies``,
+  ``no-binary-package``, ``no-build-package``, ``no-build-isolation-package``, ``no-sources-package``,
+  ``reinstall-package``, ``upgrade-package``
+
+Other arrays:
+  ``environments``, ``required-environments``, ``allow-insecure-host``, ``no-proxy``, ``workspace.members``,
+  ``workspace.exclude``
+
+**Sources table:**
+
+The ``sources`` table entries are sorted alphabetically by package name:
+
+.. code-block:: toml
+
+    # Before
+    [tool.uv.sources]
+    zebra = { git = "..." }
+    alpha = { path = "..." }
+
+    # After
+    [tool.uv.sources]
+    alpha = { path = "..." }
+    zebra = { git = "..." }
+
+**pip subsection:**
+
+The ``[tool.uv.pip]`` subsection follows similar formatting rules, with arrays like ``extra``, ``no-binary-package``,
+``no-build-package``, ``reinstall-package``, and ``upgrade-package`` sorted alphabetically.
+
 Other Tables
 ~~~~~~~~~~~~
 

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -17,6 +17,7 @@ mod global;
 mod ruff;
 #[cfg(test)]
 mod tests;
+mod uv;
 
 #[pyclass(frozen, get_all)]
 pub struct Settings {
@@ -145,6 +146,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     );
     dependency_groups::fix(&mut tables, opt.keep_full_version);
     ruff::fix(&mut tables);
+    uv::fix(&mut tables);
     reorder_tables(&root_ast, &tables);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);
     common::string::wrap_all_long_strings(&root_ast, opt.column_width, &indent_string);

--- a/pyproject-fmt/rust/src/tests/data/uv-order.toml
+++ b/pyproject-fmt/rust/src/tests/data/uv-order.toml
@@ -1,0 +1,136 @@
+[tool.uv]
+torch-backend = "cu124"
+preview = true
+pip = {}
+build-backend = {}
+cache-keys = []
+conflicts = []
+workspace = {}
+package = true
+managed = true
+python-downloads-json-url = "https://example.com"
+pypy-install-mirror = "https://example.com"
+python-install-mirror = "https://example.com"
+trusted-publishing = "always"
+check-url = "https://example.com"
+publish-url = "https://example.com"
+no-proxy = ["localhost", "*.internal.com"]
+https-proxy = "https://proxy.example.com"
+http-proxy = "http://proxy.example.com"
+cache-dir = "~/.cache/uv"
+no-cache = true
+offline = true
+native-tls = true
+allow-insecure-host = ["internal.corp.com", "build.corp.com"]
+concurrent-installs = 4
+concurrent-downloads = 4
+concurrent-builds = 4
+extra-build-variables = {}
+extra-build-dependencies = []
+config-settings-package = {}
+config-settings = {}
+link-mode = "clone"
+compile-bytecode = true
+exclude-newer-package = {}
+exclude-newer = "2024-01-01"
+required-environments = ["sys_platform == 'linux'", "python_version >= '3.8'"]
+environments = ["sys_platform == 'darwin'", "python_version >= '3.10'"]
+fork-strategy = "fewest"
+prerelease = "disallow"
+resolution = "highest"
+upgrade-package = ["requests", "flask"]
+upgrade = true
+reinstall-package = ["mypy", "black"]
+reinstall = true
+no-sources-package = ["pkg1", "pkg2"]
+no-sources = true
+no-build-isolation-package = ["scipy", "numpy"]
+no-build-isolation = true
+no-build-package = ["torch", "tensorflow"]
+no-build = true
+no-binary-package = ["scipy", "numpy", "pillow"]
+no-binary = true
+keyring-provider = "subprocess"
+index-strategy = "first-index"
+no-index = true
+find-links = ["https://example.com/packages"]
+extra-index-url = "https://example.com/simple"
+index-url = "https://pypi.org/simple"
+index = []
+sources = {}
+dependency-metadata = []
+exclude-dependencies = ["unwanted"]
+override-dependencies = ["numpy==1.24", "pandas>=2"]
+constraint-dependencies = ["requests<3", "flask>=2"]
+dependency-groups = {}
+default-groups = ["dev"]
+dev-dependencies = ["pytest", "black", "mypy"]
+python-downloads = "automatic"
+python-preference = "managed"
+required-version = ">=0.4.0"
+
+[tool.uv.sources]
+zebra = { git = "https://github.com/example/zebra" }
+alpha = { path = "../alpha" }
+mango = { workspace = true }
+beta = { url = "https://example.com/beta.whl" }
+
+[tool.uv.pip]
+universal = true
+output-file = "requirements.txt"
+no-strip-markers = true
+no-strip-extras = true
+no-header = true
+no-emit-package = ["setuptools", "pip"]
+no-annotate = true
+generate-hashes = true
+emit-marker-expression = true
+emit-index-url = true
+emit-index-annotation = true
+emit-find-links = true
+emit-build-options = true
+custom-compile-command = "uv pip compile"
+annotation-style = "line"
+exclude-newer-package = {}
+strict = true
+python-version = "3.10"
+python-platform = "linux"
+upgrade-package = ["requests"]
+upgrade = true
+reinstall-package = ["mypy"]
+reinstall = true
+allow-empty-requirements = true
+no-deps = true
+extra = ["dev", "test"]
+all-extras = true
+cache-dir = "~/.cache/uv"
+no-cache = true
+offline = true
+native-tls = true
+allow-insecure-host = ["internal.corp.com"]
+config-settings = {}
+link-mode = "clone"
+compile-bytecode = true
+exclude-newer = "2024-01-01"
+fork-strategy = "fewest"
+prerelease = "disallow"
+resolution = "highest"
+no-build-isolation-package = ["scipy"]
+no-build-isolation = true
+no-build-package = ["torch"]
+no-build = true
+only-binary-package = ["numpy"]
+only-binary = true
+no-binary-package = ["scipy"]
+no-binary = true
+keyring-provider = "subprocess"
+index-strategy = "first-index"
+no-index = true
+find-links = ["https://example.com/packages"]
+extra-index-url = "https://example.com/simple"
+index-url = "https://pypi.org/simple"
+prefix = "/usr/local"
+target = "/tmp/install"
+break-system-packages = true
+system = true
+python = "3.10"

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod global_tests;
 mod main_tests;
 mod project_tests;
 mod ruff_tests;
+mod uv_tests;
 
 static TOKIO_RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 

--- a/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__uv_tests__order_uv.snap
+++ b/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__uv_tests__order_uv.snap
@@ -1,0 +1,137 @@
+---
+source: pyproject-fmt/rust/src/tests/uv_tests.rs
+expression: result
+---
+required-version = ">=0.4.0"
+python-preference = "managed"
+python-downloads = "automatic"
+dev-dependencies = [ "black", "mypy", "pytest" ]
+default-groups = [ "dev" ]
+dependency-groups = {  }
+constraint-dependencies = [ "flask>=2", "requests<3" ]
+override-dependencies = [ "numpy==1.24", "pandas>=2" ]
+exclude-dependencies = [ "unwanted" ]
+dependency-metadata = [  ]
+sources = {  }
+sources.alpha = { path = "../alpha" }
+sources.beta = { url = "https://example.com/beta.whl" }
+sources.mango = { workspace = true }
+sources.zebra = { git = "https://github.com/example/zebra" }
+index = [  ]
+index-url = "https://pypi.org/simple"
+extra-index-url = "https://example.com/simple"
+find-links = [ "https://example.com/packages" ]
+no-index = true
+index-strategy = "first-index"
+keyring-provider = "subprocess"
+no-binary = true
+no-binary-package = [ "numpy", "pillow", "scipy" ]
+no-build = true
+no-build-package = [ "tensorflow", "torch" ]
+no-build-isolation = true
+no-build-isolation-package = [ "numpy", "scipy" ]
+no-sources = true
+no-sources-package = [ "pkg1", "pkg2" ]
+reinstall = true
+reinstall-package = [ "black", "mypy" ]
+upgrade = true
+upgrade-package = [ "flask", "requests" ]
+resolution = "highest"
+prerelease = "disallow"
+fork-strategy = "fewest"
+environments = [ "python_version >= '3.10'", "sys_platform == 'darwin'" ]
+required-environments = [ "python_version >= '3.8'", "sys_platform == 'linux'" ]
+exclude-newer = "2024-01-01"
+exclude-newer-package = {  }
+compile-bytecode = true
+link-mode = "clone"
+config-settings = {  }
+config-settings-package = {  }
+extra-build-dependencies = [  ]
+extra-build-variables = {  }
+concurrent-builds = 4
+concurrent-downloads = 4
+concurrent-installs = 4
+allow-insecure-host = [ "build.corp.com", "internal.corp.com" ]
+native-tls = true
+offline = true
+no-cache = true
+cache-dir = "~/.cache/uv"
+http-proxy = "http://proxy.example.com"
+https-proxy = "https://proxy.example.com"
+no-proxy = [ "*.internal.com", "localhost" ]
+publish-url = "https://example.com"
+check-url = "https://example.com"
+trusted-publishing = "always"
+python-install-mirror = "https://example.com"
+pypy-install-mirror = "https://example.com"
+python-downloads-json-url = "https://example.com"
+managed = true
+package = true
+workspace = {  }
+conflicts = [  ]
+cache-keys = [  ]
+build-backend = {  }
+pip = {  }
+pip.all-extras = true
+pip.allow-empty-requirements = true
+pip.allow-insecure-host = [ "internal.corp.com" ]
+pip.annotation-style = "line"
+pip.break-system-packages = true
+pip.cache-dir = "~/.cache/uv"
+pip.compile-bytecode = true
+pip.config-settings = {  }
+pip.custom-compile-command = "uv pip compile"
+pip.emit-build-options = true
+pip.emit-find-links = true
+pip.emit-index-annotation = true
+pip.emit-index-url = true
+pip.emit-marker-expression = true
+pip.exclude-newer = "2024-01-01"
+pip.exclude-newer-package = {  }
+pip.extra = [ "dev", "test" ]
+pip.extra-index-url = "https://example.com/simple"
+pip.find-links = [ "https://example.com/packages" ]
+pip.fork-strategy = "fewest"
+pip.generate-hashes = true
+pip.index-strategy = "first-index"
+pip.index-url = "https://pypi.org/simple"
+pip.keyring-provider = "subprocess"
+pip.link-mode = "clone"
+pip.native-tls = true
+pip.no-annotate = true
+pip.no-binary = true
+pip.no-binary-package = [ "scipy" ]
+pip.no-build = true
+pip.no-build-isolation = true
+pip.no-build-isolation-package = [ "scipy" ]
+pip.no-build-package = [ "torch" ]
+pip.no-cache = true
+pip.no-deps = true
+pip.no-emit-package = [ "pip", "setuptools" ]
+pip.no-header = true
+pip.no-index = true
+pip.no-strip-extras = true
+pip.no-strip-markers = true
+pip.offline = true
+pip.only-binary = true
+pip.only-binary-package = [ "numpy" ]
+pip.output-file = "requirements.txt"
+pip.prefix = "/usr/local"
+pip.prerelease = "disallow"
+pip.python = "3.10"
+pip.python-platform = "linux"
+pip.python-version = "3.10"
+pip.reinstall = true
+pip.reinstall-package = [ "mypy" ]
+pip.resolution = "highest"
+pip.strict = true
+pip.system = true
+pip.target = "/tmp/install"
+pip.universal = true
+pip.upgrade = true
+pip.upgrade-package = [ "requests" ]
+preview = true
+
+[tool.uv]
+torch-backend = "cu124"

--- a/pyproject-fmt/rust/src/tests/uv_tests.rs
+++ b/pyproject-fmt/rust/src/tests/uv_tests.rs
@@ -1,0 +1,236 @@
+use std::fs::read_to_string;
+use std::path::{Path, PathBuf};
+
+use insta::assert_snapshot;
+
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{collect_entries, format_syntax, parse};
+use crate::uv::fix;
+
+fn data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("rust")
+        .join("src")
+        .join("tests")
+        .join("data")
+}
+
+fn evaluate(start: &str) -> String {
+    evaluate_with_collapse(start, true)
+}
+
+fn evaluate_with_collapse(start: &str, collapse: bool) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| collapse, &["tool.uv"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    format_syntax(root_ast, 120)
+}
+
+#[test]
+fn test_order_uv() {
+    let data = data_dir();
+    let start = read_to_string(data.join("uv-order.toml")).unwrap();
+    let result = evaluate(&start);
+    assert_snapshot!(result);
+}
+
+#[test]
+fn test_uv_sources_sorting() {
+    let start = indoc::indoc! {r#"
+    [tool.uv.sources]
+    zebra = { git = "https://github.com/example/zebra" }
+    alpha = { path = "../alpha" }
+    mango = { workspace = true }
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.uv]
+    sources.alpha = { path = "../alpha" }
+    sources.mango = { workspace = true }
+    sources.zebra = { git = "https://github.com/example/zebra" }
+    "#);
+}
+
+#[test]
+fn test_uv_dependency_arrays() {
+    let start = indoc::indoc! {r#"
+    [tool.uv]
+    dev-dependencies = ["pytest", "black", "mypy"]
+    constraint-dependencies = ["requests<3", "flask>=2"]
+    override-dependencies = ["numpy==1.24", "pandas>=2"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.uv]
+    dev-dependencies = [ "black", "mypy", "pytest" ]
+    constraint-dependencies = [ "flask>=2", "requests<3" ]
+    override-dependencies = [ "numpy==1.24", "pandas>=2" ]
+    "#);
+}
+
+#[test]
+fn test_uv_package_arrays() {
+    let start = indoc::indoc! {r#"
+    [tool.uv]
+    no-binary-package = ["scipy", "numpy", "pillow"]
+    no-build-package = ["torch", "tensorflow"]
+    reinstall-package = ["mypy", "black"]
+    upgrade-package = ["requests", "flask"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.uv]
+    no-binary-package = [ "numpy", "pillow", "scipy" ]
+    no-build-package = [ "tensorflow", "torch" ]
+    reinstall-package = [ "black", "mypy" ]
+    upgrade-package = [ "flask", "requests" ]
+    "#);
+}
+
+#[test]
+fn test_uv_workspace_members() {
+    let start = indoc::indoc! {r#"
+    [tool.uv]
+    workspace.members = ["packages/zebra", "packages/alpha", "packages/beta"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.uv]
+    workspace.members = [ "packages/alpha", "packages/beta", "packages/zebra" ]
+    "#);
+}
+
+#[test]
+fn test_uv_workspace_exclude() {
+    let start = indoc::indoc! {r#"
+    [tool.uv]
+    workspace.exclude = ["examples/demo", "examples/alpha"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.uv]
+    workspace.exclude = [ "examples/alpha", "examples/demo" ]
+    "#);
+}
+
+#[test]
+fn test_uv_preserve_comments() {
+    let start = indoc::indoc! {r#"
+    [tool.uv]
+    dev-dependencies = [
+        # Testing tools
+        "pytest",
+        "coverage",
+    ]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.uv]
+    dev-dependencies = [
+      # Testing tools
+      "pytest",
+      "coverage",
+    ]
+    "#);
+}
+
+#[test]
+fn test_uv_no_uv_section() {
+    let start = indoc::indoc! {r#"
+    [tool.ruff]
+    line-length = 120
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.ruff]
+    line-length = 120
+    "#);
+}
+
+#[test]
+fn test_uv_pip_subsection() {
+    let start = indoc::indoc! {r#"
+    [tool.uv.pip]
+    no-binary-package = ["scipy", "numpy"]
+    extra = ["dev", "test", "docs"]
+    index-url = "https://pypi.org/simple"
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.uv]
+    pip.extra = [ "dev", "docs", "test" ]
+    pip.index-url = "https://pypi.org/simple"
+    pip.no-binary-package = [ "numpy", "scipy" ]
+    "#);
+}
+
+#[test]
+fn test_uv_environments() {
+    let start = indoc::indoc! {r#"
+    [tool.uv]
+    environments = ["sys_platform == 'darwin'", "sys_platform == 'linux'", "python_version >= '3.10'"]
+    required-environments = ["sys_platform == 'win32'", "python_version >= '3.8'"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.uv]
+    environments = [ "python_version >= '3.10'", "sys_platform == 'darwin'", "sys_platform == 'linux'" ]
+    required-environments = [ "python_version >= '3.8'", "sys_platform == 'win32'" ]
+    "#);
+}
+
+#[test]
+fn test_uv_network_arrays() {
+    let start = indoc::indoc! {r#"
+    [tool.uv]
+    allow-insecure-host = ["internal.corp.com", "dev.local", "build.corp.com"]
+    no-proxy = ["localhost", "*.internal.com", "127.0.0.1"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.uv]
+    allow-insecure-host = [ "build.corp.com", "dev.local", "internal.corp.com" ]
+    no-proxy = [ "*.internal.com", "127.0.0.1", "localhost" ]
+    "#);
+}
+
+#[test]
+fn test_uv_pip_table_no_collapse() {
+    let start = indoc::indoc! {r#"
+    [tool.uv.pip]
+    upgrade-package = ["requests", "flask"]
+    no-binary-package = ["scipy", "numpy"]
+    extra = ["dev", "test", "docs"]
+    index-url = "https://pypi.org/simple"
+    "#};
+    let result = evaluate_with_collapse(start, false);
+    assert_snapshot!(result, @r#"
+    index-url = "https://pypi.org/simple"no-binary-package = ["numpy","scipy" ]
+    extra = ["dev", "docs","test" ]
+    [tool.uv.pip]
+    upgrade-package = ["flask","requests" ]
+    "#);
+}
+
+#[test]
+fn test_uv_sources_table_no_collapse() {
+    let start = indoc::indoc! {r#"
+    [tool.uv.sources]
+    zebra = { git = "https://github.com/example/zebra" }
+    alpha = { path = "../alpha" }
+    mango = { workspace = true }
+    "#};
+    let result = evaluate_with_collapse(start, false);
+    assert_snapshot!(result, @r#"
+    alpha = { path = "../alpha" }
+    mango = { workspace = true }[tool.uv.sources]
+    zebra = { git = "https://github.com/example/zebra" }
+    "#);
+}

--- a/pyproject-fmt/rust/src/uv.rs
+++ b/pyproject-fmt/rust/src/uv.rs
@@ -1,0 +1,214 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+use tombi_syntax::SyntaxKind::KEY_VALUE;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    "required-version",
+    "python-preference",
+    "python-downloads",
+    "dev-dependencies",
+    "default-groups",
+    "dependency-groups",
+    "constraint-dependencies",
+    "override-dependencies",
+    "exclude-dependencies",
+    "dependency-metadata",
+    "sources",
+    "index",
+    "index-url",
+    "extra-index-url",
+    "find-links",
+    "no-index",
+    "index-strategy",
+    "keyring-provider",
+    "no-binary",
+    "no-binary-package",
+    "no-build",
+    "no-build-package",
+    "no-build-isolation",
+    "no-build-isolation-package",
+    "no-sources",
+    "no-sources-package",
+    "reinstall",
+    "reinstall-package",
+    "upgrade",
+    "upgrade-package",
+    "resolution",
+    "prerelease",
+    "fork-strategy",
+    "environments",
+    "required-environments",
+    "exclude-newer",
+    "exclude-newer-package",
+    "compile-bytecode",
+    "link-mode",
+    "config-settings",
+    "config-settings-package",
+    "extra-build-dependencies",
+    "extra-build-variables",
+    "concurrent-builds",
+    "concurrent-downloads",
+    "concurrent-installs",
+    "allow-insecure-host",
+    "native-tls",
+    "offline",
+    "no-cache",
+    "cache-dir",
+    "http-proxy",
+    "https-proxy",
+    "no-proxy",
+    "publish-url",
+    "check-url",
+    "trusted-publishing",
+    "python-install-mirror",
+    "pypy-install-mirror",
+    "python-downloads-json-url",
+    "managed",
+    "package",
+    "workspace",
+    "conflicts",
+    "cache-keys",
+    "build-backend",
+    "pip",
+    "preview",
+    "torch-backend",
+];
+
+const PIP_KEY_ORDER: &[&str] = &[
+    "",
+    "python",
+    "system",
+    "break-system-packages",
+    "target",
+    "prefix",
+    "index-url",
+    "extra-index-url",
+    "find-links",
+    "no-index",
+    "index-strategy",
+    "keyring-provider",
+    "no-binary",
+    "no-binary-package",
+    "only-binary",
+    "only-binary-package",
+    "no-build",
+    "no-build-package",
+    "no-build-isolation",
+    "no-build-isolation-package",
+    "resolution",
+    "prerelease",
+    "fork-strategy",
+    "exclude-newer",
+    "compile-bytecode",
+    "link-mode",
+    "config-settings",
+    "allow-insecure-host",
+    "native-tls",
+    "offline",
+    "no-cache",
+    "cache-dir",
+    "all-extras",
+    "extra",
+    "no-deps",
+    "allow-empty-requirements",
+    "reinstall",
+    "reinstall-package",
+    "upgrade",
+    "upgrade-package",
+    "python-platform",
+    "python-version",
+    "strict",
+    "exclude-newer-package",
+    "annotation-style",
+    "custom-compile-command",
+    "emit-build-options",
+    "emit-find-links",
+    "emit-index-annotation",
+    "emit-index-url",
+    "emit-marker-expression",
+    "generate-hashes",
+    "no-annotate",
+    "no-emit-package",
+    "no-header",
+    "no-strip-extras",
+    "no-strip-markers",
+    "output-file",
+    "universal",
+];
+
+fn has_key_value_entries(table: &[tombi_syntax::SyntaxElement]) -> bool {
+    table.iter().any(|e| e.kind() == KEY_VALUE)
+}
+
+#[allow(clippy::too_many_lines)]
+pub fn fix(tables: &mut Tables) {
+    if let Some(table_elements) = tables.get("tool.uv") {
+        let table = &mut table_elements.first().unwrap().borrow_mut();
+        for_entries(table, &mut |key, entry| match key.as_str() {
+            "allow-insecure-host"
+            | "build-constraint-dependencies"
+            | "constraint-dependencies"
+            | "dev-dependencies"
+            | "environments"
+            | "exclude-dependencies"
+            | "no-binary-package"
+            | "no-build-isolation-package"
+            | "no-build-package"
+            | "no-proxy"
+            | "no-sources-package"
+            | "override-dependencies"
+            | "reinstall-package"
+            | "required-environments"
+            | "upgrade-package"
+            | "workspace.exclude"
+            | "workspace.members"
+            | "pip.allow-insecure-host"
+            | "pip.extra"
+            | "pip.no-binary-package"
+            | "pip.no-build-isolation-package"
+            | "pip.no-build-package"
+            | "pip.no-emit-package"
+            | "pip.only-binary-package"
+            | "pip.reinstall-package"
+            | "pip.upgrade-package" => {
+                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            }
+            _ => {}
+        });
+        reorder_table_keys(table, KEY_ORDER);
+    }
+
+    if let Some(sources_tables) = tables.get("tool.uv.sources") {
+        for sources_ref in sources_tables {
+            let sources_table = &mut sources_ref.borrow_mut();
+            if has_key_value_entries(sources_table) {
+                reorder_table_keys(sources_table, &[""]);
+            }
+        }
+    }
+
+    if let Some(pip_elements) = tables.get("tool.uv.pip") {
+        let pip_table = &mut pip_elements.first().unwrap().borrow_mut();
+        if has_key_value_entries(pip_table) {
+            for_entries(pip_table, &mut |key, entry| match key.as_str() {
+                "allow-insecure-host"
+                | "extra"
+                | "no-binary-package"
+                | "no-build-isolation-package"
+                | "no-build-package"
+                | "no-emit-package"
+                | "only-binary-package"
+                | "reinstall-package"
+                | "upgrade-package" => {
+                    sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| {
+                        natural_lexical_cmp(lhs, rhs)
+                    });
+                }
+                _ => {}
+            });
+            reorder_table_keys(pip_table, PIP_KEY_ORDER);
+        }
+    }
+}


### PR DESCRIPTION
pyproject-fmt lacked support for formatting the `[tool.uv]` section, which is increasingly common as uv gains adoption. Users had to manually maintain consistent key ordering and array sorting in their uv configuration, leading to inconsistent pyproject.toml files across projects.

This adds comprehensive uv support following the pattern established by the ruff formatter. ✨ Keys are reordered into logical functional groups (dependencies, sources/indexes, package handling, resolution, network/security, etc.), package arrays and dependency lists are sorted alphabetically, and `tool.uv.sources` entries are sorted by package name (addressing #154). The `[tool.uv.pip]` subsection receives the same treatment.

The implementation mirrors the existing `ruff.rs` module structure, making it straightforward to maintain and extend as uv's configuration options evolve.

Fixes #154.