### PR TITLE
🔧 ci(deps): reduce dependency update frequency to biweekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -2,7 +2,7 @@ name: 📦 update dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "0 8 1,15 * *"
 
 permissions:
   contents: write


### PR DESCRIPTION
Daily dependency update PRs create noise and churn without much benefit — most updates are patch-level bumps that don't need immediate attention. Slowing the cadence to biweekly keeps dependencies reasonably fresh while reducing PR volume.

The \`update_dependencies.yaml\` workflow cron changes from daily (\`0 8 * * *\`) to the 1st and 15th of each month (\`0 8 1,15 * *\`). Dependabot for GitHub Actions updates also slows from daily to weekly on Mondays.