### PR TITLE
🐛 fix(array): sort by value not comment for entries with leading comments

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -104,7 +104,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 pypy3.10" }
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 pypy3.11" }
           - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2 }
           - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true }
           - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
@@ -176,7 +176,7 @@ jobs:
         uses: PyO3/maturin-action@v1.50.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 pypy3.10" --target-dir target
+          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 pypy3.11" --target-dir target
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@v6

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -104,7 +104,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 pypy3.10" }
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 pypy3.11" }
           - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2 }
           - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true }
           - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
@@ -176,7 +176,7 @@ jobs:
         uses: PyO3/maturin-action@v1.50.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 pypy3.10" --target-dir target
+          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 pypy3.11" --target-dir target
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@v6

--- a/common/src/array.rs
+++ b/common/src/array.rs
@@ -285,7 +285,7 @@ where
         |e| -> Option<String> {
             let kind = e.kind();
             if kind == BASIC_STRING || kind == LITERAL_STRING {
-                let token = e.first_token().expect("string has token");
+                let token = e.last_token().expect("string has token");
                 Some(to_key(load_text(token.text(), kind)))
             } else {
                 None

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -195,6 +195,29 @@ fn test_order_array_with_leading_comments() {
 }
 
 #[test]
+fn test_order_array_with_some_leading_comments() {
+    let start = indoc! {r#"
+    a = [
+      "aaa",
+      "bbb",
+      # A comment about ddd.
+      "ddd",
+      "ccc",
+    ]
+    "#};
+    let res = sort_array_helper(start);
+    insta::assert_snapshot!(res, @r#"
+    a = [
+      "aaa",
+      "bbb",
+      "ccc",
+      # A comment about ddd.
+      "ddd",
+    ]
+    "#);
+}
+
+#[test]
 fn test_order_array_with_mixed_comments() {
     let start = indoc! {r#"
     a = [

--- a/pyproject-fmt/rust/src/tests/uv_tests.rs
+++ b/pyproject-fmt/rust/src/tests/uv_tests.rs
@@ -134,9 +134,9 @@ fn test_uv_preserve_comments() {
     assert_snapshot!(result, @r#"
     [tool.uv]
     dev-dependencies = [
+      "coverage",
       # Testing tools
       "pytest",
-      "coverage",
     ]
     "#);
 }


### PR DESCRIPTION
Since v2.13.0, array entries with preceding comments were incorrectly sorted by the comment text instead of the actual string value. 🔍 For example, an entry like `# comment\n"ddd"` would sort to the top of the array because `#` has a lower ASCII value than the quote character.

The root cause is that tombi's `BASIC_STRING` nodes include leading comments as child tokens. The `sort_strings` function was calling `first_token()` to get the sort key, which returned the COMMENT token rather than the actual string. Changing to `last_token()` correctly retrieves the string value while preserving the comment attachment behavior.

Fixes #185.