### PR TITLE
⬆️ build(deps): update Rust and Python dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,7 +193,7 @@ nodes, or manipulate the tree structure directly. The tree maintains parent-chil
 modifications.
 
 ```rust
-let syntax = tombi_parser::parse(toml_str, TomlVersion::default())
+let syntax = tombi_parser::parse(toml_str)
     .syntax_node()
     .clone_for_update();
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,9 +983,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1024,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1276,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.192"
+version = "2.1.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a44aab7d263c3aa2716d68589ff0b1e3a54ad1642a7a28592f5e64626fe1d2d"
+checksum = "530defb7f90261f0f83c9af4534efe2e2e7912b265c7890fd402e55f60791fd4"
 dependencies = [
  "psl-types",
 ]
@@ -1574,9 +1574,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "tombi-accessor"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "indexmap",
  "itertools",
@@ -1991,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "tombi-ast"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "itertools",
  "thiserror",
@@ -2006,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "tombi-ast-editor"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "ahash",
  "indexmap",
@@ -2022,7 +2022,6 @@ dependencies = [
  "tombi-regex",
  "tombi-schema-store",
  "tombi-syntax",
- "tombi-toml-version",
  "tombi-validator",
  "tombi-version-sort",
  "tombi-x-keyword",
@@ -2031,7 +2030,7 @@ dependencies = [
 [[package]]
 name = "tombi-cache"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "dirs",
  "log",
@@ -2043,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "tombi-comment-directive"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "serde",
  "thiserror",
@@ -2057,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "tombi-comment-directive-serde"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "serde",
  "tombi-ast",
@@ -2070,7 +2069,7 @@ dependencies = [
 [[package]]
 name = "tombi-comment-directive-store"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "tokio",
  "tombi-json",
@@ -2081,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "tombi-config"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "serde",
  "thiserror",
@@ -2094,7 +2093,7 @@ dependencies = [
 [[package]]
 name = "tombi-date-time"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "chrono",
  "serde",
@@ -2104,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "tombi-diagnostic"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "nu-ansi-term",
  "serde",
@@ -2115,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "tombi-document"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2132,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "tombi-document-tree"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "chrono",
  "indexmap",
@@ -2151,14 +2150,13 @@ dependencies = [
 [[package]]
 name = "tombi-formatter"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "itertools",
  "log",
  "tokio",
  "tombi-ast",
  "tombi-ast-editor",
- "tombi-comment-directive",
  "tombi-config",
  "tombi-diagnostic",
  "tombi-parser",
@@ -2173,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "tombi-future"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "futures",
 ]
@@ -2181,7 +2179,7 @@ dependencies = [
 [[package]]
 name = "tombi-json"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "indexmap",
  "itertools",
@@ -2196,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "tombi-json-lexer"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "tombi-json-syntax",
  "tombi-regex",
@@ -2206,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "tombi-json-syntax"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "tombi-rg-tree",
 ]
@@ -2214,7 +2212,7 @@ dependencies = [
 [[package]]
 name = "tombi-json-value"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "indexmap",
  "serde",
@@ -2223,7 +2221,7 @@ dependencies = [
 [[package]]
 name = "tombi-lexer"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "tombi-regex",
  "tombi-syntax",
@@ -2233,14 +2231,13 @@ dependencies = [
 [[package]]
 name = "tombi-parser"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "drop_bomb",
  "itertools",
  "log",
  "thiserror",
  "tombi-ast",
- "tombi-config",
  "tombi-diagnostic",
  "tombi-lexer",
  "tombi-rg-tree",
@@ -2251,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "tombi-regex"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "fancy-regex",
 ]
@@ -2259,7 +2256,7 @@ dependencies = [
 [[package]]
 name = "tombi-rg-tree"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "countme",
  "hashbrown 0.15.5",
@@ -2271,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "tombi-schema-store"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "ahash",
  "bytes",
@@ -2299,7 +2296,7 @@ dependencies = [
 [[package]]
 name = "tombi-severity-level"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "serde",
 ]
@@ -2307,7 +2304,7 @@ dependencies = [
 [[package]]
 name = "tombi-syntax"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "thiserror",
  "tombi-rg-tree",
@@ -2316,7 +2313,7 @@ dependencies = [
 [[package]]
 name = "tombi-text"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "log",
  "serde",
@@ -2327,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "tombi-toml-text"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "thiserror",
  "tombi-toml-version",
@@ -2336,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "tombi-toml-version"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "clap",
  "serde",
@@ -2345,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "tombi-uri"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "serde",
  "url",
@@ -2354,7 +2351,7 @@ dependencies = [
 [[package]]
 name = "tombi-validator"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "addr",
  "ahash",
@@ -2384,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "tombi-version-sort"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "itertools",
 ]
@@ -2392,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "tombi-x-keyword"
 version = "0.0.0-dev"
-source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.31#74df128b7d4a00081c46a5d17e9095ed005ece61"
+source = "git+https://github.com/tombi-toml/tombi?tag=v0.7.32#debd1c7788764bb36a731c609b88d4a7ad168463"
 dependencies = [
  "serde",
 ]
@@ -2700,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2713,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "fe88540d1c934c4ec8e6db0afa536876c5441289d7f9f9123d4f065ac1250a6b"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2727,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2737,9 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2750,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
 dependencies = [
  "unicode-ident",
 ]
@@ -2793,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ pedantic = "warn"
 nursery = "warn"
 
 [workspace.dependencies]
-tombi-parser = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.31" }
-tombi-syntax = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.31" }
-tombi-formatter = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.31" }
-tombi-toml-text = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.31" }
-tombi-config = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.31" }
-tombi-schema-store = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.31" }
+tombi-parser = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.32" }
+tombi-syntax = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.32" }
+tombi-formatter = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.32" }
+tombi-toml-text = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.32" }
+tombi-config = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.32" }
+tombi-schema-store = { git = "https://github.com/tombi-toml/tombi", tag = "v0.7.32" }
 
 [workspace.lints.rust]

--- a/common/src/create.rs
+++ b/common/src/create.rs
@@ -8,7 +8,6 @@
 //! 2. **Proper escaping**: The parser handles all TOML escape sequences correctly
 //! 3. **Simplicity**: Straightforward code that's easy to understand and maintain
 
-use tombi_config::TomlVersion;
 use tombi_syntax::SyntaxElement;
 use tombi_syntax::SyntaxKind::{
     ARRAY, BASIC_STRING, COMMA, KEYS, LINE_BREAK, LITERAL_STRING, MULTI_LINE_BASIC_STRING, WHITESPACE,
@@ -20,9 +19,7 @@ fn escape(text: &str) -> String {
 }
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
-    tombi_parser::parse(source, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update()
+    tombi_parser::parse(source).syntax_node().clone_for_update()
 }
 
 pub fn make_multiline_string_node(wrapped: &str) -> SyntaxElement {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -34,9 +34,7 @@ pub mod test_util {
     }
 
     pub fn parse(source: &str) -> SyntaxNode {
-        tombi_parser::parse(source, TomlVersion::default())
-            .syntax_node()
-            .clone_for_update()
+        tombi_parser::parse(source).syntax_node().clone_for_update()
     }
 
     pub fn format_toml_str(source: &str, column_width: usize) -> String {

--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, HashSet};
 use std::iter::zip;
 use std::ops::Index;
 
-use tombi_config::TomlVersion;
 use tombi_syntax::SyntaxKind::{
     ARRAY_OF_TABLE, BARE_KEY, BASIC_STRING, BRACKET_END, BRACKET_START, COMMENT, DOUBLE_BRACKET_START, EQUAL,
     KEY_VALUE, KEYS, LINE_BREAK, LITERAL_STRING, TABLE, WHITESPACE,
@@ -71,9 +70,7 @@ fn filter_entries(table: &mut RefMut<Vec<SyntaxElement>>, entries_to_remove: &Ha
 use crate::string::load_text;
 
 fn parse(source: &str) -> SyntaxNode {
-    tombi_parser::parse(source, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update()
+    tombi_parser::parse(source).syntax_node().clone_for_update()
 }
 
 #[derive(Debug)]

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -1,5 +1,4 @@
 use indoc::indoc;
-use tombi_config::TomlVersion;
 use tombi_syntax::SyntaxKind::{ARRAY, KEY_VALUE};
 use tombi_syntax::SyntaxNode;
 
@@ -29,14 +28,10 @@ fn apply_to_arrays<F>(source: &str, mut f: F) -> String
 where
     F: FnMut(&SyntaxNode),
 {
-    let root_ast = tombi_parser::parse(source, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(source).syntax_node().clone_for_update();
     for_each_array(&root_ast, &mut f);
     let formatted = format_toml(&root_ast, 120);
-    let formatted_ast = tombi_parser::parse(&formatted, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let formatted_ast = tombi_parser::parse(&formatted).syntax_node().clone_for_update();
     align_array_comments(&formatted_ast);
     formatted_ast.to_string()
 }
@@ -45,9 +40,7 @@ fn apply_to_arrays_raw<F>(source: &str, mut f: F) -> String
 where
     F: FnMut(&SyntaxNode),
 {
-    let root_ast = tombi_parser::parse(source, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(source).syntax_node().clone_for_update();
     for_each_array(&root_ast, &mut f);
     let mut res = root_ast.to_string();
     res.retain(|x| !x.is_whitespace());
@@ -385,9 +378,7 @@ fn test_sort_with_duplicate_keys() {
           "pkg; marker2",
         ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for children in root_ast.children_with_tokens() {
         if children.kind() == KEY_VALUE {
             for entry in children.as_node().unwrap().children_with_tokens() {
@@ -411,9 +402,7 @@ fn test_ensure_trailing_comma() {
     let expected_raw = indoc! {r#"a = [
         "x", "y",
         ]"#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for children in root_ast.children_with_tokens() {
         if children.kind() == KEY_VALUE {
             for entry in children.as_node().unwrap().children_with_tokens() {
@@ -435,9 +424,7 @@ fn test_trailing_comma_prevents_collapse() {
           "y",
         ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for children in root_ast.children_with_tokens() {
         if children.kind() == KEY_VALUE {
             for entry in children.as_node().unwrap().children_with_tokens() {
@@ -457,9 +444,7 @@ fn test_ensure_all_arrays_multiline_no_duplicate() {
 build-backend = "backend"
 requires = ["c", "d"]
 "#;
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     let result = root_ast.to_string();
 
@@ -470,9 +455,7 @@ requires = ["c", "d"]
 #[test]
 fn test_ensure_all_arrays_multiline_empty_array() {
     let input = r#"a = []"#;
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     let result = root_ast.to_string();
     assert_eq!(result, r#"a = []"#);
@@ -481,9 +464,7 @@ fn test_ensure_all_arrays_multiline_empty_array() {
 #[test]
 fn test_ensure_all_arrays_multiline_already_multiline() {
     let input = "a = [\n  \"x\",\n]";
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     let result = root_ast.to_string();
     assert!(result.contains("\n"), "Should remain multiline");
@@ -493,9 +474,7 @@ fn test_ensure_all_arrays_multiline_already_multiline() {
 #[test]
 fn test_ensure_all_arrays_multiline_has_trailing_but_no_newline() {
     let input = r#"a = ["x",]"#;
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     let result = root_ast.to_string();
     assert!(result.contains("\n"), "Should add newlines, got: {}", result);
@@ -504,9 +483,7 @@ fn test_ensure_all_arrays_multiline_has_trailing_but_no_newline() {
 #[test]
 fn test_ensure_all_arrays_multiline_nested_arrays_no_trailing() {
     let input = r#"a = [["x", "y"], ["z"]]"#;
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     insta::assert_snapshot!(root_ast.to_string(), @r#"a = [["x", "y"], ["z"]]"#);
 }
@@ -514,9 +491,7 @@ fn test_ensure_all_arrays_multiline_nested_arrays_no_trailing() {
 #[test]
 fn test_ensure_all_arrays_multiline_nested_arrays_with_trailing() {
     let input = r#"a = [["x", "y",], ["z",],]"#;
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     insta::assert_snapshot!(root_ast.to_string(), @r#"
     a = [
@@ -537,9 +512,7 @@ fn test_ensure_all_arrays_multiline_no_magic_comma() {
           "y"
         ]
     "#};
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     insta::assert_snapshot!(root_ast.to_string(), @r#"
     a = [
@@ -557,9 +530,7 @@ fn test_align_simple() {
       "CPY",  # Comment 2
     ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     let result = root_ast.to_string();
 
@@ -579,9 +550,7 @@ fn test_align_multiple_arrays() {
       "S", # Short
     ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"
@@ -605,9 +574,7 @@ fn test_align_mixed_comments() {
       "C", # Another comment
     ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"
@@ -624,9 +591,7 @@ fn test_align_no_comments() {
     let start = indoc! {r#"
     a = ["A", "B", "C"]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"a = ["A", "B", "C"]"#);
@@ -640,9 +605,7 @@ fn test_align_very_long_value() {
       "SHORT", # Another
     ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"
@@ -660,9 +623,7 @@ fn test_align_single_item_with_comment() {
       "ITEM", # Comment
     ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"
@@ -685,9 +646,7 @@ fn test_align_nested_structure() {
       "Y", # Short
     ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"
@@ -706,9 +665,7 @@ fn test_align_nested_structure() {
 #[test]
 fn test_ensure_trailing_comma_empty_array() {
     let start = r#"a = []"#;
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for children in root_ast.children_with_tokens() {
         if children.kind() == KEY_VALUE {
             for entry in children.as_node().unwrap().children_with_tokens() {
@@ -724,9 +681,7 @@ fn test_ensure_trailing_comma_empty_array() {
 #[test]
 fn test_ensure_trailing_comma_already_multiline_with_comma() {
     let start = "a = [\n  \"x\",\n]";
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for children in root_ast.children_with_tokens() {
         if children.kind() == KEY_VALUE {
             for entry in children.as_node().unwrap().children_with_tokens() {
@@ -765,9 +720,7 @@ fn test_dedupe_with_inline_table() {
 #[test]
 fn test_sort_with_none_key() {
     let start = r#"a = [42, "B", "A"]"#;
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for children in root_ast.children_with_tokens() {
         if children.kind() == KEY_VALUE {
             for entry in children.as_node().unwrap().children_with_tokens() {
@@ -816,9 +769,7 @@ fn test_transform_literal_string_with_comment() {
 #[test]
 fn test_align_empty_array() {
     let start = r#"a = []"#;
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     insta::assert_snapshot!(root_ast.to_string(), @"a = []");
 }
@@ -826,9 +777,7 @@ fn test_align_empty_array() {
 #[test]
 fn test_align_array_no_string_values() {
     let start = r#"a = [1, 2, 3]"#;
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     insta::assert_snapshot!(root_ast.to_string(), @"a = [1, 2, 3]");
 }
@@ -843,9 +792,7 @@ fn test_dedupe_with_value_wrapper() {
       "bar",
     ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for descendant in root_ast.descendants() {
         if descendant.kind() == ARRAY {
             dedupe_strings(&descendant, |s| s.to_lowercase());
@@ -864,9 +811,7 @@ fn test_dedupe_with_value_wrapper() {
 #[test]
 fn test_sort_multiline_no_trailing_comma() {
     let start = "a = [\n  \"B\",\n  \"A\"\n]";
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for children in root_ast.children_with_tokens() {
         if children.kind() == KEY_VALUE {
             for entry in children.as_node().unwrap().children_with_tokens() {
@@ -895,9 +840,7 @@ fn test_align_comment_after_whitespace() {
       "verylongstring",   # another
     ]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     align_array_comments(&root_ast);
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"
@@ -911,9 +854,7 @@ fn test_align_comment_after_whitespace() {
 #[test]
 fn test_ensure_trailing_comma_single_item_no_comma() {
     let start = r#"a = ["only"]"#;
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for children in root_ast.children_with_tokens() {
         if children.kind() == KEY_VALUE {
             for entry in children.as_node().unwrap().children_with_tokens() {
@@ -952,9 +893,7 @@ fn test_dedupe_consecutive_duplicates() {
 #[test]
 fn test_dedupe_array_with_non_string_values() {
     let start = r#"a = [1, "foo", 2, "FOO", 3]"#;
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     for children in root_ast.children_with_tokens() {
         if children.kind() == KEY_VALUE {
             for entry in children.as_node().unwrap().children_with_tokens() {
@@ -1009,9 +948,7 @@ fn test_issue_184_comment_with_double_quotes_sort() {
 #[test]
 fn test_ensure_multiline_no_trailing_comma_exceeds_width() {
     let input = r#"a = ["very long string that exceeds column width"]"#;
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 30);
     insta::assert_snapshot!(root_ast.to_string(), @r#"
     a = [
@@ -1040,9 +977,7 @@ fn test_format_trailing_comment_no_comma() {
 fn test_issue_202_trailing_comment_preserves_single_line_array() {
     let input = r#"a = [ "x" ] # trailing comment
 "#;
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     let result = root_ast.to_string();
     assert!(
@@ -1060,9 +995,7 @@ fn test_comment_inside_array_triggers_multiline() {
     let input = r#"a = [ "x", # inline comment
 "y" ]
 "#;
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     let result = root_ast.to_string();
     assert!(
@@ -1076,9 +1009,7 @@ fn test_comment_in_nested_array_triggers_multiline() {
     let input = r#"a = [ [ "x" # nested comment
 ] ]
 "#;
-    let root_ast = tombi_parser::parse(input, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
     ensure_all_arrays_multiline(&root_ast, 120);
     let result = root_ast.to_string();
     assert!(

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -1,4 +1,3 @@
-use tombi_config::TomlVersion;
 use tombi_syntax::SyntaxKind::{
     BARE_KEY, BASIC_STRING, KEY_VALUE, LITERAL_STRING, MULTI_LINE_BASIC_STRING, MULTI_LINE_LITERAL_STRING,
 };
@@ -8,9 +7,7 @@ use crate::string::{
 };
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
-    tombi_parser::parse(source, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update()
+    tombi_parser::parse(source).syntax_node().clone_for_update()
 }
 
 fn is_string_kind(kind: tombi_syntax::SyntaxKind) -> bool {

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -1,5 +1,4 @@
 use indoc::indoc;
-use tombi_config::TomlVersion;
 
 use super::format_toml;
 use crate::table::{
@@ -8,9 +7,7 @@ use crate::table::{
 };
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
-    tombi_parser::parse(source, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update()
+    tombi_parser::parse(source).syntax_node().clone_for_update()
 }
 
 fn tables_reorder_helper(start: &str, order: &[&str]) -> String {

--- a/common/src/tests/util_tests.rs
+++ b/common/src/tests/util_tests.rs
@@ -1,14 +1,11 @@
 use std::cell::RefCell;
 
-use tombi_config::TomlVersion;
 use tombi_syntax::SyntaxKind::{BASIC_STRING, KEY_VALUE, KEYS};
 
 use crate::util::{find_first, iter, limit_blank_lines};
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
-    tombi_parser::parse(source, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update()
+    tombi_parser::parse(source).syntax_node().clone_for_update()
 }
 
 #[test]

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -3,11 +3,11 @@ use std::string::String;
 
 use pyo3::prelude::{PyModule, PyModuleMethods};
 use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult};
-use tombi_config::TomlVersion;
 
 use crate::global::reorder_tables;
 use common::array::ensure_all_arrays_multiline;
 use common::table::{apply_table_formatting, Tables};
+use tombi_config::TomlVersion;
 
 mod build_system;
 mod dependency_groups;
@@ -101,9 +101,7 @@ impl TableFormatConfig {
 }
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
-    tombi_parser::parse(source, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update()
+    tombi_parser::parse(source).syntax_node().clone_for_update()
 }
 
 async fn format_with_tombi(content: &str, column_width: usize, indent: usize) -> String {

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -4,8 +4,6 @@ use common::array::ensure_all_arrays_multiline;
 use common::table::{apply_table_formatting, Tables};
 use indoc::indoc;
 
-use tombi_config::TomlVersion;
-
 use crate::project::fix;
 use crate::tests::{assert_valid_toml, collect_entries, format_syntax, format_toml_str, parse};
 use crate::TableFormatConfig;
@@ -1002,9 +1000,7 @@ fn test_project_with_table_format_expand() {
         [project.urls]
         Homepage = "https://example.com"
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
     let table_config = TableFormatConfig {
         default_collapse: false,
@@ -1041,9 +1037,7 @@ fn test_project_with_collapse_specific_table() {
         Homepage = "https://example.com"
         Repository = "https://github.com/user/repo"
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
     let mut collapse_tables = HashSet::new();
     collapse_tables.insert("project.urls".to_string());
@@ -1079,9 +1073,7 @@ fn test_project_with_expand_specific_table() {
         urls.Homepage = "https://example.com"
         urls.Repository = "https://github.com/user/repo"
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
     let mut expand_tables = HashSet::new();
     expand_tables.insert("project.urls".to_string());
@@ -2052,9 +2044,7 @@ fn test_project_expand_authors_to_array_of_tables() {
         name = "test"
         authors = [{ name = "Alice", email = "alice@example.com" }, { name = "Bob" }]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
     let mut expand_tables = HashSet::new();
     expand_tables.insert("project.authors".to_string());
@@ -2086,9 +2076,7 @@ fn test_project_expand_maintainers_to_array_of_tables() {
         name = "test"
         maintainers = [{ name = "Charlie", email = "charlie@example.com" }]
     "#};
-    let root_ast = tombi_parser::parse(start, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update();
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
     let mut tables = Tables::from_ast(&root_ast);
     let mut expand_tables = HashSet::new();
     expand_tables.insert("project.maintainers".to_string());

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -3,8 +3,8 @@ use std::string::String;
 
 use pyo3::prelude::{PyModule, PyModuleMethods};
 use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult};
-use tombi_config::TomlVersion;
 
+use tombi_config::TomlVersion;
 use tombi_syntax::SyntaxKind::KEY_VALUE;
 
 use crate::global::{fix_envs, fix_root, normalize_aliases, normalize_strings, reorder_tables, sort_env_list};
@@ -87,9 +87,7 @@ impl TableFormatConfig {
 }
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
-    tombi_parser::parse(source, TomlVersion::default())
-        .syntax_node()
-        .clone_for_update()
+    tombi_parser::parse(source).syntax_node().clone_for_update()
 }
 
 async fn format_with_tombi(content: &str, column_width: usize, indent: usize) -> String {


### PR DESCRIPTION
Several Rust and Python dependencies were out of date, most notably tombi which moved from v0.7.31 to v0.7.32. 📦 The tombi update includes an API change where `tombi_parser::parse()` no longer accepts a `TomlVersion` parameter, so all call sites across `common`, `pyproject-fmt`, and `tox-toml-fmt` have been updated accordingly.

Other dependency bumps include pyo3 0.28.1 → 0.28.2, toml 1.0.2 → 1.0.3, and various Python package updates (filelock, virtualenv, tox). The `tox.toml` files across all packages now require tox >= 4.40.