### PR TITLE
🐛 fix(pyproject-fmt): resolve panic on non-valid classifiers

### DIFF
--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -308,20 +308,20 @@ fn generate_classifiers_to_entry(
                             let txt = load_text(token.text(), BASIC_STRING);
                             delete_mode = delete.contains(&txt);
                             if delete_mode {
-                                let mut remove_count = to_insert.len();
-                                for (at, v) in to_insert.iter().rev().enumerate() {
-                                    if [COMMA, BRACKET_START].contains(&v.kind()) {
-                                        remove_count = at;
-                                        for (i, e) in to_insert.iter().enumerate().skip(to_insert.len() - at) {
-                                            if e.kind() == LINE_BREAK {
-                                                remove_count = i + 1;
-                                                break;
-                                            }
-                                        }
+                                let mut truncate_at = to_insert.len();
+                                for (rev_idx, v) in to_insert.iter().rev().enumerate() {
+                                    let fwd_idx = to_insert.len() - 1 - rev_idx;
+                                    if v.kind() == BRACKET_START {
+                                        truncate_at = fwd_idx + 1;
+                                        break;
+                                    }
+                                    if v.kind() == COMMA {
+                                        // Keep the comma, remove whitespace/newline after it
+                                        truncate_at = fwd_idx + 1;
                                         break;
                                     }
                                 }
-                                to_insert.truncate(remove_count);
+                                to_insert.truncate(truncate_at);
                             }
                         }
                     }

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -2322,3 +2322,28 @@ fn test_project_classifiers_no_trailing_comma_multiline() {
     ]
     "#);
 }
+
+#[test]
+fn test_project_classifiers_with_invalid_classifier() {
+    let start = indoc! {r#"
+        [project]
+        name = "test"
+        version = "0.0.1"
+        classifiers = ["Programming Language :: Python :: 3", "a :: string"]
+    "#};
+    let result = evaluate_project(start, false, (3, 13), true);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "test"
+    version = "0.0.1"
+    classifiers = [
+      "a :: string",
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.11",
+      "Programming Language :: Python :: 3.12",
+      "Programming Language :: Python :: 3.13",
+    ]
+    "#);
+}

--- a/pyproject-fmt/tests/test_lib.py
+++ b/pyproject-fmt/tests/test_lib.py
@@ -66,6 +66,26 @@ from pyproject_fmt._lib import Settings, format_toml
             """,
             id="collapsed",
         ),
+        pytest.param(
+            """
+            [project]
+            name = "test"
+            version = "0.0.1"
+            classifiers = ["Programming Language :: Python :: 3", "a :: string"]
+            """,
+            """\
+            [project]
+            name = "test"
+            version = "0.0.1"
+            classifiers = [
+                "a :: string",
+                "Programming Language :: Python :: 3 :: Only",
+                "Programming Language :: Python :: 3.7",
+                "Programming Language :: Python :: 3.8",
+            ]
+            """,
+            id="invalid_classifier",
+        ),
     ],
 )
 def test_format_toml(start: str, expected: str) -> None:


### PR DESCRIPTION
When a `pyproject.toml` contains non-valid classifiers (e.g. `"a :: string"`) alongside valid Python version classifiers, `pyproject-fmt` panics with `split index (is 2) should be <= len (is 1)`. This happens because the delete-mode truncation logic in `generate_classifiers_to_entry` uses reverse enumeration indices directly as forward indices, causing `BRACKET_START` to be stripped from the reconstructed array. The malformed array then triggers a panic downstream during `split_off`.

The fix converts the reverse index to a forward index before truncating, and preserves the `COMMA` token when removing trailing whitespace after a deleted classifier. Non-valid classifiers are now correctly kept in the output and sorted alongside valid ones.

Fixes #242