### PR TITLE
🐛 fix(array): preserve comments with strings

### DIFF
--- a/common/src/string.rs
+++ b/common/src/string.rs
@@ -102,6 +102,13 @@ pub fn strip_quotes(s: &str) -> String {
         .to_string()
 }
 
+pub fn get_string_token(node: &SyntaxNode) -> Option<tombi_syntax::SyntaxToken> {
+    let kind = node.kind();
+    node.descendants_with_tokens()
+        .filter_map(|elem| elem.into_token())
+        .find(|token| token.kind() == kind)
+}
+
 pub fn load_text(value: &str, kind: SyntaxKind) -> String {
     let offset = if [BASIC_STRING, LITERAL_STRING].contains(&kind) {
         1
@@ -260,7 +267,15 @@ fn wrap_string_node_if_needed(string_node: &SyntaxNode, column_width: usize, ind
         } else {
             make_string_node(&text)
         };
+        let mut new_children: Vec<SyntaxElement> = Vec::new();
         let count = string_node.children_with_tokens().count();
-        string_node.splice_children(0..count, vec![new_element]);
+        for child in string_node.children_with_tokens() {
+            if is_string_kind(child.kind()) {
+                new_children.push(new_element.clone());
+            } else {
+                new_children.push(child);
+            }
+        }
+        string_node.splice_children(0..count, new_children);
     }
 }

--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -267,6 +267,9 @@ pub fn reorder_table_keys(table: &mut RefMut<Vec<SyntaxElement>>, order: &[&str]
         matching_keys.sort_by_key(|key| key.to_lowercase().replace('"', ""));
         for key in matching_keys {
             let position = key_to_position[key];
+            if !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
+                to_insert.push(make_newline());
+            }
             to_insert.extend(key_set[position].clone());
             handled_positions.insert(position);
         }
@@ -278,6 +281,9 @@ pub fn reorder_table_keys(table: &mut RefMut<Vec<SyntaxElement>>, order: &[&str]
         .collect();
     unhandled.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
     for (_, position) in unhandled {
+        if !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
+            to_insert.push(make_newline());
+        }
         to_insert.extend(key_set[position].clone());
     }
     table.splice(0..size, to_insert);

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -815,6 +815,27 @@ fn test_transform_with_literal_string() {
 }
 
 #[test]
+fn test_transform_literal_string_with_comment() {
+    let start = indoc! {r"
+    a = [
+        'first',
+        # A comment
+        'second',
+    ]
+    "};
+    let res = apply_to_arrays(start, |array| {
+        transform(array, &|s| s.to_uppercase());
+    });
+    insta::assert_snapshot!(res, @r#"
+    a = [
+      "FIRST",
+      # A comment
+      "SECOND",
+    ]
+    "#);
+}
+
+#[test]
 fn test_align_empty_array() {
     let start = r#"a = []"#;
     let root_ast = tombi_parser::parse(start, TomlVersion::default())

--- a/pyproject-fmt/rust/src/tests/build_systems_tests.rs
+++ b/pyproject-fmt/rust/src/tests/build_systems_tests.rs
@@ -65,7 +65,8 @@ fn test_format_build_systems_join() {
     let res = format_build_systems_helper(start, false);
     insta::assert_snapshot!(res, @r#"
     [build-system]
-    build-backend = "hatchling.build"[build-system]
+    build-backend = "hatchling.build"
+    [build-system]
     requires=["a"]
     [[build-system.a]]
     name = "Hammer"[[build-system.a]]  # empty table within the array

--- a/pyproject-fmt/rust/src/tests/dependency_groups_tests.rs
+++ b/pyproject-fmt/rust/src/tests/dependency_groups_tests.rs
@@ -73,10 +73,12 @@ fn test_format_dependency_groups_multiple_groups() {
     "#};
     let res = format_dependency_groups_helper(start, false);
     insta::assert_snapshot!(res, @r#"
-    dev=["d>=2"]test=["a>1"]
-    docs=["b==1"]
+    dev = [ "d>=2" ]
+    test = [ "a>1" ]
+    docs = [ "b==1" ]
+
     [dependency-groups]
-    example=["c<1"]
+    example = [ "c<1" ]
     "#);
 }
 
@@ -108,8 +110,10 @@ fn test_format_dependency_groups_include_single_group() {
     "#};
     let res = format_dependency_groups_helper(start, false);
     insta::assert_snapshot!(res, @r#"
-    test=["a>1",{include-group="docs"}][dependency-groups]
-    docs=["b==1"]
+    test = [ "a>1", { include-group = "docs" } ]
+
+    [dependency-groups]
+    docs = [ "b==1" ]
     "#);
 }
 
@@ -123,9 +127,11 @@ fn test_format_dependency_groups_include_many_groups() {
     "#};
     let res = format_dependency_groups_helper(start, false);
     insta::assert_snapshot!(res, @r#"
-    test = ["a>1"]docs = ["b==1"]
+    test = [ "a>1" ]
+    docs = [ "b==1" ]
+
     [dependency-groups]
-    all=[{include-group='docs'}, "c<1", {include-group='test'}, "d>1"]
+    all = [ { include-group = "docs" }, "c<1", { include-group = "test" }, "d>1" ]
     "#);
 }
 
@@ -200,9 +206,9 @@ fn test_format_dependency_groups_array_with_comments() {
     insta::assert_snapshot!(res, @r#"
     [dependency-groups]
     test = [
-      "pytest>=7",
       # This is a comment
       "black>=23",
+      "pytest>=7",
       { include-group = "docs" },
       # Another comment
     ]
@@ -283,9 +289,11 @@ fn test_dependency_groups_ordering_dev_test_docs() {
         "#};
     let result = format_dependency_groups_helper(start, false);
     insta::assert_snapshot!(result, @r#"
-    dev = ["ruff>=0.4"]
-    test = ["pytest>=7"][dependency-groups]
-    docs = ["sphinx>=5"]
+    dev = [ "ruff>=0.4" ]
+    test = [ "pytest>=7" ]
+
+    [dependency-groups]
+    docs = [ "sphinx>=5" ]
     "#);
 }
 
@@ -299,9 +307,11 @@ fn test_dependency_groups_unknown_group_name() {
         "#};
     let result = format_dependency_groups_helper(start, false);
     insta::assert_snapshot!(result, @r#"
-    alpha = ["third>=3"][dependency-groups]
-    custom = ["pkg>=1"]
-    zebra = ["other>=2"]
+    alpha = [ "third>=3" ]
+
+    [dependency-groups]
+    custom = [ "pkg>=1" ]
+    zebra = [ "other>=2" ]
     "#);
 }
 
@@ -350,7 +360,9 @@ fn test_dependency_groups_empty_group() {
         "#};
     let result = format_dependency_groups_helper(start, false);
     insta::assert_snapshot!(result, @r#"
-    test = ["pkg>=1"][dependency-groups]
+    test = [ "pkg>=1" ]
+
+    [dependency-groups]
     empty = []
     "#);
 }
@@ -391,10 +403,11 @@ fn test_dependency_groups_with_nested_inline_table() {
     [dependency-groups]
     test = [
       "pkg>=1",
-      {include-group = "base"},
-      {include-group = "docs"},
+      { include-group = "base" },
+      { include-group = "docs" },
     ]
-    docs = ["sphinx"]base = ["base-pkg"]
+    docs = [ "sphinx" ]
+    base = [ "base-pkg" ]
     "#);
 }
 

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -43,27 +43,29 @@ fn test_format_toml_simple() {
     let res = format_toml_helper(start, 2, false, (3, 13), true);
     assert_snapshot!(res, @r#"
     # comment
-    a= "b"
+    a = "b"
 
     [build-system]
-    build-backend="backend"
-    requires=["c>=1.5", "d==2"]
+    build-backend = "backend"
+    requires = [ "c>=1.5", "d==2" ]
 
     [project]
-    name="alpha"
+    name = "alpha"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
       "Programming Language :: Python :: 3.12",
       "Programming Language :: Python :: 3.13",
-    ]dependencies=["e>=1.5"]
+    ]
+    dependencies = [ "e>=1.5" ]
 
     [dependency-groups]
-    test=["p>1"]
+    test = [ "p>1" ]
 
     [tool.mypy]
-    mk="mv"
+    mk = "mv"
     "#);
 }
 
@@ -936,4 +938,36 @@ fn test_idempotent_formatting() {
     let third = format_toml(&second, &settings);
     assert_eq!(first, second, "formatting should be idempotent (first->second)");
     assert_eq!(second, third, "formatting should be idempotent (second->third)");
+}
+
+#[test]
+fn test_issue_186_single_quote_with_comments() {
+    let start = indoc! {r#"
+    [tool.something]
+    items = [
+        'first',
+        # A comment
+        'second',
+    ]
+    "#};
+    let settings = Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+    };
+    let got = format_toml(start, &settings);
+    assert_snapshot!(got, @r#"
+    [tool.something]
+    items = [
+      "first",
+      # A comment
+      "second",
+    ]
+    "#);
 }

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -62,8 +62,11 @@ fn test_project_dependencies_normalize_no_keep() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",][project]
-    dependencies=["a>=1", "b-c>=1.5"]
+      "Programming Language :: Python :: 3.9",
+    ]
+
+    [project]
+    dependencies = [ "a>=1", "b-c>=1.5" ]
     "#);
 }
 
@@ -77,8 +80,11 @@ fn test_project_dependencies_normalize_keep_version() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",][project]
-    dependencies=["a>=1.0.0", "b-c>=1.5.0"]
+      "Programming Language :: Python :: 3.9",
+    ]
+
+    [project]
+    dependencies = [ "a>=1.0.0", "b-c>=1.5.0" ]
     "#);
 }
 
@@ -92,17 +98,16 @@ fn test_project_optional_dependencies() {
     let result = evaluate_project(start, false, (3, 13), true);
     insta::assert_snapshot!(result, @r#"
     [project]
-
-
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
       "Programming Language :: Python :: 3.12",
       "Programming Language :: Python :: 3.13",
-    ]optional-dependencies.dev = ["pytest>=7"]
-
-    optional-dependencies.docs = ["sphinx>=4"]
+    ]
+    optional-dependencies.dev = [ "pytest>=7" ]
+    optional-dependencies.docs = [ "sphinx>=4" ]
     "#);
 }
 
@@ -315,13 +320,13 @@ fn test_project_gui_scripts() {
     let result = evaluate_project(start, false, (3, 11), true);
     insta::assert_snapshot!(result, @r#"
     [project]
-
-
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ]gui-scripts.mygui = "mypackage.gui:main"
+    ]
+    gui-scripts.mygui = "mypackage.gui:main"
     "#);
 }
 
@@ -335,10 +340,13 @@ fn test_project_dynamic_fields() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
-    dynamic = ["description","version" ]
+    ]
+
+    [project]
+    dynamic = [ "description", "version" ]
     "#);
 }
 
@@ -361,10 +369,12 @@ fn test_project_full_metadata() {
     requires-python = ">=3.9"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
       "Programming Language :: Python :: 3.12",
-    ]dependencies = ["requests>=2.28"]
+    ]
+    dependencies = [ "requests>=2.28" ]
     "#);
 }
 
@@ -402,17 +412,15 @@ fn test_project_optional_dependencies_multiple_groups() {
     let result = evaluate_project(start, false, (3, 11), true);
     insta::assert_snapshot!(result, @r#"
     [project]
-
-
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ]optional-dependencies.dev = ["black>=22","pytest>=7" ]
-
-    optional-dependencies.docs = ["myst-parser>=0.18","sphinx>=4" ]
-
-    optional-dependencies.test = ["coverage>=6"]
+    ]
+    optional-dependencies.dev = [ "black>=22", "pytest>=7" ]
+    optional-dependencies.docs = [ "myst-parser>=0.18", "sphinx>=4" ]
+    optional-dependencies.test = [ "coverage>=6" ]
     "#);
 }
 
@@ -546,10 +554,13 @@ fn test_project_dependencies_with_extras() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
-    dependencies = ["click[colorama]>=8","requests[security]>=2.28" ]
+    ]
+
+    [project]
+    dependencies = [ "click[colorama]>=8", "requests[security]>=2.28" ]
     "#);
 }
 
@@ -566,13 +577,13 @@ fn test_project_dependencies_with_markers() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
-    dependencies = [
-        "importlib-metadata>=4; python_version<'3.10'",
-        "typing-extensions>=4; python_version<'3.11'"
     ]
+
+    [project]
+    dependencies = [ "importlib-metadata>=4; python_version<'3.10'", "typing-extensions>=4; python_version<'3.11'" ]
     "#);
 }
 
@@ -639,9 +650,12 @@ fn test_project_empty_dependencies() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
+    ]
+
+    [project]
     dependencies = []
     "#);
 }
@@ -655,13 +669,13 @@ fn test_project_empty_optional_dependencies() {
     let result = evaluate_project(start, false, (3, 11), true);
     insta::assert_snapshot!(result, @r#"
     [project]
-
-
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ]optional-dependencies.dev = []
+    ]
+    optional-dependencies.dev = []
     "#);
 }
 
@@ -675,10 +689,13 @@ fn test_project_normalize_package_name_underscores() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
-    dependencies = ["another-package>=2","my-package>=1" ]
+    ]
+
+    [project]
+    dependencies = [ "another-package>=2", "my-package>=1" ]
     "#);
 }
 
@@ -692,10 +709,13 @@ fn test_project_dependencies_git_urls() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
-    dependencies = ["pkg @ git+https://github.com/user/repo.git@main"]
+    ]
+
+    [project]
+    dependencies = [ "pkg @ git+https://github.com/user/repo.git@main" ]
     "#);
 }
 
@@ -709,10 +729,13 @@ fn test_project_dependencies_local_paths() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
-    dependencies = ["pkg @ file:///path/to/package"]
+    ]
+
+    [project]
+    dependencies = [ "pkg @ file:///path/to/package" ]
     "#);
 }
 
@@ -810,23 +833,23 @@ fn test_project_all_fields() {
     version = "1.0.0"
     description = "A comprehensive test"
     readme = "README.md"
-    keywords = ["example","test" ]
+    keywords = [ "example", "test" ]
     license = { text = "MIT" }
-    maintainers = [{ name = "Maintainer" }]
-    authors = [{ name = "Dev", email = "dev@example.com" }]
+    maintainers = [ { name = "Maintainer" } ]
+    authors = [ { name = "Dev", email = "dev@example.com" } ]
     requires-python = ">=3.9"
     classifiers = [
-    "Development Status :: 4 - Beta",
+      "Development Status :: 4 - Beta",
       "Programming Language :: Python :: 3 :: Only",
       "Programming Language :: Python :: 3.9",
       "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
       "Programming Language :: Python :: 3.12",
     ]
-    dependencies = ["requests>=2.28"]
-    optional-dependencies.dev = ["pytest>=7"]
-
-    urls.Homepage = "https://example.com"scripts.mytool = "mypackage:main"
+    dependencies = [ "requests>=2.28" ]
+    optional-dependencies.dev = [ "pytest>=7" ]
+    urls.Homepage = "https://example.com"
+    scripts.mytool = "mypackage:main"
     "#);
 }
 
@@ -907,11 +930,14 @@ fn test_project_dependencies_url_format() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
+    ]
+
+    [project]
     dependencies = [
-        "pkg @ https://example.com/pkg-1.0.tar.gz",
+      "pkg @ https://example.com/pkg-1.0.tar.gz",
     ]
     "#);
 }
@@ -926,12 +952,13 @@ fn test_project_entry_points_inline_tables() {
     let result = evaluate_project(start, false, (3, 11), true);
     insta::assert_snapshot!(result, @r#"
     [project]
-
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ]entry-points = [{ name = "console_scripts", value = { mytool = "mypackage:main", another = "mypackage:other" } }]
+    ]
+    entry-points = [ { name = "console_scripts", value = { mytool = "mypackage:main", another = "mypackage:other" } } ]
     "#);
 }
 
@@ -945,9 +972,12 @@ fn test_project_scripts_inline_table() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
+    ]
+
+    [project]
     scripts = { mytool = "mypackage:main", helper = "mypackage.cli:run" }
     "#);
 }
@@ -962,9 +992,12 @@ fn test_project_gui_scripts_inline_table() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
+    ]
+
+    [project]
     gui-scripts = { mygui = "mypackage.gui:main" }
     "#);
 }
@@ -1184,13 +1217,16 @@ fn test_project_dependencies_complex_markers() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
       "Programming Language :: Python :: 3.12",
-    ][project]
+    ]
+
+    [project]
     dependencies = [
-        "other>=2; (python_version>='3.10' or sys_platform!='win32')",
-        "pkg>=1; python_version<'3.10' and platform_system=='Linux'",
+      "other>=2; (python_version>='3.10' or sys_platform!='win32')",
+      "pkg>=1; python_version<'3.10' and platform_system=='Linux'",
     ]
     "#);
 }
@@ -1205,10 +1241,13 @@ fn test_project_dependencies_multiple_extras() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
-    dependencies = ["pkg[extra1,extra2,extra3]>=1"]
+    ]
+
+    [project]
+    dependencies = [ "pkg[extra1,extra2,extra3]>=1" ]
     "#);
 }
 
@@ -1283,9 +1322,11 @@ fn test_project_dynamic_version_only() {
     name = "test"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ]dynamic = ["version"]
+    ]
+    dynamic = [ "version" ]
     "#);
 }
 
@@ -1299,10 +1340,13 @@ fn test_project_dependencies_duplicate_handling() {
     insta::assert_snapshot!(result, @r#"
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.9",  "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
       "Programming Language :: Python :: 3.11",
-    ][project]
-    dependencies = ["requests>=2.28", "requests>=2.30"]
+    ]
+
+    [project]
+    dependencies = [ "requests>=2.28", "requests>=2.30" ]
     "#);
 }
 
@@ -1599,7 +1643,8 @@ fn test_project_entry_points_inline_table_expansion() {
     insta::assert_snapshot!(result, @r#"
     [project]
     name = "test"
-    entry-points.console_scripts.bar = "pkg:bar"entry-points.console_scripts.foo = "pkg:main"
+    entry-points.console_scripts.bar = "pkg:bar"
+    entry-points.console_scripts.foo = "pkg:main"
     "#);
 }
 

--- a/pyproject-fmt/rust/src/tests/uv_tests.rs
+++ b/pyproject-fmt/rust/src/tests/uv_tests.rs
@@ -212,10 +212,12 @@ fn test_uv_pip_table_no_collapse() {
     "#};
     let result = evaluate_with_collapse(start, false);
     assert_snapshot!(result, @r#"
-    index-url = "https://pypi.org/simple"no-binary-package = ["numpy","scipy" ]
-    extra = ["dev", "docs","test" ]
+    index-url = "https://pypi.org/simple"
+    no-binary-package = [ "numpy", "scipy" ]
+    extra = [ "dev", "docs", "test" ]
+
     [tool.uv.pip]
-    upgrade-package = ["flask","requests" ]
+    upgrade-package = [ "flask", "requests" ]
     "#);
 }
 
@@ -230,7 +232,9 @@ fn test_uv_sources_table_no_collapse() {
     let result = evaluate_with_collapse(start, false);
     assert_snapshot!(result, @r#"
     alpha = { path = "../alpha" }
-    mango = { workspace = true }[tool.uv.sources]
+    mango = { workspace = true }
+
+    [tool.uv.sources]
     zebra = { git = "https://github.com/example/zebra" }
     "#);
 }


### PR DESCRIPTION
Since version 2.13.0, comments in arrays containing quoted strings were being converted into malformed string values. 🔧 This corrupted user configuration files and required manual fixes to restore the original content.

The tombi parser groups leading trivia (comments, whitespace) with the following string node. When `wrap_string_node_if_needed` called `splice_children`, it replaced all children including comments with just the new string element, effectively deleting the comments. Additionally, `reorder_table_keys` wasn't ensuring newlines between reordered entries, causing output like `]optional-dependencies.dev = ...` where the closing bracket ran into the next key.

The fix introduces `get_string_token()` to correctly locate string tokens within nodes that have leading trivia, and modifies `splice_children` to preserve non-string children. 🔄 The `reorder_table_keys` function now ensures proper newline separation between entries.

Fixes #186