### PR TITLE
🐛 fix(project): stop sorting authors and maintainers

### DIFF
--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -128,48 +128,7 @@ pub fn fix(
             dedupe_strings(entry, |s| s.to_lowercase());
             sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
         }
-        "authors" | "maintainers" => {
-            sort::<(String, String), _, _>(
-                entry,
-                |node| {
-                    let mut name = String::new();
-                    let mut email = String::new();
-                    if node.kind() == INLINE_TABLE {
-                        for child in node.children_with_tokens() {
-                            if child.kind() == KEY_VALUE {
-                                let mut current_key = String::new();
-                                for e in child.as_node().unwrap().children_with_tokens() {
-                                    match e.kind() {
-                                        KEYS => {
-                                            current_key = e.as_node().unwrap().text().to_string().trim().to_string();
-                                        }
-                                        BASIC_STRING => {
-                                            if let Some(string_node) = e.as_node() {
-                                                let val = load_text(&string_node.text().to_string(), BASIC_STRING);
-                                                match current_key.as_str() {
-                                                    "name" => name = val.to_lowercase(),
-                                                    "email" => email = val.to_lowercase(),
-                                                    _ => {}
-                                                }
-                                            }
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    Some((name, email))
-                },
-                &|lhs, rhs| {
-                    let mut res = natural_lexical_cmp(lhs.0.as_str(), rhs.0.as_str());
-                    if res == Ordering::Equal {
-                        res = natural_lexical_cmp(lhs.1.as_str(), rhs.1.as_str());
-                    }
-                    res
-                },
-            );
-        }
+        "authors" | "maintainers" => {}
         _ => {}
     });
 

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -325,8 +325,8 @@ fn test_collapse_authors_with_url_field() {
     [project]
     name = "test"
     authors = [
-      { name = "Alice", email = "alice@example.com" },
-      { name = "Bob", email = "bob@example.com", url = "https://bob.com" }
+      { name = "Bob", email = "bob@example.com", url = "https://bob.com" },
+      { name = "Alice", email = "alice@example.com" }
     ]
     "#);
 }

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -221,7 +221,7 @@ fn test_project_authors_maintainers() {
     insta::assert_snapshot!(result, @r#"
     [project]
     maintainers = [ { email = "maintain@example.com" } ]
-    authors = [ { name = "Jane Smith" }, { name = "John Doe", email = "john@example.com" } ]
+    authors = [ { name = "John Doe", email = "john@example.com" }, { name = "Jane Smith" } ]
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
       "Programming Language :: Python :: 3.9",
@@ -879,7 +879,7 @@ fn test_project_maintainers_multiple() {
     let result = evaluate_project(start, false, (3, 11), true);
     insta::assert_snapshot!(result, @r#"
     [project]
-    maintainers = [ { email = "charlie@example.com" }, { name = "Alice", email = "alice@example.com" }, { name = "Bob" } ]
+    maintainers = [ { name = "Alice", email = "alice@example.com" }, { name = "Bob" }, { email = "charlie@example.com" } ]
     classifiers = [
       "Programming Language :: Python :: 3 :: Only",
       "Programming Language :: Python :: 3.9",
@@ -1445,7 +1445,7 @@ fn test_project_keywords_dedupe() {
 }
 
 #[test]
-fn test_project_authors_sorting_by_name() {
+fn test_project_authors_preserve_order() {
     let start = indoc! {r#"
         [project]
         name = "test"
@@ -1460,15 +1460,15 @@ fn test_project_authors_sorting_by_name() {
     [project]
     name = "test"
     authors = [
+      { name = "Zoe", email = "zoe@example.com" },
       { name = "Alice", email = "alice@example.com" },
       { name = "Bob", email = "bob@example.com" },
-      { name = "Zoe", email = "zoe@example.com" },
     ]
     "#);
 }
 
 #[test]
-fn test_project_authors_sorting_by_email_when_no_name() {
+fn test_project_authors_preserve_order_email_only() {
     let start = indoc! {r#"
         [project]
         name = "test"
@@ -1482,14 +1482,14 @@ fn test_project_authors_sorting_by_email_when_no_name() {
     [project]
     name = "test"
     authors = [
-      { email = "alice@example.com" },
       { email = "zoe@example.com" },
+      { email = "alice@example.com" },
     ]
     "#);
 }
 
 #[test]
-fn test_project_maintainers_sorting() {
+fn test_project_maintainers_preserve_order() {
     let start = indoc! {r#"
         [project]
         name = "test"
@@ -1503,8 +1503,8 @@ fn test_project_maintainers_sorting() {
     [project]
     name = "test"
     maintainers = [
-      { name = "Alice" },
       { name = "Charlie" },
+      { name = "Alice" },
     ]
     "#);
 }
@@ -1664,7 +1664,7 @@ fn test_project_classifiers_filter_existing_python_versions() {
 }
 
 #[test]
-fn test_project_authors_same_name_sort_by_email() {
+fn test_project_authors_same_name_preserve_order() {
     let start = indoc! {r#"
         [project]
         name = "test"
@@ -1678,8 +1678,8 @@ fn test_project_authors_same_name_sort_by_email() {
     [project]
     name = "test"
     authors = [
-      { name = "Alice", email = "a@example.com" },
       { name = "Alice", email = "z@example.com" },
+      { name = "Alice", email = "a@example.com" },
     ]
     "#);
 }


### PR DESCRIPTION
The order of `project.authors` and `project.maintainers` is intentional in most projects — it reflects contribution significance, historical order, or other meaningful conventions. Alphabetically sorting these entries destroys that intent. For example, numpy lists the primary author first followed by "et al.", and many projects list contributors in order of involvement.

🐛 This removes the alphabetical sorting logic for `authors` and `maintainers` arrays, preserving the order as defined by the package author. All other array sorting (e.g. `classifiers`, `dependencies`) remains unchanged.

Fixes #228