### PR TITLE
👷 ci(release): fix tag placement, workflow cancellation, and maturin deprecation

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -15,7 +15,7 @@ on:
     - cron: "0 8 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.event.inputs.release && github.event.inputs.release != 'no' && '-release' || '' }}
   cancel-in-progress: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null }}
 
 permissions:
@@ -231,9 +231,7 @@ jobs:
         run: |
           git config --global user.name 'Bernat Gabor'
           git config --global user.email 'gaborbernat@users.noreply.github.com'
-          git commit -am "Release pyproject-fmt ${{needs.bump.outputs.version}}"
-      - name: 🏷️ Tag release
-        run: git tag pyproject-fmt/${{needs.bump.outputs.version}}
+          git commit -am "Release pyproject-fmt ${{needs.bump.outputs.version}} [skip ci]"
       - name: 📥 Download wheels
         uses: actions/download-artifact@v7
         with:
@@ -243,15 +241,15 @@ jobs:
       - name: 👀 Show wheels
         run: ls -lth dist
       - name: 🚀 Publish to PyPI
-        uses: PyO3/maturin-action@v1.50.0
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
-          command: upload
-          args: --non-interactive --skip-existing dist/*
+          skip-existing: true
       - name: 📢 Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           git pull --rebase origin main
+          git tag pyproject-fmt/${{needs.bump.outputs.version}}
           git push
           git push --tags
           gh release create "pyproject-fmt/${{needs.bump.outputs.version}}" \

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -15,7 +15,7 @@ on:
     - cron: "0 8 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.event.inputs.release && github.event.inputs.release != 'no' && '-release' || '' }}
   cancel-in-progress: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null }}
 
 permissions:
@@ -231,9 +231,7 @@ jobs:
         run: |
           git config --global user.name 'Bernat Gabor'
           git config --global user.email 'gaborbernat@users.noreply.github.com'
-          git commit -am "Release tox-toml-fmt ${{needs.bump.outputs.version}}"
-      - name: 🏷️ Tag release
-        run: git tag tox-toml-fmt/${{needs.bump.outputs.version}}
+          git commit -am "Release tox-toml-fmt ${{needs.bump.outputs.version}} [skip ci]"
       - name: 📥 Download wheels
         uses: actions/download-artifact@v7
         with:
@@ -243,15 +241,15 @@ jobs:
       - name: 👀 Show wheels
         run: ls -lth dist
       - name: 🚀 Publish to PyPI
-        uses: PyO3/maturin-action@v1.50.0
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
-          command: upload
-          args: --non-interactive --skip-existing dist/*
+          skip-existing: true
       - name: 📢 Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           git pull --rebase origin main
+          git tag tox-toml-fmt/${{needs.bump.outputs.version}}
           git push
           git push --tags
           gh release create "tox-toml-fmt/${{needs.bump.outputs.version}}" \


### PR DESCRIPTION
Release workflows had three interconnected issues causing changelog duplication and cancelled releases. 🐛 The changelog for version 2.14.1 incorrectly included all commits from 2.14.0 because git tags were pointing to orphaned commits not reachable from main's linear history. Additionally, manual release runs were being cancelled mid-flight by push-triggered workflow runs.

The root cause was the order of operations in the release job: tags were created before `git pull --rebase`, so when rebase rewrote the commit with a new hash, the tag still pointed to the old (now orphaned) commit. When `changelog.py` iterated through commits looking for tagged hexshas to stop at, it never found them. The cancellation happened because pushing the release commit triggered a new workflow run with `cancel-in-progress: true` (since `inputs.release == null` for push events), which terminated the still-running release.

🔧 This fix moves tag creation after the rebase so tags point to the correct commit in main's history. Adding `[skip ci]` to release commit messages prevents the push from triggering a competing workflow. The deprecated `maturin upload` command is replaced with `pypa/gh-action-pypi-publish` for trusted publishing, eliminating the deprecation warning.