### PR TITLE
🐛 fix(tox-toml-fmt): handle quoted env keys with dots

### DIFF
--- a/tox-toml-fmt/rust/src/tests/main_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/main_tests.rs
@@ -1095,3 +1095,54 @@ fn test_env_sub_tables_still_collapse_in_short_format() {
     sub.value = 1
     "#);
 }
+
+#[test]
+fn test_env_quoted_key_with_dot_not_collapsed() {
+    let start = indoc! {r#"
+        [env."3.13t"]
+        base_python = "3.13t"
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env."3.13t"]
+    base_python = "3.13t"
+    "#);
+}
+
+#[test]
+fn test_env_quoted_key_dotted_expand() {
+    let start = indoc! {r#"
+        [env]
+        "3.13t".base_python = "3.13t"
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env."3.13t"]
+    base_python = "3.13t"
+    "#);
+}
+
+#[test]
+fn test_env_multiple_quoted_keys_not_collapsed() {
+    let start = indoc! {r#"
+        [env."3.13t"]
+        base_python = "3.13t"
+
+        [env."3.14t"]
+        base_python = "3.14t"
+
+        [env.fix]
+        description = "fix"
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env."3.13t"]
+    base_python = "3.13t"
+
+    [env."3.14t"]
+    base_python = "3.14t"
+
+    [env.fix]
+    description = "fix"
+    "#);
+}


### PR DESCRIPTION
Env names containing dots like `"3.13t"` were being incorrectly collapsed into dotted keys under `[env]` because multiple call sites used naive `str::find(".")`, `str::contains(".")`, `str::split(".")`, and `str::rfind(".")` which treat dots inside quoted strings as key separators. 🐛 This affected projects like virtualenv that use free-threaded Python version names as env keys.

The fix consolidates three separate quote-aware dot-parsing functions (`count_unquoted_dots`, `find_first_unquoted_dot`, `split_table_name`) into a shared `unquoted_dot_positions` iterator, then switches all dot-handling call sites to use it — `should_collapse`, prefix collection, and `collect_all_sub_tables`. This eliminates the duplicated quote-tracking logic while making the public API reusable across crates.

This is a follow-up to #231 which introduced the env table expansion behavior but missed the quoted-key edge case.