### PR TITLE
👷 ci(deps): add rust job, fix workspace deps

### DIFF
--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -70,6 +70,18 @@ jobs:
       - name: 🦀 Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: ⬆️ Update git dependencies
+        run: |
+          TOMBI_TAG=$(gh api repos/tombi-toml/tombi/releases/latest --jq .tag_name)
+          sed -i "s/tombi-toml\/tombi\", tag = \"v[^\"]*\"/tombi-toml\/tombi\", tag = \"$TOMBI_TAG\"/" Cargo.toml
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: ⬆️ Update Cargo.toml dependencies
+        run: |
+          cargo install cargo-edit
+          cargo upgrade --incompatible
+
       - name: ⬆️ Update Cargo.lock
         run: cargo update
 


### PR DESCRIPTION
Dependabot's cargo ecosystem was hanging for 20+ minutes on this workspace,
likely due to the large dependency tree. Moving to a custom workflow job
gives us more control and runs faster.

Also fixes an issue where bump-deps-index would incorrectly pin the workspace
member toml-fmt-common based on PyPI versions. Workspace members should remain
unpinned since they're resolved locally via uv.sources.
