### PR TITLE
🐛 fix(array): preserve trailing comments during sort

### DIFF
--- a/common/src/array.rs
+++ b/common/src/array.rs
@@ -203,7 +203,7 @@ where
             BRACKET_END => {
                 match current_set_value.take() {
                     None => {
-                        entries.extend(current_set.borrow_mut().clone());
+                        entries.extend(current_set.borrow_mut().drain(..));
                     }
                     Some(val) => {
                         add_to_order_sets(val);
@@ -246,6 +246,8 @@ where
         }
     }
 
+    let remaining: Vec<SyntaxElement> = current_set.borrow_mut().drain(..).collect();
+
     let trailing_content = entries.split_off(if multiline { 2 } else { 1 });
     let mut order: Vec<T> = key_to_order_set.keys().cloned().collect();
     order.sort_by(&cmp);
@@ -261,6 +263,7 @@ where
         entries.extend(order_sets[key_to_order_set[&key]].clone());
     }
     entries.extend(trailing_content);
+    entries.extend(remaining);
     array.splice_children(0..count, entries);
 
     if !has_trailing_comma {

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -1086,3 +1086,31 @@ fn test_comment_in_nested_array_triggers_multiline() {
         "Comment in nested array should be preserved"
     );
 }
+
+#[test]
+fn test_sort_preserves_trailing_comment_after_bracket_end() {
+    let start = r#"a = [ "no-sysmon" ] # 3.11 and earlier"#;
+    let res = apply_to_arrays(start, |array| {
+        sort_strings::<String, _, _>(array, |s| s.to_lowercase(), &|lhs, rhs| lhs.cmp(rhs));
+    });
+    insta::assert_snapshot!(res, @r#"a = [ "no-sysmon" ]  # 3.11 and earlier"#);
+}
+
+#[test]
+fn test_sort_preserves_trailing_comment_after_bracket_end_multiline() {
+    let start = indoc! {r#"
+        a = [
+          "b",
+          "a",
+        ] # trailing comment
+    "#};
+    let res = apply_to_arrays(start, |array| {
+        sort_strings::<String, _, _>(array, |s| s.to_lowercase(), &|lhs, rhs| lhs.cmp(rhs));
+    });
+    insta::assert_snapshot!(res, @r#"
+    a = [
+      "a",
+      "b",
+    ]  # trailing comment
+    "#);
+}

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -1910,6 +1910,25 @@ fn test_apply_table_formatting_with_empty_intermediate_table() {
 }
 
 #[test]
+fn test_collapse_sub_table_trailing_comment_on_single_line_array() {
+    let toml = indoc! {r#"
+        [tool.coverage.run]
+        core = "sysmon" # default for 3.14+, available for 3.12+
+        disable_warnings = [ "no-sysmon" ] # 3.11 and earlier
+    "#};
+    let root_ast = parse(toml);
+    let mut tables = Tables::from_ast(&root_ast);
+    collapse_sub_table(&mut tables, "tool.coverage", "run", 120);
+    tables.reorder(&root_ast, &["tool.coverage", "tool.coverage.run"], &[]);
+    let result = format_toml(&root_ast, 120);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    run.core = "sysmon"  # default for 3.14+, available for 3.12+
+    run.disable_warnings = [ "no-sysmon" ]  # 3.11 and earlier
+    "#);
+}
+
+#[test]
 fn test_collapse_sub_table_empty_parent_with_subtable() {
     let toml = indoc! {r#"
         [parent]

--- a/pyproject-fmt/rust/src/tests/coverage_tests.rs
+++ b/pyproject-fmt/rust/src/tests/coverage_tests.rs
@@ -160,6 +160,41 @@ fn test_coverage_report_arrays_sorted() {
 }
 
 #[test]
+fn test_coverage_trailing_comment_on_single_line_array() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage.run]
+    omit = [
+      "**/__main__.py",
+      "**/cli.py",
+    ]
+    core = "sysmon" # default for 3.14+, available for 3.12+
+    disable_warnings = [ "no-sysmon" ] # 3.11 and earlier
+
+    [tool.coverage.report]
+    # Regexes for lines to exclude from consideration
+    exclude_also = [
+      # Don't complain if non-runnable code isn't run:
+      "if __name__ == .__main__.:",
+    ]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    run.core = "sysmon"  # default for 3.14+, available for 3.12+
+    run.disable_warnings = [ "no-sysmon" ]  # 3.11 and earlier
+    run.omit = [
+      "**/__main__.py",
+      "**/cli.py",
+    ]
+    # Regexes for lines to exclude from consideration
+    report.exclude_also = [
+      # Don't complain if non-runnable code isn't run:
+      "if __name__ == .__main__.:",
+    ]
+    "#);
+}
+
+#[test]
 fn test_coverage_paths_not_sorted() {
     let start = indoc::indoc! {r#"
     [tool.coverage]


### PR DESCRIPTION
When an array like `disable_warnings = [ "no-sysmon" ] # 3.11 and earlier` was sorted by `sort_strings`, the trailing comment after `]` was silently dropped. 🐛 This meant users lost important context comments on single-line arrays in `[tool.coverage]` and other sections that undergo array sorting.

The root cause was in the `sort` function in `common/src/array.rs`. Elements appearing after `BRACKET_END` (whitespace and comments) were accumulated into `current_set` via the catch-all branch, but never flushed back into the final `entries` list. Additionally, the `BRACKET_END` handler used `.clone()` instead of `.drain(..)` when flushing `current_set` with no active key, leaving stale elements that could cause duplicate entries in edge cases (e.g. arrays with non-string values where `to_key` returns `None`).

Fixes #207