### PR TITLE
🐛 fix(parser): handle comments with double quotes in arrays

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,12 +146,16 @@ tox run -e 3.13
 Sometimes you need to run commands across all packages at once. This is especially useful for CI-like validation before
 committing or when you've modified common code that affects multiple packages.
 
+**Important:** The CI runs tests with `--no-default-features` to disable the PyO3 `extension-module` feature, which
+allows tests to link against Python. Always use this flag when running workspace-wide tests locally to match CI
+behavior.
+
 ```bash
 # Run all tests in workspace (common, pyproject-fmt, tox-toml-fmt)
-cargo test --workspace
+cargo test --workspace --no-default-features
 
 # Check workspace-wide coverage
-cargo llvm-cov --workspace --summary-only
+cargo llvm-cov --workspace --no-default-features --summary-only
 
 # Format all Rust code
 cargo fmt --all

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -7,7 +7,7 @@ use crate::array::{
     transform,
 };
 use crate::pep508::Requirement;
-use crate::tests::format_toml;
+use crate::tests::{format_toml, format_toml_str};
 
 fn apply_to_arrays<F>(source: &str, mut f: F) -> String
 where
@@ -967,4 +967,42 @@ fn test_dedupe_array_with_non_string_values() {
     }
     let res = root_ast.to_string();
     insta::assert_snapshot!(res, @r#"a = [1, "foo", 2, 3]"#);
+}
+
+#[test]
+fn test_issue_184_comment_with_double_quotes() {
+    let start = indoc! {r#"
+    [tool.something]
+    items = [
+        # A "quoted" word.
+        "value",
+    ]
+    "#};
+    let res = format_toml_str(start, 120);
+    insta::assert_snapshot!(res, @r#"
+    [tool.something]
+    items = [
+      # A "quoted" word.
+      "value",
+    ]
+    "#);
+}
+
+#[test]
+fn test_issue_184_comment_with_double_quotes_sort() {
+    let start = indoc! {r#"
+    items = [
+        # A "quoted" word.
+        "zebra",
+        "alpha",
+    ]
+    "#};
+    let res = sort_array_helper(start);
+    insta::assert_snapshot!(res, @r#"
+    items = [
+      "alpha",
+      # A "quoted" word.
+      "zebra",
+    ]
+    "#);
 }


### PR DESCRIPTION
Comments containing double quotes inside TOML arrays were being incorrectly converted into string values, with the actual array values being dropped. 🔍 This regression appeared in version 2.13.0 after migrating from taplo to tombi.

The tombi parser creates syntax trees where comments preceding a string value get nested as children of the `BASIC_STRING` node. When code used `first_token()` to extract string content, it retrieved the comment token instead of the actual string token, causing the comment text to be treated as the value.

The fix changes all locations that extract string text from syntax nodes to explicitly find the token with matching kind using `descendants_with_tokens()` rather than relying on `first_token()`. This ensures we get the actual string token even when the node contains preceding comments. ✨ Also documented the `--no-default-features` flag requirement for running workspace-wide tests locally.

Fixes #184