### PR TITLE
✨ feat(pyproject-fmt): add tool.coverage formatting

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -425,6 +425,77 @@ The ``sources`` table entries are sorted alphabetically by package name:
 The ``[tool.uv.pip]`` subsection follows similar formatting rules, with arrays like ``extra``, ``no-binary-package``,
 ``no-build-package``, ``reinstall-package``, and ``upgrade-package`` sorted alphabetically.
 
+``[tool.coverage]``
+~~~~~~~~~~~~~~~~~~~
+
+**Key ordering:**
+
+Keys are reordered to follow coverage.py's workflow phases:
+
+1. **Run phase** (``run.*``): Data collection settings
+
+   - Source selection: ``source`` → ``source_pkgs`` → ``source_dirs``
+   - File filtering: ``include`` → ``omit``
+   - Measurement: ``branch`` → ``cover_pylib`` → ``timid``
+   - Execution context: ``command_line`` → ``concurrency`` → ``context`` → ``dynamic_context``
+   - Data management: ``data_file`` → ``parallel`` → ``relative_files``
+   - Extensions: ``plugins``
+   - Debugging: ``debug`` → ``debug_file`` → ``disable_warnings``
+   - Other: ``core`` → ``patch`` → ``sigterm``
+
+2. **Paths** (``paths.*``): Path mapping between source locations
+
+3. **Report phase** (``report.*``): General reporting
+
+   - Thresholds: ``fail_under`` → ``precision``
+   - File filtering: ``include`` → ``omit`` → ``include_namespace_packages``
+   - Line exclusion: ``exclude_lines`` → ``exclude_also``
+   - Partial branches: ``partial_branches`` → ``partial_also``
+   - Output control: ``skip_covered`` → ``skip_empty`` → ``show_missing``
+   - Formatting: ``format`` → ``sort``
+   - Error handling: ``ignore_errors``
+
+4. **Output formats** (after report):
+
+   - ``html.*``: ``directory`` → ``title`` → ``extra_css`` → ``show_contexts`` → ``skip_covered`` → ``skip_empty``
+   - ``json.*``: ``output`` → ``pretty_print`` → ``show_contexts``
+   - ``lcov.*``: ``output`` → ``line_checksums``
+   - ``xml.*``: ``output`` → ``package_depth``
+
+**Grouping principle:**
+
+Related options are grouped together:
+
+- File selection: ``include``/``omit`` are adjacent
+- Exclusion patterns: ``exclude_lines``/``exclude_also`` are adjacent
+- Partial branches: ``partial_branches``/``partial_also`` are adjacent
+- Skip options: ``skip_covered``/``skip_empty`` are adjacent
+
+**Sorted arrays:**
+
+Run phase:
+  ``source``, ``source_pkgs``, ``source_dirs``, ``include``, ``omit``, ``concurrency``, ``plugins``, ``debug``,
+  ``disable_warnings``
+
+Report phase:
+  ``include``, ``omit``, ``exclude_lines``, ``exclude_also``, ``partial_branches``, ``partial_also``
+
+.. code-block:: toml
+
+    # Before (alphabetical)
+    [tool.coverage]
+    report.exclude_also = ["if TYPE_CHECKING:"]
+    report.omit = ["tests/*"]
+    run.branch = true
+    run.omit = ["tests/*"]
+
+    # After (workflow order with groupings)
+    [tool.coverage]
+    run.branch = true
+    run.omit = ["tests/*"]
+    report.omit = ["tests/*"]
+    report.exclude_also = ["if TYPE_CHECKING:"]
+
 Other Tables
 ~~~~~~~~~~~~
 

--- a/pyproject-fmt/rust/src/coverage.rs
+++ b/pyproject-fmt/rust/src/coverage.rs
@@ -1,0 +1,116 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    // === Run phase (data collection) ===
+    "run",
+    // Source selection (what to measure)
+    "run.source",
+    "run.source_pkgs",
+    "run.source_dirs",
+    // File filtering (include/omit together)
+    "run.include",
+    "run.omit",
+    // Measurement options
+    "run.branch",
+    "run.cover_pylib",
+    "run.timid",
+    // Execution context
+    "run.command_line",
+    "run.concurrency",
+    "run.context",
+    "run.dynamic_context",
+    // Data management
+    "run.data_file",
+    "run.parallel",
+    "run.relative_files",
+    // Plugins and extensions
+    "run.plugins",
+    // Debugging
+    "run.debug",
+    "run.debug_file",
+    "run.disable_warnings",
+    // Other
+    "run.core",
+    "run.patch",
+    "run.sigterm",
+    // === Paths (path mapping) ===
+    "paths",
+    // === Report phase (general reporting) ===
+    "report",
+    // Coverage threshold
+    "report.fail_under",
+    "report.precision",
+    // File filtering (include/omit together)
+    "report.include",
+    "report.omit",
+    "report.include_namespace_packages",
+    // Line exclusion (exclude patterns together)
+    "report.exclude_lines",
+    "report.exclude_also",
+    // Partial branch handling (partial together)
+    "report.partial_branches",
+    "report.partial_also",
+    // Output control (skip together)
+    "report.skip_covered",
+    "report.skip_empty",
+    "report.show_missing",
+    // Formatting
+    "report.format",
+    "report.sort",
+    // Error handling
+    "report.ignore_errors",
+    // === HTML output ===
+    "html",
+    "html.directory",
+    "html.title",
+    "html.extra_css",
+    "html.show_contexts",
+    "html.skip_covered",
+    "html.skip_empty",
+    // === JSON output ===
+    "json",
+    "json.output",
+    "json.pretty_print",
+    "json.show_contexts",
+    // === LCOV output ===
+    "lcov",
+    "lcov.output",
+    "lcov.line_checksums",
+    // === XML output ===
+    "xml",
+    "xml.output",
+    "xml.package_depth",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(table_elements) = tables.get("tool.coverage") else {
+        return;
+    };
+    let table = &mut table_elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| match key.as_str() {
+        // Run phase arrays
+        "run.source"
+        | "run.source_pkgs"
+        | "run.source_dirs"
+        | "run.include"
+        | "run.omit"
+        | "run.concurrency"
+        | "run.plugins"
+        | "run.debug"
+        | "run.disable_warnings"
+        // Report phase arrays
+        | "report.include"
+        | "report.omit"
+        | "report.exclude_lines"
+        | "report.exclude_also"
+        | "report.partial_branches"
+        | "report.partial_also" => {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+        _ => {}
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -13,6 +13,7 @@ mod build_system;
 mod dependency_groups;
 mod project;
 
+mod coverage;
 mod global;
 mod ruff;
 #[cfg(test)]
@@ -147,6 +148,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     dependency_groups::fix(&mut tables, opt.keep_full_version);
     ruff::fix(&mut tables);
     uv::fix(&mut tables);
+    coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);
     common::string::wrap_all_long_strings(&root_ast, opt.column_width, &indent_string);

--- a/pyproject-fmt/rust/src/tests/coverage_tests.rs
+++ b/pyproject-fmt/rust/src/tests/coverage_tests.rs
@@ -1,0 +1,173 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::coverage::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.coverage"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_coverage_run_before_report() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage]
+    report.omit = ["tests/*"]
+    run.omit = ["tests/*"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    run.omit = [ "tests/*" ]
+    report.omit = [ "tests/*" ]
+    "#);
+}
+
+#[test]
+fn test_coverage_paths_between_run_and_report() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage]
+    report.fail_under = 90
+    paths.source = ["src/", "/build/src"]
+    run.source = ["src"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    run.source = [ "src" ]
+    paths.source = [ "src/", "/build/src" ]
+    report.fail_under = 90
+    "#);
+}
+
+#[test]
+fn test_coverage_report_formats_after_report() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage]
+    xml.output = "coverage.xml"
+    html.directory = "htmlcov"
+    json.output = "coverage.json"
+    lcov.output = "coverage.lcov"
+    report.fail_under = 90
+    run.branch = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    run.branch = true
+    report.fail_under = 90
+    html.directory = "htmlcov"
+    json.output = "coverage.json"
+    lcov.output = "coverage.lcov"
+    xml.output = "coverage.xml"
+    "#);
+}
+
+#[test]
+fn test_coverage_grouped_options() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage]
+    run.branch = true
+    run.omit = ["tests/*"]
+    run.source = ["src"]
+    run.include = ["**/*.py"]
+    report.exclude_lines = ["pragma: no cover"]
+    report.exclude_also = ["if TYPE_CHECKING:"]
+    report.skip_empty = true
+    report.skip_covered = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    run.branch = true
+    run.include = [ "**/*.py" ]
+    run.omit = [ "tests/*" ]
+    run.source = [ "src" ]
+    report.exclude_also = [ "if TYPE_CHECKING:" ]
+    report.exclude_lines = [ "pragma: no cover" ]
+    report.skip_covered = true
+    report.skip_empty = true
+    "#);
+}
+
+#[test]
+fn test_coverage_comments_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage]
+    # Run configuration
+    run.branch = true
+    run.omit = [
+        "tests/*",  # Don't measure tests
+    ]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    # Run configuration
+    run.branch = true
+    run.omit = [
+      "tests/*",  # Don't measure tests
+    ]
+    "#);
+}
+
+#[test]
+fn test_coverage_run_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage]
+    run.omit = ["z_tests/*", "a_fixtures/*", "m_mocks/*"]
+    run.source = ["zulu", "alpha", "bravo"]
+    run.concurrency = ["multiprocessing", "gevent", "thread"]
+    run.plugins = ["coverage_plugin", "another_plugin"]
+    run.debug = ["trace", "config", "sys"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    run.concurrency = [ "gevent", "multiprocessing", "thread" ]
+    run.debug = [ "config", "sys", "trace" ]
+    run.omit = [ "a_fixtures/*", "m_mocks/*", "z_tests/*" ]
+    run.plugins = [ "another_plugin", "coverage_plugin" ]
+    run.source = [ "alpha", "bravo", "zulu" ]
+    "#);
+}
+
+#[test]
+fn test_coverage_report_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage]
+    report.omit = ["tests/*", "fixtures/*", "conftest.py"]
+    report.exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:", "raise NotImplementedError"]
+    report.partial_branches = ["pragma: no branch", "if DEBUG:"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    report.exclude_lines = [ "if TYPE_CHECKING:", "pragma: no cover", "raise NotImplementedError" ]
+    report.omit = [ "conftest.py", "fixtures/*", "tests/*" ]
+    report.partial_branches = [ "if DEBUG:", "pragma: no branch" ]
+    "#);
+}
+
+#[test]
+fn test_coverage_paths_not_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage]
+    paths.source = ["src/mypackage", "/home/user/project/src/mypackage", "/build/src/mypackage"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    paths.source = [ "src/mypackage", "/home/user/project/src/mypackage", "/build/src/mypackage" ]
+    "#);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -3,6 +3,7 @@ use tombi_syntax::SyntaxElement;
 pub use common::test_util::{assert_valid_toml, format_syntax, format_toml_str, parse};
 
 mod build_systems_tests;
+mod coverage_tests;
 mod dependency_groups_tests;
 mod global_tests;
 mod main_tests;


### PR DESCRIPTION
When `[tool.coverage]` keys are sorted alphabetically, `report` appears before `run`. This contradicts coverage.py's natural workflow where you first collect data, then generate reports. 🔧 Users reading their config see reporting options before they even know what's being measured.

Keys are now reordered to match the tool's execution phases: `run` (data collection) → `paths` (source mapping) → `report` (general reporting) → output formats (`html`, `json`, `lcov`, `xml`). Within each section, related options are grouped together—for example, `include`/`omit` stay adjacent, as do `skip_covered`/`skip_empty`. ✨ This makes configs more scannable and mirrors how developers think about coverage workflows.

Array values that represent unordered sets are also sorted alphabetically. This includes `run.source`, `run.omit`, `run.concurrency`, `run.plugins`, `report.omit`, `report.exclude_lines`, and similar options. The `paths.*` arrays are intentionally left unsorted since the first entry is the canonical path.

Closes #195