### PR TITLE
🧪 test: add idempotency tests for string wrapping

### DIFF
--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -308,6 +308,29 @@ fn test_line_continuation_with_crlf() {
 }
 
 #[test]
+fn test_wrap_long_string_is_idempotent() {
+    use crate::string::wrap_all_long_strings;
+
+    let original_text = "This is a long description string that needs to exceed the default column width of one hundred and twenty characters to trigger wrapping.";
+    let toml = format!("[project]\ndescription = \"{}\"", original_text);
+
+    let root_ast = parse(&toml);
+    wrap_all_long_strings(&root_ast, 120, "  ");
+    let after_first = root_ast.to_string();
+
+    let root_ast2 = parse(&after_first);
+    wrap_all_long_strings(&root_ast2, 120, "  ");
+    let after_second = root_ast2.to_string();
+
+    let root_ast3 = parse(&after_second);
+    wrap_all_long_strings(&root_ast3, 120, "  ");
+    let after_third = root_ast3.to_string();
+
+    assert_eq!(after_first, after_second, "wrap_all_long_strings should be idempotent (first->second)");
+    assert_eq!(after_second, after_third, "wrap_all_long_strings should be idempotent (second->third)");
+}
+
+#[test]
 fn test_multiline_with_regular_escapes() {
     let toml = "desc = \"\"\"hello\\nworld\"\"\"";
     let root_ast = parse(toml);

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -912,3 +912,28 @@ fn test_lib_module_registration() {
         assert!(module.hasattr("Settings").unwrap());
     });
 }
+
+#[test]
+fn test_idempotent_formatting() {
+    let start = indoc! {r#"
+        [project]
+        name = "test"
+        description = "This is a long description string that needs to exceed the default column width of one hundred and twenty characters to trigger wrapping."
+    "#};
+    let settings = Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+    };
+    let first = format_toml(start, &settings);
+    let second = format_toml(&first, &settings);
+    let third = format_toml(&second, &settings);
+    assert_eq!(first, second, "formatting should be idempotent (first->second)");
+    assert_eq!(second, third, "formatting should be idempotent (second->third)");
+}


### PR DESCRIPTION
Adds tests that verify multiline string wrapping is idempotent - running the formatter multiple times on the same content produces identical output.

This addresses issue #187, which was fixed by PR #189. These tests ensure the fix works correctly and prevent regression.