### PR TITLE
🐛 fix(changelog): stop at release commits for orphaned tags

### DIFF
--- a/pyproject-fmt/CHANGELOG.md
+++ b/pyproject-fmt/CHANGELOG.md
@@ -2,49 +2,13 @@
 
 ## 2.14.2 - 2026-02-09
 
+- Release pyproject-fmt 2.14.2 [skip ci] by [@gaborbernat](https://github.com/gaborbernat)
 - 🧪 test(coverage): increase coverage to 98% and fix bugs by [@gaborbernat](https://github.com/gaborbernat) in
   [#194](https://github.com/tox-dev/toml-fmt/pull/194)
-- Release pyproject-fmt 2.14.1 by [@gaborbernat](https://github.com/gaborbernat)
-- 🐛 fix(table): preserve table headers and reduce duplication by [@gaborbernat](https://github.com/gaborbernat) in
-  [#192](https://github.com/tox-dev/toml-fmt/pull/192)
-- 🐛 fix(array): preserve comments with strings by [@gaborbernat](https://github.com/gaborbernat) in
-  [#191](https://github.com/tox-dev/toml-fmt/pull/191)
-- 🧪 test: add idempotency tests for string wrapping by [@gaborbernat](https://github.com/gaborbernat) in
-  [#190](https://github.com/tox-dev/toml-fmt/pull/190)
-- 🐛 fix(parser): handle comments with double quotes in arrays by [@gaborbernat](https://github.com/gaborbernat) in
-  [#189](https://github.com/tox-dev/toml-fmt/pull/189)
-- 🐛 fix(array): sort by value not comment for entries with leading comments by
-  [@gaborbernat](https://github.com/gaborbernat) in [#188](https://github.com/tox-dev/toml-fmt/pull/188)
-- Update Rust dependencies by [@gaborbernat](https://github.com/gaborbernat) in
-  [#183](https://github.com/tox-dev/toml-fmt/pull/183)
-- Update Python dependencies by [@gaborbernat](https://github.com/gaborbernat) in
-  [#178](https://github.com/tox-dev/toml-fmt/pull/178)
-- ✨ feat(workspace): internalize toml-fmt-common as workspace member by [@gaborbernat](https://github.com/gaborbernat)
-  in [#170](https://github.com/tox-dev/toml-fmt/pull/170)
-- ✨ feat(pyproject-fmt): add tool.uv section formatting by [@gaborbernat](https://github.com/gaborbernat) in
-  [#169](https://github.com/tox-dev/toml-fmt/pull/169)
-- Release pyproject-fmt 2.14.0 by [@gaborbernat](https://github.com/gaborbernat)
-- ✨ feat(changelog): add --regenerate flag for full changelog rebuild by [@gaborbernat](https://github.com/gaborbernat)
-  in [#166](https://github.com/tox-dev/toml-fmt/pull/166)
-- 🐛 fix(readme): use explicit UTF-8 encoding for file operations by [@gaborbernat](https://github.com/gaborbernat) in
-  [#165](https://github.com/tox-dev/toml-fmt/pull/165)
-- Release pyproject-fmt 2.13.0 by [@gaborbernat](https://github.com/gaborbernat)
-- 📝 docs(formatting): restructure docs and fix array formatting behavior by
-  [@gaborbernat](https://github.com/gaborbernat) in [#164](https://github.com/tox-dev/toml-fmt/pull/164)
-- ♻️ refactor(parser): migrate from taplo to tombi by [@gaborbernat](https://github.com/gaborbernat) in
-  [#159](https://github.com/tox-dev/toml-fmt/pull/159)
-- Fix expand_tables setting for deeply nested tables (#146) by [@gaborbernat](https://github.com/gaborbernat) in
-  [#160](https://github.com/tox-dev/toml-fmt/pull/160)
-- Prefer double quotes, use single quotes to avoid escaping by [@gaborbernat](https://github.com/gaborbernat) in
-  [#162](https://github.com/tox-dev/toml-fmt/pull/162)
-- Fix comment before table moving incorrectly when table has comments by [@gaborbernat](https://github.com/gaborbernat)
-  in [#158](https://github.com/tox-dev/toml-fmt/pull/158)
-- Fix regex for SPDX license normalization by [@alexfikl](https://github.com/alexfikl) in
-  [#156](https://github.com/tox-dev/toml-fmt/pull/156)
-- Add tests to improve coverage for edge cases by [@gaborbernat](https://github.com/gaborbernat) in
-  [#155](https://github.com/tox-dev/toml-fmt/pull/155) <a id="2.14.1"></a>
 
-## 2.14.1 - 2026-02-08
+<a id="2.14.1"></a>
+
+## 2.14.1 - 2026-02-09
 
 - 🐛 fix(table): preserve table headers and reduce duplication by [@gaborbernat](https://github.com/gaborbernat) in
   [#192](https://github.com/tox-dev/toml-fmt/pull/192)
@@ -64,26 +28,8 @@
   in [#170](https://github.com/tox-dev/toml-fmt/pull/170)
 - ✨ feat(pyproject-fmt): add tool.uv section formatting by [@gaborbernat](https://github.com/gaborbernat) in
   [#169](https://github.com/tox-dev/toml-fmt/pull/169)
-- Release pyproject-fmt 2.14.0 by [@gaborbernat](https://github.com/gaborbernat)
-- ✨ feat(changelog): add --regenerate flag for full changelog rebuild by [@gaborbernat](https://github.com/gaborbernat)
-  in [#166](https://github.com/tox-dev/toml-fmt/pull/166)
-- 🐛 fix(readme): use explicit UTF-8 encoding for file operations by [@gaborbernat](https://github.com/gaborbernat) in
-  [#165](https://github.com/tox-dev/toml-fmt/pull/165)
-- Release pyproject-fmt 2.13.0 by [@gaborbernat](https://github.com/gaborbernat)
-- 📝 docs(formatting): restructure docs and fix array formatting behavior by
-  [@gaborbernat](https://github.com/gaborbernat) in [#164](https://github.com/tox-dev/toml-fmt/pull/164)
-- ♻️ refactor(parser): migrate from taplo to tombi by [@gaborbernat](https://github.com/gaborbernat) in
-  [#159](https://github.com/tox-dev/toml-fmt/pull/159)
-- Fix expand_tables setting for deeply nested tables (#146) by [@gaborbernat](https://github.com/gaborbernat) in
-  [#160](https://github.com/tox-dev/toml-fmt/pull/160)
-- Prefer double quotes, use single quotes to avoid escaping by [@gaborbernat](https://github.com/gaborbernat) in
-  [#162](https://github.com/tox-dev/toml-fmt/pull/162)
-- Fix comment before table moving incorrectly when table has comments by [@gaborbernat](https://github.com/gaborbernat)
-  in [#158](https://github.com/tox-dev/toml-fmt/pull/158)
-- Fix regex for SPDX license normalization by [@alexfikl](https://github.com/alexfikl) in
-  [#156](https://github.com/tox-dev/toml-fmt/pull/156)
-- Add tests to improve coverage for edge cases by [@gaborbernat](https://github.com/gaborbernat) in
-  [#155](https://github.com/tox-dev/toml-fmt/pull/155) <a id="2.14.0"></a>
+
+<a id="2.14.0"></a>
 
 ## 2.14.0 - 2026-02-08
 
@@ -91,7 +37,6 @@
   in [#166](https://github.com/tox-dev/toml-fmt/pull/166)
 - 🐛 fix(readme): use explicit UTF-8 encoding for file operations by [@gaborbernat](https://github.com/gaborbernat) in
   [#165](https://github.com/tox-dev/toml-fmt/pull/165)
-- Release pyproject-fmt 2.13.0 by [@gaborbernat](https://github.com/gaborbernat)
 - 📝 docs(formatting): restructure docs and fix array formatting behavior by
   [@gaborbernat](https://github.com/gaborbernat) in [#164](https://github.com/tox-dev/toml-fmt/pull/164)
 - ♻️ refactor(parser): migrate from taplo to tombi by [@gaborbernat](https://github.com/gaborbernat) in
@@ -105,7 +50,9 @@
 - Fix regex for SPDX license normalization by [@alexfikl](https://github.com/alexfikl) in
   [#156](https://github.com/tox-dev/toml-fmt/pull/156)
 - Add tests to improve coverage for edge cases by [@gaborbernat](https://github.com/gaborbernat) in
-  [#155](https://github.com/tox-dev/toml-fmt/pull/155) <a id="2.12.1"></a>
+  [#155](https://github.com/tox-dev/toml-fmt/pull/155)
+
+<a id="2.12.1"></a>
 
 ## 2.12.1 - 2026-01-31
 

--- a/tox-toml-fmt/CHANGELOG.md
+++ b/tox-toml-fmt/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## 1.5.2 - 2026-02-09
 
+- Release tox-toml-fmt 1.5.2 [skip ci] by [@gaborbernat](https://github.com/gaborbernat)
 - 🧪 test(coverage): increase coverage to 98% and fix bugs by [@gaborbernat](https://github.com/gaborbernat) in
-  [#194](https://github.com/tox-dev/toml-fmt/pull/194) <a id="1.5.1"></a>
+  [#194](https://github.com/tox-dev/toml-fmt/pull/194)
+
+<a id="1.5.1"></a>
 
 ## 1.5.1 - 2026-02-08
 
@@ -22,7 +25,9 @@
 - Update Python dependencies by [@gaborbernat](https://github.com/gaborbernat) in
   [#178](https://github.com/tox-dev/toml-fmt/pull/178)
 - ✨ feat(workspace): internalize toml-fmt-common as workspace member by [@gaborbernat](https://github.com/gaborbernat)
-  in [#170](https://github.com/tox-dev/toml-fmt/pull/170) <a id="1.5.0"></a>
+  in [#170](https://github.com/tox-dev/toml-fmt/pull/170)
+
+<a id="1.5.0"></a>
 
 ## 1.5.0 - 2026-02-08
 
@@ -30,7 +35,6 @@
   in [#166](https://github.com/tox-dev/toml-fmt/pull/166)
 - 🐛 fix(readme): use explicit UTF-8 encoding for file operations by [@gaborbernat](https://github.com/gaborbernat) in
   [#165](https://github.com/tox-dev/toml-fmt/pull/165)
-- Release tox-toml-fmt 1.4.0 by [@gaborbernat](https://github.com/gaborbernat)
 - 📝 docs(formatting): restructure docs and fix array formatting behavior by
   [@gaborbernat](https://github.com/gaborbernat) in [#164](https://github.com/tox-dev/toml-fmt/pull/164)
 - ♻️ refactor(parser): migrate from taplo to tombi by [@gaborbernat](https://github.com/gaborbernat) in
@@ -47,40 +51,8 @@
   [#148](https://github.com/tox-dev/toml-fmt/pull/148)
 - Use RELEASE_TOKEN to bypass branch protection for releases by [@gaborbernat](https://github.com/gaborbernat) in
   [#147](https://github.com/tox-dev/toml-fmt/pull/147)
-- Generate README.rst dynamically from docs at build time by [@gaborbernat](https://github.com/gaborbernat) in
-  [#145](https://github.com/tox-dev/toml-fmt/pull/145)
-- 📚 Document formatting principles and normalizations by [@gaborbernat](https://github.com/gaborbernat) in
-  [#144](https://github.com/tox-dev/toml-fmt/pull/144)
-- Improve maintainalibility by [@gaborbernat](https://github.com/gaborbernat) in
-  [#143](https://github.com/tox-dev/toml-fmt/pull/143)
-- Add configurable table formatting to pyproject-fmt and order tox env tables by env_list by
-  [@gaborbernat](https://github.com/gaborbernat) in [#142](https://github.com/tox-dev/toml-fmt/pull/142)
-- Order tox env tables according to env_list and add codecov token by [@gaborbernat](https://github.com/gaborbernat) in
-  [#141](https://github.com/tox-dev/toml-fmt/pull/141)
-- Fix comments before table headers staying with correct table by [@gaborbernat](https://github.com/gaborbernat) in
-  [#140](https://github.com/tox-dev/toml-fmt/pull/140)
-- Sort subtables alphabetically within the same tool by [@gaborbernat](https://github.com/gaborbernat) in
-  [#139](https://github.com/tox-dev/toml-fmt/pull/139)
-- Collapse [[project.authors]] array of tables to inline format by [@gaborbernat](https://github.com/gaborbernat) in
-  [#137](https://github.com/tox-dev/toml-fmt/pull/137)
-- Bump toml-fmt-common to 1.2 by [@gaborbernat](https://github.com/gaborbernat) in
-  [#138](https://github.com/tox-dev/toml-fmt/pull/138)
-- Add keyword and classifier deduplication by [@gaborbernat](https://github.com/gaborbernat) in
-  [#133](https://github.com/tox-dev/toml-fmt/pull/133)
-- Fix crash on multi-line strings with line continuation by [@gaborbernat](https://github.com/gaborbernat) in
-  [#132](https://github.com/tox-dev/toml-fmt/pull/132)
-- Add PEP 794 private dependency support by [@gaborbernat](https://github.com/gaborbernat) in
-  [#131](https://github.com/tox-dev/toml-fmt/pull/131)
-- Fix literal strings with invalid escapes being corrupted by [@gaborbernat](https://github.com/gaborbernat) in
-  [#130](https://github.com/tox-dev/toml-fmt/pull/130)
-- Remove testpaths config to fix sdist warning (#120) by [@gaborbernat](https://github.com/gaborbernat) in
-  [#129](https://github.com/tox-dev/toml-fmt/pull/129)
-- Fix build requirements with duplicate package names being removed (#2) by
-  [@gaborbernat](https://github.com/gaborbernat) in [#127](https://github.com/tox-dev/toml-fmt/pull/127)
-- Improve CI: add Rust coverage thresholds and prek parallel hooks by [@gaborbernat](https://github.com/gaborbernat) in
-  [#126](https://github.com/tox-dev/toml-fmt/pull/126)
-- Improve GitHub Actions workflows by [@gaborbernat](https://github.com/gaborbernat) in
-  [#125](https://github.com/tox-dev/toml-fmt/pull/125) <a id="1.3.0"></a>
+
+<a id="1.3.0"></a>
 
 ## 1.3.0 - 2026-01-30
 


### PR DESCRIPTION
The changelog for version 2.14.1 incorrectly included all commits from 2.14.0 and earlier releases. 🐛 This happened because release tags were pointing to orphaned commits that aren't reachable from main's linear history, a side effect of `git pull --rebase` rewriting commit hashes after tags were created.

The `entries()` function iterates commits looking for hexshas matching release tags, but since those tagged commits aren't in main's history, the loop never found a stopping point. Adding a fallback check for release commit messages (`Release {project} X.Y.Z`) ensures changelog generation stops at the right boundary regardless of tag placement.

This fix makes changelog generation resilient to orphaned tags while preserving the existing tag-based detection as the primary mechanism.