### PR TITLE
👷 ci(workflows): add gate jobs for branch protection

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -264,3 +264,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: gh workflow run main.yaml --repo tox-dev/pyproject-fmt
+
+  all-pass:
+    name: ✅ pyproject-fmt-build
+    if: always()
+    needs: [changes, bump, linux, windows, macos, sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether all jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs failed or were canceled"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped"

--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -185,3 +185,17 @@ jobs:
         run: tox run --skip-pkg-install -e ${{ matrix.env }}
         env:
           PYTEST_ADDOPTS: "-vv --durations=20"
+
+  all-pass:
+    name: ✅ pyproject-fmt
+    if: always()
+    needs: [changes, clippy, fmt, build, test, py, check]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether all jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs failed or were canceled"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped"

--- a/.github/workflows/toml_fmt_common_build.yaml
+++ b/.github/workflows/toml_fmt_common_build.yaml
@@ -48,3 +48,17 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           attestations: true
+
+  all-pass:
+    name: ✅ toml-fmt-common-build
+    if: always()
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether all jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs failed or were canceled"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped"

--- a/.github/workflows/toml_fmt_common_test.yaml
+++ b/.github/workflows/toml_fmt_common_test.yaml
@@ -70,3 +70,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: toml-fmt-common/.tox/${{ matrix.env }}
           flags: python-${{ matrix.env }}
+
+  all-pass:
+    name: ✅ toml-fmt-common
+    if: always()
+    needs: [changes, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether all jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs failed or were canceled"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped"

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -264,3 +264,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: gh workflow run main.yaml --repo tox-dev/tox-toml-fmt
+
+  all-pass:
+    name: ✅ tox-toml-fmt-build
+    if: always()
+    needs: [changes, bump, linux, windows, macos, sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether all jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs failed or were canceled"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped"

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -185,3 +185,17 @@ jobs:
         run: tox run --skip-pkg-install -e ${{ matrix.env }}
         env:
           PYTEST_ADDOPTS: "-vv --durations=20"
+
+  all-pass:
+    name: ✅ tox-toml-fmt
+    if: always()
+    needs: [changes, clippy, fmt, build, test, py, check]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether all jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs failed or were canceled"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped"


### PR DESCRIPTION
With path-based filtering in place, jobs that skip due to no relevant file changes cause branch protection to fail. 🚫 GitHub requires all listed status checks to run, but skipped jobs don't satisfy this requirement. This creates an awkward situation where every PR touching different parts of the monorepo needs different branch protection rules.

Gate jobs solve this elegantly by acting as a single checkpoint that aggregates all job results. Each gate job uses `if: always()` to run regardless of whether its dependencies were skipped, then checks if any dependency failed or was cancelled. ✅ When all jobs either succeeded or were correctly skipped, the gate passes. Branch protection can then require only these gate jobs instead of listing every individual check.

Added `all-pass` gate jobs to all workflows except `common.yaml` (which doesn't use path filtering). The test workflows get gates like `✅ pyproject-fmt` and `✅ tox-toml-fmt`, while build workflows get `✅ pyproject-fmt-build` etc. After merging, branch protection rules should be updated to require only these gate jobs.