### PR TITLE
🐛 fix(table): preserve empty tables as inline empty tables

### DIFF
--- a/common/src/create.rs
+++ b/common/src/create.rs
@@ -158,6 +158,14 @@ pub fn make_entry_of_string(key: &String, value: &String) -> SyntaxElement {
         .expect("parsed entry has KEY_VALUE")
 }
 
+pub fn make_empty_inline_table(key: &str) -> SyntaxElement {
+    let txt = format!("{key} = {{}}\n");
+    parse(txt.as_str())
+        .first_child()
+        .map(SyntaxElement::Node)
+        .expect("parsed entry has KEY_VALUE")
+}
+
 pub fn make_table_entry(key: &str) -> Vec<SyntaxElement> {
     let txt = format!("[{key}]\n");
     parse(txt.as_str()).children_with_tokens().collect()


### PR DESCRIPTION
Empty TOML tables like `[tool.hatch.metadata.hooks.docstring-description]` were being silently removed when pyproject-fmt collapsed nested tables. 🔧 This broke configurations where users intentionally declared empty tables to enable tool-specific behavior (like hatch's docstring-description hook).

The fix detects tables without `KEY_VALUE` children during collapse and converts them to inline empty table syntax like `metadata.hooks.docstring-description = {}`. This preserves the semantic meaning while following the collapsed format conventions.

While investigating, I discovered a related bug where `collect_all_sub_tables` could add the same table twice - once from the main iteration and once from `add_intermediate_parents`. This caused tables to be processed twice: first correctly with content, then incorrectly as empty after being cleared. Adding a deduplication check resolved both issues.

Closes #201