### PR TITLE
🐛 fix(array): preserve single-line arrays with trailing comments

### DIFF
--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -861,3 +861,16 @@ fn test_table_key_without_prefix_match_long_format() {
     other = "data"
     "#);
 }
+
+#[test]
+fn test_issue_202_preserve_inline_comment_after_array() {
+    let start = indoc! {r#"
+    [tool.uv]
+    lint.per-file-ignores."docs/**/*.py" = [ "INP001" ] # No __init__.py in docs
+    "#};
+    let got = format_toml(start, &default_settings());
+    assert_snapshot!(got, @r#"
+    [tool.uv]
+    lint.per-file-ignores."docs/**/*.py" = [ "INP001" ]  # No __init__.py in docs
+    "#);
+}


### PR DESCRIPTION
Single-line arrays with trailing comments like `[ "INP001" ] # No __init__.py` were being unexpectedly converted to multiline format. 🔍 This happened because tombi's parser includes trailing comments as descendants of the `ARRAY` node, and the multiline conversion logic was triggering on any comment found in the array's AST subtree.

The fix distinguishes between comments *inside* the array (which should trigger multiline for readability) and comments *after* the closing bracket (which are just end-of-line annotations). ✨ By walking the AST from the end and only considering comments before `BRACKET_END`, trailing comments no longer affect the array's formatting decision.

Arrays with comments between elements still correctly expand to multiline, while arrays like `lint.per-file-ignores."docs/**/*.py" = [ "INP001" ] # explanation` now stay compact as users expect.

Fixes #202