### PR TITLE
🐛 fix(tox-toml-fmt): keep env tables as separate sections

### DIFF
--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -135,6 +135,27 @@ Sub-tables can be formatted in two styles controlled by ``table_format``:
 Individual tables can override the default using ``expand_tables`` and ``collapse_tables``.
 See :doc:`configuration` for how to control this behavior.
 
+**Environment tables are always expanded:**
+
+Regardless of the ``table_format`` setting, ``[env.*]`` tables are never collapsed into dotted keys under ``[env]``.
+Each environment always gets its own ``[env.NAME]`` table section:
+
+.. code-block:: toml
+
+    # This is always the output format, even in short mode:
+    [env.fix]
+    description = "fix"
+
+    [env.test]
+    description = "test"
+
+    # Dotted keys under [env] are automatically expanded:
+    # [env]
+    # fix.description = "fix"    →    [env.fix]
+    #                                  description = "fix"
+
+Sub-tables within an environment (e.g. ``[env.test.sub]``) still follow the ``table_format`` setting.
+
 Comment Preservation
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/tox-toml-fmt/rust/src/tests/main_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/main_tests.rs
@@ -1042,3 +1042,56 @@ fn test_sort_labels() {
     labels = [ "all", "ci", "test" ]
     "#);
 }
+
+#[test]
+fn test_env_dotted_keys_expand_to_tables() {
+    let start = indoc! {r#"
+        [env]
+        fix.description = "fix"
+        fix.skip_install = true
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.fix]
+    description = "fix"
+    skip_install = true
+    "#);
+}
+
+#[test]
+fn test_env_tables_not_collapsed_in_short_format() {
+    let start = indoc! {r#"
+        [env.fix]
+        description = "fix"
+        skip_install = true
+
+        [env.test]
+        description = "test"
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.fix]
+    description = "fix"
+    skip_install = true
+
+    [env.test]
+    description = "test"
+    "#);
+}
+
+#[test]
+fn test_env_sub_tables_still_collapse_in_short_format() {
+    let start = indoc! {r#"
+        [env.test]
+        description = "run tests"
+
+        [env.test.sub]
+        value = 1
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    description = "run tests"
+    sub.value = 1
+    "#);
+}


### PR DESCRIPTION
When using `table_format = "short"`, the formatter was collapsing `[env.NAME]` sections into dotted keys under `[env]` (e.g. `fix.description = "fix"`). This triggers a RecursionError in tox's TOML config loader, which cannot handle dotted keys under the `[env]` table. 🐛

The fix ensures `[env.*]` tables are always kept as separate sections regardless of the `table_format` setting. When dotted keys already exist under `[env]`, they are expanded into their own `[env.NAME]` sections, and any empty parent table left behind is cleaned up. Sub-tables within an environment (e.g. `[env.test.sub]`) still follow the `table_format` setting, so only the first level of environment names is protected.

This is a targeted fix — `env_run_base`, `env_pkg_base`, and all other tables continue to respect the `table_format` option as before.