### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   clippy:
     name: 📎 clippy

--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: 🔍 changes

--- a/.github/workflows/toml_fmt_common_test.yaml
+++ b/.github/workflows/toml_fmt_common_test.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: 🔍 changes

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: 🔍 changes


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to workflow files
- Satisfies the `actions/missing-workflow-permissions` code scanning rule
