### PR TITLE
✨ feat(common): add shared config file support

### DIFF
--- a/common/src/array.rs
+++ b/common/src/array.rs
@@ -4,9 +4,68 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use tombi_syntax::SyntaxKind::{
     ARRAY, BASIC_STRING, BRACKET_END, BRACKET_START, COMMA, COMMENT, DOUBLE_BRACKET_END, DOUBLE_BRACKET_START,
-    LINE_BREAK, LITERAL_STRING, WHITESPACE,
+    LINE_BREAK, LITERAL_STRING, VALUE_WITH_COMMA_GROUP, WHITESPACE,
 };
 use tombi_syntax::{SyntaxElement, SyntaxKind, SyntaxNode};
+
+fn flat_array_children(array: &SyntaxNode) -> Vec<SyntaxElement> {
+    let mut result = Vec::new();
+    for child in array.children_with_tokens() {
+        if child.kind() == VALUE_WITH_COMMA_GROUP {
+            for inner in child.as_node().unwrap().children_with_tokens() {
+                unwrap_leading_trivia(&mut result, inner);
+            }
+        } else {
+            result.push(child);
+        }
+    }
+    result
+}
+
+fn unwrap_leading_trivia(result: &mut Vec<SyntaxElement>, elem: SyntaxElement) {
+    if !is_array_value(elem.kind()) || elem.as_node().is_none() {
+        result.push(elem);
+        return;
+    }
+    let node = elem.as_node().unwrap();
+    let children: Vec<_> = node.children_with_tokens().collect();
+    let leading_count = children
+        .iter()
+        .take_while(|c| matches!(c.kind(), LINE_BREAK | WHITESPACE))
+        .count();
+    if leading_count == 0 {
+        result.push(elem);
+        return;
+    }
+    for child in &children[..leading_count] {
+        result.push(child.clone());
+    }
+    let remaining: Vec<_> = children[leading_count..].to_vec();
+    let trailing_comment_start = remaining
+        .iter()
+        .position(|c| matches!(c.kind(), WHITESPACE | COMMENT) && !is_array_value(c.kind()))
+        .filter(|&pos| {
+            remaining[pos..]
+                .iter()
+                .all(|c| matches!(c.kind(), WHITESPACE | COMMENT))
+        });
+    if let Some(tcs) = trailing_comment_start {
+        node.splice_children(0..children.len(), remaining[..tcs].to_vec());
+        result.push(elem);
+        for child in &remaining[tcs..] {
+            result.push(child.clone());
+        }
+    } else {
+        node.splice_children(0..children.len(), remaining);
+        result.push(elem);
+    }
+}
+
+fn flatten_array_in_place(array: &SyntaxNode) {
+    let count = array.children_with_tokens().count();
+    let flat = flat_array_children(array);
+    array.splice_children(0..count, flat);
+}
 
 use crate::create::{make_comma, make_newline, make_whitespace_n};
 use crate::string::{load_text, update_content};
@@ -26,18 +85,18 @@ fn is_array_value(kind: SyntaxKind) -> bool {
 }
 
 fn has_trailing_comma(array: &SyntaxNode) -> bool {
-    array
-        .children_with_tokens()
-        .filter(|x| x.kind() == COMMA || is_array_value(x.kind()))
-        .last()
+    flat_array_children(array)
+        .iter()
+        .rfind(|x| x.kind() == COMMA || is_array_value(x.kind()))
         .is_some_and(|x| x.kind() == COMMA)
 }
 
 fn is_multiline(array: &SyntaxNode) -> bool {
-    array.children_with_tokens().any(|x| x.kind() == LINE_BREAK)
+    flat_array_children(array).iter().any(|x| x.kind() == LINE_BREAK)
 }
 
 fn add_trailing_comma_if_missing(array: &SyntaxNode) {
+    flatten_array_in_place(array);
     if let Some((i, _)) = array
         .children_with_tokens()
         .enumerate()
@@ -49,6 +108,7 @@ fn add_trailing_comma_if_missing(array: &SyntaxNode) {
 }
 
 fn insert_newlines_around_content(array: &SyntaxNode) {
+    flatten_array_in_place(array);
     if let Some((start_idx, _)) = array
         .children_with_tokens()
         .enumerate()
@@ -66,6 +126,7 @@ fn insert_newlines_around_content(array: &SyntaxNode) {
 }
 
 pub fn ensure_trailing_comma(array: &SyntaxNode) {
+    flatten_array_in_place(array);
     if !array.children_with_tokens().any(|x| is_array_value(x.kind())) {
         return;
     }
@@ -87,14 +148,14 @@ pub fn ensure_trailing_comma(array: &SyntaxNode) {
 }
 
 pub fn ensure_all_arrays_multiline(root: &SyntaxNode, column_width: usize) {
-    for descendant in root.descendants() {
-        if descendant.kind() == ARRAY {
-            ensure_array_multiline(&descendant, column_width);
-        }
+    let arrays: Vec<_> = root.descendants().filter(|d| d.kind() == ARRAY).collect();
+    for array in arrays.iter().rev() {
+        ensure_array_multiline(array, column_width);
     }
 }
 
 fn ensure_array_multiline(array: &SyntaxNode, column_width: usize) {
+    flatten_array_in_place(array);
     if !array.children_with_tokens().any(|x| is_array_value(x.kind())) {
         return;
     }
@@ -118,7 +179,7 @@ fn ensure_array_multiline(array: &SyntaxNode, column_width: usize) {
 }
 
 fn has_comment_before_bracket_end(array: &SyntaxNode) -> bool {
-    let children: Vec<_> = array.children_with_tokens().collect();
+    let children: Vec<_> = flat_array_children(array);
     let mut seen_bracket_end = false;
     for child in children.iter().rev() {
         if child.kind() == BRACKET_END {
@@ -140,6 +201,7 @@ pub fn transform<F>(array: &SyntaxNode, transform: &F)
 where
     F: Fn(&str) -> String,
 {
+    flatten_array_in_place(array);
     for entry in array.children_with_tokens() {
         if (entry.kind() == BASIC_STRING || entry.kind() == LITERAL_STRING)
             && let Some(string_node) = entry.as_node()
@@ -156,6 +218,7 @@ where
     C: Fn(&T, &T) -> Ordering,
     T: Clone + Eq + Hash,
 {
+    flatten_array_in_place(array);
     let has_trailing_comma = array
         .children_with_tokens()
         .map(|x| x.kind())
@@ -311,6 +374,7 @@ pub fn dedupe_strings<K>(array: &SyntaxNode, to_key: K)
 where
     K: Fn(&str) -> String,
 {
+    flatten_array_in_place(array);
     let mut seen: HashSet<String> = HashSet::new();
     let mut to_insert: Vec<SyntaxElement> = Vec::new();
     let mut skip_until_next_value = false;
@@ -365,14 +429,14 @@ where
 }
 
 pub fn align_array_comments(root: &SyntaxNode) {
-    for descendant in root.descendants() {
-        if descendant.kind() == ARRAY {
-            align_comments_in_array(&descendant);
-        }
+    let arrays: Vec<_> = root.descendants().filter(|d| d.kind() == ARRAY).collect();
+    for array in arrays.iter().rev() {
+        align_comments_in_array(array);
     }
 }
 
 fn align_comments_in_array(array: &SyntaxNode) {
+    flatten_array_in_place(array);
     let mut max_value_len = 0;
     let elements: Vec<_> = array.children_with_tokens().collect();
     let mut value_indices = Vec::new();

--- a/common/src/create.rs
+++ b/common/src/create.rs
@@ -8,25 +8,50 @@
 //! 2. **Proper escaping**: The parser handles all TOML escape sequences correctly
 //! 3. **Simplicity**: Straightforward code that's easy to understand and maintain
 
-use tombi_syntax::SyntaxElement;
 use tombi_syntax::SyntaxKind::{
-    ARRAY, BASIC_STRING, COMMA, KEYS, LINE_BREAK, LITERAL_STRING, MULTI_LINE_BASIC_STRING, WHITESPACE,
+    ARRAY, BASIC_STRING, COMMA, COMMENT, KEY_VALUE_GROUP, KEYS, LINE_BREAK, LITERAL_STRING, MULTI_LINE_BASIC_STRING,
+    VALUE_WITH_COMMA_GROUP, WHITESPACE,
 };
+use tombi_syntax::{SyntaxElement, SyntaxNode};
 
 fn escape(text: &str) -> String {
     let escaped = tombi_toml_text::to_basic_string(text);
     escaped[1..escaped.len() - 1].to_string()
 }
 
-fn parse(source: &str) -> tombi_syntax::SyntaxNode {
+fn parse(source: &str) -> SyntaxNode {
     tombi_parser::parse(source).syntax_node().clone_for_update()
+}
+
+fn first_key_value(root: &SyntaxNode) -> SyntaxNode {
+    let first = root.first_child().expect("parsed TOML has children");
+    if first.kind() == KEY_VALUE_GROUP {
+        first.first_child().expect("KEY_VALUE_GROUP has KEY_VALUE")
+    } else {
+        first
+    }
+}
+
+fn find_in_array(array_node: &SyntaxNode, target: tombi_syntax::SyntaxKind) -> Option<SyntaxElement> {
+    for child in array_node.children_with_tokens() {
+        if child.kind() == target {
+            return Some(child);
+        }
+        if child.kind() == VALUE_WITH_COMMA_GROUP {
+            for inner in child.as_node().unwrap().children_with_tokens() {
+                if inner.kind() == target {
+                    return Some(inner);
+                }
+            }
+        }
+    }
+    None
 }
 
 pub fn make_multiline_string_node(wrapped: &str) -> SyntaxElement {
     let expr = format!("a = {wrapped}");
-    parse(&expr)
-        .first_child()
-        .expect("parsed TOML has a child")
+    let root = parse(&expr);
+    first_key_value(&root)
         .children_with_tokens()
         .find(|n| n.kind() == MULTI_LINE_BASIC_STRING)
         .expect("KEY_VALUE contains MULTI_LINE_BASIC_STRING")
@@ -39,9 +64,8 @@ pub fn make_multiline_string_node(wrapped: &str) -> SyntaxElement {
 pub fn make_string_node(text: &str) -> SyntaxElement {
     let escaped = escape(text);
     let expr = format!("a = \"{escaped}\"");
-    parse(&expr)
-        .first_child()
-        .expect("parsed TOML has a child")
+    let root = parse(&expr);
+    first_key_value(&root)
         .children_with_tokens()
         .find(|n| n.kind() == BASIC_STRING)
         .expect("KEY_VALUE contains BASIC_STRING")
@@ -53,9 +77,8 @@ pub fn make_string_node(text: &str) -> SyntaxElement {
 /// Content must not contain single quotes (there's no way to escape them in literal strings).
 pub fn make_literal_string_node(text: &str) -> SyntaxElement {
     let expr = format!("a = '{text}'");
-    parse(&expr)
-        .first_child()
-        .expect("parsed TOML has a child")
+    let root = parse(&expr);
+    first_key_value(&root)
         .children_with_tokens()
         .find(|n| n.kind() == LITERAL_STRING)
         .expect("KEY_VALUE contains LITERAL_STRING")
@@ -80,45 +103,45 @@ pub fn make_newline() -> SyntaxElement {
         .expect("parsed newline contains LINE_BREAK")
 }
 
+pub fn make_comment(text: &str) -> SyntaxElement {
+    let src = format!("{text}\na = 1\n");
+    let root = parse(&src);
+    for c in root.descendants_with_tokens() {
+        if c.kind() == COMMENT {
+            return c;
+        }
+    }
+    unreachable!("parsed comment TOML contains COMMENT")
+}
+
 /// Create a COMMA token for use in arrays.
 pub fn make_comma() -> SyntaxElement {
-    parse("a=[1,2]")
-        .first_child()
-        .expect("parsed TOML has KEY_VALUE")
+    let root = parse("a=[1,2]");
+    let array_node = first_key_value(&root)
         .children_with_tokens()
         .find(|n| n.kind() == ARRAY)
-        .expect("KEY_VALUE has ARRAY")
-        .as_node()
-        .expect("ARRAY is a node")
-        .children_with_tokens()
-        .find(|n| n.kind() == COMMA)
-        .expect("ARRAY contains COMMA")
+        .expect("KEY_VALUE has ARRAY");
+    find_in_array(array_node.as_node().unwrap(), COMMA).expect("ARRAY contains COMMA")
 }
 
 /// Create a WHITESPACE token with a custom number of spaces.
 pub fn make_whitespace_n(count: usize) -> SyntaxElement {
     let spaces = " ".repeat(count.max(1));
     let sample = format!("a=[1,{}2]", spaces);
-    parse(&sample)
-        .first_child()
-        .expect("parsed TOML has KEY_VALUE")
+    let root = parse(&sample);
+    let array_node = first_key_value(&root)
         .children_with_tokens()
         .find(|n| n.kind() == ARRAY)
-        .expect("KEY_VALUE has ARRAY")
-        .as_node()
-        .expect("ARRAY is a node")
-        .children_with_tokens()
-        .find(|n| n.kind() == WHITESPACE)
-        .expect("ARRAY contains WHITESPACE")
+        .expect("KEY_VALUE has ARRAY");
+    find_in_array(array_node.as_node().unwrap(), WHITESPACE).expect("ARRAY contains WHITESPACE")
 }
 
 /// Create a KEYS node with the given text.
 ///
 /// Supports dotted keys like `"foo.bar"`.
 pub fn make_key(text: &str) -> SyntaxElement {
-    parse(format!("{text}=1").as_str())
-        .first_child()
-        .expect("parsed TOML has KEY_VALUE")
+    let root = parse(format!("{text}=1").as_str());
+    first_key_value(&root)
         .children_with_tokens()
         .find(|n| n.kind() == KEYS)
         .expect("KEY_VALUE has KEYS")
@@ -126,41 +149,30 @@ pub fn make_key(text: &str) -> SyntaxElement {
 
 pub fn make_array(key: &str) -> SyntaxElement {
     let txt = format!("{key} = []");
-    parse(txt.as_str())
-        .first_child()
-        .map(SyntaxElement::Node)
-        .expect("parsed array has KEY_VALUE")
+    let root = parse(txt.as_str());
+    SyntaxElement::Node(first_key_value(&root))
 }
 
 pub fn make_array_entry(key: &str) -> SyntaxElement {
     let txt = format!("a = [\"{key}\"]");
-    parse(txt.as_str())
-        .first_child()
-        .expect("parsed TOML has KEY_VALUE")
+    let root = parse(txt.as_str());
+    let array_node = first_key_value(&root)
         .children_with_tokens()
         .find(|n| n.kind() == ARRAY)
-        .expect("KEY_VALUE has ARRAY")
-        .as_node()
-        .expect("ARRAY is a node")
-        .children_with_tokens()
-        .find(|n| n.kind() == BASIC_STRING)
-        .expect("ARRAY contains BASIC_STRING")
+        .expect("KEY_VALUE has ARRAY");
+    find_in_array(array_node.as_node().unwrap(), BASIC_STRING).expect("ARRAY contains BASIC_STRING")
 }
 
 pub fn make_entry_of_string(key: &String, value: &String) -> SyntaxElement {
     let txt = format!("{key} = \"{value}\"\n");
-    parse(txt.as_str())
-        .first_child()
-        .map(SyntaxElement::Node)
-        .expect("parsed entry has KEY_VALUE")
+    let root = parse(txt.as_str());
+    SyntaxElement::Node(first_key_value(&root))
 }
 
 pub fn make_empty_inline_table(key: &str) -> SyntaxElement {
     let txt = format!("{key} = {{}}\n");
-    parse(txt.as_str())
-        .first_child()
-        .map(SyntaxElement::Node)
-        .expect("parsed entry has KEY_VALUE")
+    let root = parse(txt.as_str());
+    SyntaxElement::Node(first_key_value(&root))
 }
 
 pub fn make_table_entry(key: &str) -> Vec<SyntaxElement> {
@@ -171,10 +183,8 @@ pub fn make_table_entry(key: &str) -> Vec<SyntaxElement> {
 pub fn make_entry_with_array_of_inline_tables(key: &str, inline_tables: &[String]) -> SyntaxElement {
     let tables_str = inline_tables.join(", ");
     let txt = format!("{key} = [{tables_str}]\n");
-    parse(txt.as_str())
-        .first_child()
-        .map(SyntaxElement::Node)
-        .expect("parsed entry has KEY_VALUE")
+    let root = parse(txt.as_str());
+    SyntaxElement::Node(first_key_value(&root))
 }
 
 /// Create an array of tables entry (e.g., `[[project.authors]]`)

--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -4,8 +4,9 @@ use std::iter::zip;
 use std::ops::Index;
 
 use tombi_syntax::SyntaxKind::{
-    ARRAY_OF_TABLE, BARE_KEY, BASIC_STRING, BRACKET_END, BRACKET_START, COMMENT, DOUBLE_BRACKET_START, EQUAL,
-    KEY_VALUE, KEYS, LINE_BREAK, LITERAL_STRING, TABLE, WHITESPACE,
+    ARRAY_OF_TABLE, BARE_KEY, BASIC_STRING, BRACKET_END, BRACKET_START, COMMENT, DANGLING_COMMENT_GROUP,
+    DOUBLE_BRACKET_START, EQUAL, KEY_VALUE, KEY_VALUE_GROUP, KEY_VALUE_WITH_COMMA_GROUP, KEYS, LINE_BREAK,
+    LITERAL_STRING, TABLE, WHITESPACE,
 };
 use tombi_syntax::{SyntaxElement, SyntaxKind, SyntaxNode};
 
@@ -71,6 +72,51 @@ use crate::string::load_text;
 
 fn parse(source: &str) -> SyntaxNode {
     tombi_parser::parse(source).syntax_node().clone_for_update()
+}
+
+fn flatten_key_value_group(group: &SyntaxNode, entry_set: &RefCell<Vec<SyntaxElement>>) {
+    for child in group.children_with_tokens() {
+        entry_set.borrow_mut().push(child);
+    }
+}
+
+fn collapse_consecutive_line_breaks(entries: &mut Vec<SyntaxElement>) {
+    let mut collapsed = Vec::new();
+    let mut prev_was_newline = false;
+    for element in entries.iter() {
+        if element.kind() == LINE_BREAK {
+            if !prev_was_newline {
+                collapsed.push(element.clone());
+            }
+            prev_was_newline = true;
+        } else {
+            prev_was_newline = false;
+            collapsed.push(element.clone());
+        }
+    }
+    entries.splice(0..entries.len(), collapsed);
+}
+
+fn has_leading_newline(element: &SyntaxElement) -> bool {
+    element
+        .as_node()
+        .is_some_and(|n| n.children_with_tokens().next().is_some_and(|c| c.kind() == LINE_BREAK))
+}
+
+fn find_key_value_in_parsed(root: &SyntaxNode) -> Option<SyntaxElement> {
+    for c in root.children_with_tokens() {
+        if c.kind() == KEY_VALUE {
+            return Some(c);
+        }
+        if c.kind() == KEY_VALUE_GROUP {
+            for kv in c.as_node().unwrap().children_with_tokens() {
+                if kv.kind() == KEY_VALUE {
+                    return Some(kv);
+                }
+            }
+        }
+    }
+    None
 }
 
 #[derive(Debug)]
@@ -146,6 +192,8 @@ impl Tables {
                     }
                 }
 
+                collapse_consecutive_line_breaks(&mut borrow);
+
                 drop(borrow);
 
                 add_to_table_set(table_kind, &current_table_name);
@@ -154,17 +202,22 @@ impl Tables {
 
                 entry_set.borrow_mut().extend(comments_for_new_table);
 
-                // For both TABLE and ARRAY_OF_TABLE, push all children
-                // We don't push the parent node to avoid duplication
                 if let Some(table_node) = c.as_node() {
                     for child in table_node.children_with_tokens() {
-                        entry_set.borrow_mut().push(child);
+                        if child.kind() == KEY_VALUE_GROUP || child.kind() == DANGLING_COMMENT_GROUP {
+                            flatten_key_value_group(child.as_node().unwrap(), &entry_set);
+                        } else {
+                            entry_set.borrow_mut().push(child);
+                        }
                     }
                 }
+            } else if c.kind() == KEY_VALUE_GROUP || c.kind() == DANGLING_COMMENT_GROUP {
+                flatten_key_value_group(c.as_node().unwrap(), &entry_set);
             } else {
                 entry_set.borrow_mut().push(c);
             }
         }
+        collapse_consecutive_line_breaks(&mut entry_set.borrow_mut());
         add_to_table_set(table_kind, &current_table_name);
         Self {
             header_to_pos,
@@ -319,7 +372,12 @@ pub fn reorder_table_keys(table: &mut RefMut<Vec<SyntaxElement>>, order: &[&str]
         matching_keys.sort_by_key(|key| key.to_lowercase());
         for key in matching_keys {
             let position = key_to_position[key];
-            if !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
+            let first_has_leading = key_set[position].first().is_some_and(has_leading_newline);
+            if first_has_leading {
+                while to_insert.last().is_some_and(|e| e.kind() == LINE_BREAK) {
+                    to_insert.pop();
+                }
+            } else if !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
                 to_insert.push(make_newline());
             }
             to_insert.extend(key_set[position].clone());
@@ -333,7 +391,12 @@ pub fn reorder_table_keys(table: &mut RefMut<Vec<SyntaxElement>>, order: &[&str]
         .collect();
     unhandled.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
     for (_, position) in unhandled {
-        if !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
+        let first_has_leading = key_set[position].first().is_some_and(has_leading_newline);
+        if first_has_leading {
+            while to_insert.last().is_some_and(|e| e.kind() == LINE_BREAK) {
+                to_insert.pop();
+            }
+        } else if !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
             to_insert.push(make_newline());
         }
         to_insert.extend(key_set[position].clone());
@@ -446,12 +509,25 @@ pub fn rename_keys(table: &mut RefMut<Vec<SyntaxElement>>, aliases: &[(&str, &st
 pub fn find_key(table: &SyntaxNode, key: &str) -> Option<SyntaxNode> {
     let mut current_key = String::new();
     for table_entry in table.children_with_tokens() {
-        if table_entry.kind() == KEY_VALUE {
+        let kind = table_entry.kind();
+        if kind == KEY_VALUE {
             for entry in table_entry.as_node().unwrap().children_with_tokens() {
                 if entry.kind() == KEYS {
                     current_key = entry.as_node().unwrap().text().to_string().trim().to_string();
                 } else if is_value_kind(entry.kind()) && current_key == key {
                     return Some(entry.as_node().unwrap().clone());
+                }
+            }
+        } else if kind == KEY_VALUE_GROUP || kind == KEY_VALUE_WITH_COMMA_GROUP {
+            for kv in table_entry.as_node().unwrap().children_with_tokens() {
+                if kv.kind() == KEY_VALUE {
+                    for entry in kv.as_node().unwrap().children_with_tokens() {
+                        if entry.kind() == KEYS {
+                            current_key = entry.as_node().unwrap().text().to_string().trim().to_string();
+                        } else if is_value_kind(entry.kind()) && current_key == key {
+                            return Some(entry.as_node().unwrap().clone());
+                        }
+                    }
                 }
             }
         }
@@ -536,7 +612,8 @@ pub fn collapse_sub_tables(tables: &mut Tables, name: &str) {
                 }
                 child_node.splice_children(0..to_insert.len(), to_insert);
             }
-            if main.last().unwrap().kind() != LINE_BREAK {
+            let kind = child.kind();
+            if main.last().unwrap().kind() != LINE_BREAK && kind != LINE_BREAK && !has_leading_newline(child) {
                 main.push(make_newline());
             }
             main.push(child.clone());
@@ -595,7 +672,7 @@ pub fn expand_sub_tables(tables: &mut Tables, name: &str) {
 
             let new_entry_text = format!("{simple_key} ={value_text}\n");
             let parsed_root = parse(&new_entry_text);
-            if let Some(entry) = parsed_root.children_with_tokens().find(|c| c.kind() == KEY_VALUE) {
+            if let Some(entry) = find_key_value_in_parsed(&parsed_root) {
                 new_table.push(entry);
             }
         }
@@ -684,7 +761,7 @@ pub fn collapse_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str
             }
             child_node.splice_children(0..to_insert.len(), to_insert);
         }
-        if main.last().unwrap().kind() != LINE_BREAK {
+        if main.last().unwrap().kind() != LINE_BREAK && kind != LINE_BREAK && !has_leading_newline(child) {
             main.push(make_newline());
         }
         main.push(child.clone());
@@ -819,7 +896,7 @@ fn collapse_array_of_tables(
     }
 
     let parsed_root = parse(&entry_text);
-    if let Some(entry) = parsed_root.children_with_tokens().find(|c| c.kind() == KEY_VALUE) {
+    if let Some(entry) = find_key_value_in_parsed(&parsed_root) {
         main.push(entry);
     }
 
@@ -873,7 +950,11 @@ pub fn expand_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str) 
         let new_entry_text = format!("{simple_key} ={value_text}\n");
         let parsed_root = parse(&new_entry_text);
         for child in parsed_root.children_with_tokens() {
-            if child.kind() == KEY_VALUE || child.kind() == LINE_BREAK {
+            if child.kind() == KEY_VALUE_GROUP {
+                for kv in child.as_node().unwrap().children_with_tokens() {
+                    new_table.push(kv);
+                }
+            } else if child.kind() == KEY_VALUE || child.kind() == LINE_BREAK {
                 new_table.push(child);
             }
         }

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -1,5 +1,5 @@
 use indoc::indoc;
-use tombi_syntax::SyntaxKind::{ARRAY, KEY_VALUE};
+use tombi_syntax::SyntaxKind::{ARRAY, KEY_VALUE, KEY_VALUE_GROUP};
 use tombi_syntax::SyntaxNode;
 
 use crate::array::{
@@ -9,19 +9,34 @@ use crate::array::{
 use crate::pep508::Requirement;
 use crate::tests::{format_toml, format_toml_str};
 
-fn for_each_array<F>(root: &SyntaxNode, mut f: F)
+fn for_each_key_value<F>(root: &SyntaxNode, mut f: F)
 where
     F: FnMut(&SyntaxNode),
 {
-    for children in root.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    f(entry.as_node().unwrap());
+    for child in root.children_with_tokens() {
+        if child.kind() == KEY_VALUE {
+            f(child.as_node().unwrap());
+        } else if child.kind() == KEY_VALUE_GROUP {
+            for kv in child.as_node().unwrap().children_with_tokens() {
+                if kv.kind() == KEY_VALUE {
+                    f(kv.as_node().unwrap());
                 }
             }
         }
     }
+}
+
+fn for_each_array<F>(root: &SyntaxNode, mut f: F)
+where
+    F: FnMut(&SyntaxNode),
+{
+    for_each_key_value(root, |kv_node| {
+        for entry in kv_node.children_with_tokens() {
+            if entry.kind() == ARRAY {
+                f(entry.as_node().unwrap());
+            }
+        }
+    });
 }
 
 fn apply_to_arrays<F>(source: &str, mut f: F) -> String
@@ -379,19 +394,13 @@ fn test_sort_with_duplicate_keys() {
         ]
     "#};
     let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
-    for children in root_ast.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    sort_strings::<String, _, _>(
-                        entry.as_node().unwrap(),
-                        |s| s.split(';').next().unwrap_or(&s).trim().to_lowercase(),
-                        &|lhs, rhs| lhs.cmp(rhs),
-                    );
-                }
-            }
-        }
-    }
+    for_each_array(&root_ast, |array| {
+        sort_strings::<String, _, _>(
+            array,
+            |s| s.split(';').next().unwrap_or(&s).trim().to_lowercase(),
+            &|lhs, rhs| lhs.cmp(rhs),
+        );
+    });
     let res = format_toml(&root_ast, 120);
     assert_eq!(res, expected);
 }
@@ -403,15 +412,9 @@ fn test_ensure_trailing_comma() {
         "x", "y",
         ]"#};
     let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
-    for children in root_ast.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    ensure_trailing_comma(entry.as_node().unwrap());
-                }
-            }
-        }
-    }
+    for_each_array(&root_ast, |array| {
+        ensure_trailing_comma(array);
+    });
     assert_eq!(root_ast.to_string(), expected_raw);
 }
 
@@ -425,15 +428,9 @@ fn test_trailing_comma_prevents_collapse() {
         ]
     "#};
     let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
-    for children in root_ast.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    ensure_trailing_comma(entry.as_node().unwrap());
-                }
-            }
-        }
-    }
+    for_each_array(&root_ast, |array| {
+        ensure_trailing_comma(array);
+    });
     let res = format_toml(&root_ast, 120);
     assert_eq!(res, expected);
 }
@@ -666,15 +663,9 @@ fn test_align_nested_structure() {
 fn test_ensure_trailing_comma_empty_array() {
     let start = r#"a = []"#;
     let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
-    for children in root_ast.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    ensure_trailing_comma(entry.as_node().unwrap());
-                }
-            }
-        }
-    }
+    for_each_array(&root_ast, |array| {
+        ensure_trailing_comma(array);
+    });
     insta::assert_snapshot!(root_ast.to_string(), @"a = []");
 }
 
@@ -682,15 +673,9 @@ fn test_ensure_trailing_comma_empty_array() {
 fn test_ensure_trailing_comma_already_multiline_with_comma() {
     let start = "a = [\n  \"x\",\n]";
     let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
-    for children in root_ast.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    ensure_trailing_comma(entry.as_node().unwrap());
-                }
-            }
-        }
-    }
+    for_each_array(&root_ast, |array| {
+        ensure_trailing_comma(array);
+    });
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"
     a = [
@@ -721,15 +706,9 @@ fn test_dedupe_with_inline_table() {
 fn test_sort_with_none_key() {
     let start = r#"a = [42, "B", "A"]"#;
     let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
-    for children in root_ast.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    sort::<String, _, _>(entry.as_node().unwrap(), |_| None, &|lhs, rhs| lhs.cmp(rhs));
-                }
-            }
-        }
-    }
+    for_each_array(&root_ast, |array| {
+        sort::<String, _, _>(array, |_| None, &|lhs, rhs| lhs.cmp(rhs));
+    });
     let res = root_ast.to_string();
     insta::assert_snapshot!(res, @r#"a = [42, "B", "A"]"#);
 }
@@ -812,17 +791,9 @@ fn test_dedupe_with_value_wrapper() {
 fn test_sort_multiline_no_trailing_comma() {
     let start = "a = [\n  \"B\",\n  \"A\"\n]";
     let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
-    for children in root_ast.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    sort_strings::<String, _, _>(entry.as_node().unwrap(), |s| s.to_lowercase(), &|lhs, rhs| {
-                        lhs.cmp(rhs)
-                    });
-                }
-            }
-        }
-    }
+    for_each_array(&root_ast, |array| {
+        sort_strings::<String, _, _>(array, |s| s.to_lowercase(), &|lhs, rhs| lhs.cmp(rhs));
+    });
     let res = root_ast.to_string();
     insta::assert_snapshot!(res, @r#"
     a = [
@@ -855,15 +826,9 @@ fn test_align_comment_after_whitespace() {
 fn test_ensure_trailing_comma_single_item_no_comma() {
     let start = r#"a = ["only"]"#;
     let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
-    for children in root_ast.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    ensure_trailing_comma(entry.as_node().unwrap());
-                }
-            }
-        }
-    }
+    for_each_array(&root_ast, |array| {
+        ensure_trailing_comma(array);
+    });
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"
     a = [
@@ -894,15 +859,9 @@ fn test_dedupe_consecutive_duplicates() {
 fn test_dedupe_array_with_non_string_values() {
     let start = r#"a = [1, "foo", 2, "FOO", 3]"#;
     let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
-    for children in root_ast.children_with_tokens() {
-        if children.kind() == KEY_VALUE {
-            for entry in children.as_node().unwrap().children_with_tokens() {
-                if entry.kind() == ARRAY {
-                    dedupe_strings(entry.as_node().unwrap(), |s| s.to_lowercase());
-                }
-            }
-        }
-    }
+    for_each_array(&root_ast, |array| {
+        dedupe_strings(array, |s| s.to_lowercase());
+    });
     let res = root_ast.to_string();
     insta::assert_snapshot!(res, @r#"a = [1, "foo", 2, 3]"#);
 }
@@ -968,7 +927,7 @@ fn test_format_trailing_comment_no_comma() {
     insta::assert_snapshot!(res, @r#"
     a = [
       "a",
-      "b",  # comment
+      "b"  # comment
     ]
     "#);
 }

--- a/common/src/tests/mod.rs
+++ b/common/src/tests/mod.rs
@@ -18,3 +18,39 @@ pub fn format_toml(node: &SyntaxNode, column_width: usize) -> String {
 fn test_assert_valid_toml_panics_on_invalid() {
     crate::test_util::assert_valid_toml("invalid = [");
 }
+
+#[test]
+fn test_tombi_format_with_tables() {
+    let input = indoc::indoc! {r#"
+        requires = ["tox>=4.22"]
+        env_list = ["3.13", "3.12"]
+        skip_missing_interpreters = true
+
+        [env_run_base]
+        description = "run the tests with pytest under {env_name}"
+        commands = [["pytest"]]
+
+        [env.type]
+        description = "run type check on code base"
+        commands = [["mypy", "src{/}tox_toml_fmt"], ["mypy", "tests"]]
+    "#};
+    let result = format_toml_str(input, 80);
+    assert!(
+        result.contains("[env_run_base]"),
+        "tables should be preserved, got:\n{result}"
+    );
+    crate::test_util::assert_valid_toml(&result);
+}
+
+#[test]
+fn test_tombi_format_no_trailing_newline() {
+    let input = "requires = [\"tox>=4.22\"]\nenv_list = [\"3.13\", \"3.12\"]\nskip_missing_interpreters = true\n[env_run_base]\ndescription = \"run the tests\"\ncommands = [[\"pytest\"]]\n";
+    let result = format_toml_str(input, 80);
+    eprintln!("INPUT:\n{input}");
+    eprintln!("FORMATTED:\n{result}");
+    assert!(
+        result.contains("[env_run_base]"),
+        "tables should be preserved, got:\n{result}"
+    );
+    crate::test_util::assert_valid_toml(&result);
+}

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -1,5 +1,6 @@
 use tombi_syntax::SyntaxKind::{
-    BARE_KEY, BASIC_STRING, KEY_VALUE, LITERAL_STRING, MULTI_LINE_BASIC_STRING, MULTI_LINE_LITERAL_STRING,
+    BARE_KEY, BASIC_STRING, KEY_VALUE, KEY_VALUE_GROUP, LITERAL_STRING, MULTI_LINE_BASIC_STRING,
+    MULTI_LINE_LITERAL_STRING,
 };
 
 use crate::string::{
@@ -26,10 +27,21 @@ where
     F: FnMut(&tombi_syntax::SyntaxNode),
 {
     for entry in root.children_with_tokens() {
-        if entry.kind() == KEY_VALUE {
+        let kind = entry.kind();
+        if kind == KEY_VALUE {
             for child in entry.as_node().unwrap().children_with_tokens() {
                 if is_string_kind(child.kind()) {
                     f(child.as_node().unwrap());
+                }
+            }
+        } else if kind == KEY_VALUE_GROUP {
+            for kv in entry.as_node().unwrap().children_with_tokens() {
+                if kv.kind() == KEY_VALUE {
+                    for child in kv.as_node().unwrap().children_with_tokens() {
+                        if is_string_kind(child.kind()) {
+                            f(child.as_node().unwrap());
+                        }
+                    }
                 }
             }
         }
@@ -808,19 +820,9 @@ fn test_update_content_wrapped_short_no_wrap() {
 fn test_update_content_wrapped_in_inline_table() {
     let toml = r#"x = { y = "very long string that would be wrapped in normal context but not in inline table" }"#;
     let root_ast = parse(toml);
-    for entry in root_ast.children_with_tokens() {
-        if entry.kind() == KEY_VALUE
-            && let Some(node) = entry.as_node()
-        {
-            for child in node.children_with_tokens() {
-                if is_string_kind(child.kind())
-                    && let Some(string_node) = child.as_node()
-                {
-                    update_content_wrapped(string_node, |s| s.to_string(), 40, "  ");
-                }
-            }
-        }
-    }
+    for_each_string(&root_ast, |string_node| {
+        update_content_wrapped(string_node, |s| s.to_string(), 40, "  ");
+    });
     let result = root_ast.to_string();
     insta::assert_snapshot!(result, @r#"x = { y = "very long string that would be wrapped in normal context but not in inline table" }"#);
 }

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -1875,7 +1875,6 @@ fn test_apply_table_formatting_with_nested_subtables_and_direct_entries() {
     [tool.ruff]
     line-length = 120
     lint.select = ["ALL"]
-
     lint.extra.ok = 1
     "#);
 }

--- a/common/src/util.rs
+++ b/common/src/util.rs
@@ -1,17 +1,32 @@
+use tombi_syntax::SyntaxKind::{KEY_VALUE, KEY_VALUE_GROUP};
 use tombi_syntax::{SyntaxElement, SyntaxKind, SyntaxNode};
+
+fn children_matching_kind(node: &SyntaxNode, target: SyntaxKind) -> Vec<SyntaxElement> {
+    let mut result = Vec::new();
+    for entry in node.children_with_tokens() {
+        if entry.kind() == target {
+            result.push(entry);
+        } else if target == KEY_VALUE && entry.kind() == KEY_VALUE_GROUP {
+            for kv in entry.as_node().unwrap().children_with_tokens() {
+                if kv.kind() == KEY_VALUE {
+                    result.push(kv);
+                }
+            }
+        }
+    }
+    result
+}
 
 pub fn iter<F>(node: &SyntaxNode, paths: &[SyntaxKind], handle: &F)
 where
     F: Fn(&SyntaxNode),
 {
-    for entry in node.children_with_tokens() {
-        if entry.kind() == paths[0] {
-            let found = entry.as_node().unwrap();
-            if paths.len() == 1 {
-                handle(found);
-            } else {
-                iter(found, &paths[1..], handle);
-            }
+    for entry in children_matching_kind(node, paths[0]) {
+        let found = entry.as_node().unwrap();
+        if paths.len() == 1 {
+            handle(found);
+        } else {
+            iter(found, &paths[1..], handle);
         }
     }
 }
@@ -20,13 +35,11 @@ pub fn find_first<F, T>(node: &SyntaxNode, paths: &[SyntaxKind], extract: &F) ->
 where
     F: Fn(SyntaxElement) -> T,
 {
-    for entry in node.children_with_tokens() {
-        if entry.kind() == paths[0] {
-            if paths.len() == 1 {
-                return Some(extract(entry));
-            } else if let Some(result) = find_first(entry.as_node().unwrap(), &paths[1..], extract) {
-                return Some(result);
-            }
+    for entry in children_matching_kind(node, paths[0]) {
+        if paths.len() == 1 {
+            return Some(extract(entry));
+        } else if let Some(result) = find_first(entry.as_node().unwrap(), &paths[1..], extract) {
+            return Some(result);
         }
     }
     None

--- a/pyproject-fmt/docs/configuration.rst
+++ b/pyproject-fmt/docs/configuration.rst
@@ -41,6 +41,32 @@ The ``tool.pyproject-fmt`` table is used when present in the ``pyproject.toml`` 
 
 If not set they will default to values from the CLI.
 
+Shared configuration file
+-------------------------
+
+You can place formatting settings in a standalone ``pyproject-fmt.toml`` file instead of (or in addition to) the
+``[tool.pyproject-fmt]`` table. This is useful for monorepos or when you want to share the same configuration across
+multiple projects without duplicating it in each ``pyproject.toml``.
+
+The formatter searches for ``pyproject-fmt.toml`` starting from the directory of the file being formatted and walking up
+to the filesystem root. The first match wins. You can also pass an explicit path via ``--config``:
+
+.. code-block:: bash
+
+    pyproject-fmt --config /path/to/pyproject-fmt.toml pyproject.toml
+
+The shared config file uses the same keys as the ``[tool.pyproject-fmt]`` table, but without the table header:
+
+.. code-block:: toml
+
+    column_width = 120
+    indent = 2
+    table_format = "short"
+    max_supported_python = "3.14"
+
+When both a shared config file and a ``[tool.pyproject-fmt]`` table exist, per-file settings from the
+``[tool.pyproject-fmt]`` table take precedence over the shared config file.
+
 Command line interface
 ----------------------
 

--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -6,8 +6,8 @@ use std::sync::LazyLock;
 use lexical_sort::natural_lexical_cmp;
 use regex::Regex;
 use tombi_syntax::SyntaxKind::{
-    ARRAY, BASIC_STRING, BRACKET_END, BRACKET_START, COMMA, COMMENT, EQUAL, INLINE_TABLE, KEYS, KEY_VALUE, LINE_BREAK,
-    WHITESPACE,
+    ARRAY, BASIC_STRING, BRACKET_END, BRACKET_START, COMMA, COMMENT, EQUAL, INLINE_TABLE, KEYS, KEY_VALUE,
+    KEY_VALUE_WITH_COMMA_GROUP, LINE_BREAK, VALUE_WITH_COMMA_GROUP, WHITESPACE,
 };
 use tombi_syntax::{SyntaxElement, SyntaxNode};
 
@@ -197,7 +197,16 @@ fn expand_entry_points_inline_tables(table: &mut RefMut<Vec<SyntaxElement>>) {
                     key = s_in_table.as_node().unwrap().text().to_string().trim().to_string();
                 } else if key.starts_with("entry-points.") && s_in_table.kind() == INLINE_TABLE {
                     has_inline_table = true;
-                    for s_in_inline_table in s_in_table.as_node().unwrap().children_with_tokens() {
+                    let it_node = s_in_table.as_node().unwrap();
+                    let kv_iter: Box<dyn Iterator<Item = SyntaxElement>> = if let Some(group) = it_node
+                        .children_with_tokens()
+                        .find(|c| c.kind() == KEY_VALUE_WITH_COMMA_GROUP)
+                    {
+                        Box::new(group.as_node().unwrap().children_with_tokens())
+                    } else {
+                        Box::new(it_node.children_with_tokens())
+                    };
+                    for s_in_inline_table in kv_iter {
                         if s_in_inline_table.kind() == KEY_VALUE {
                             let mut with_key = String::new();
                             for s_in_entry in s_in_inline_table.as_node().unwrap().children_with_tokens() {
@@ -494,38 +503,54 @@ fn expand_array_of_tables(tables: &mut Tables, full_name: &str, key_order: &[&st
                 if child.kind() == KEYS {
                     current_key = child.as_node().unwrap().text().to_string().trim().to_string();
                 } else if current_key == field_name && child.kind() == ARRAY {
-                    for array_element in child.as_node().unwrap().children_with_tokens() {
-                        if array_element.kind() == INLINE_TABLE {
-                            let mut fields: Vec<(String, String)> = Vec::new();
-                            for inline_entry in array_element.as_node().unwrap().children_with_tokens() {
-                                if inline_entry.kind() == KEY_VALUE {
-                                    let mut key_name = String::new();
-                                    let mut value_str = String::new();
-                                    for e in inline_entry.as_node().unwrap().children_with_tokens() {
-                                        match e.kind() {
-                                            KEYS => {
-                                                key_name = e.as_node().unwrap().text().to_string().trim().to_string();
-                                            }
-                                            BASIC_STRING => {
-                                                if let Some(string_node) = e.as_node() {
-                                                    value_str = string_node.text().to_string();
-                                                }
-                                            }
-                                            _ => {}
+                    let mut process_inline_table = |it_node: &SyntaxNode| {
+                        let mut fields: Vec<(String, String)> = Vec::new();
+                        let kv_iter: Box<dyn Iterator<Item = SyntaxElement>> = if let Some(group) = it_node
+                            .children_with_tokens()
+                            .find(|c| c.kind() == KEY_VALUE_WITH_COMMA_GROUP)
+                        {
+                            Box::new(group.as_node().unwrap().children_with_tokens())
+                        } else {
+                            Box::new(it_node.children_with_tokens())
+                        };
+                        for inline_entry in kv_iter {
+                            if inline_entry.kind() == KEY_VALUE {
+                                let mut key_name = String::new();
+                                let mut value_str = String::new();
+                                for e in inline_entry.as_node().unwrap().children_with_tokens() {
+                                    match e.kind() {
+                                        KEYS => {
+                                            key_name = e.as_node().unwrap().text().to_string().trim().to_string();
                                         }
-                                    }
-                                    if !key_name.is_empty() && !value_str.is_empty() {
-                                        fields.push((key_name, value_str));
+                                        BASIC_STRING => {
+                                            if let Some(string_node) = e.as_node() {
+                                                value_str = string_node.text().to_string();
+                                            }
+                                        }
+                                        _ => {}
                                     }
                                 }
+                                if !key_name.is_empty() && !value_str.is_empty() {
+                                    fields.push((key_name, value_str));
+                                }
                             }
-                            if !fields.is_empty() {
-                                fields.sort_by(|a, b| {
-                                    let order =
-                                        |s: &str| key_order.iter().position(|&k| k == s).unwrap_or(key_order.len());
-                                    order(&a.0).cmp(&order(&b.0)).then_with(|| a.0.cmp(&b.0))
-                                });
-                                inline_table_entries.push(fields);
+                        }
+                        if !fields.is_empty() {
+                            fields.sort_by(|a, b| {
+                                let order = |s: &str| key_order.iter().position(|&k| k == s).unwrap_or(key_order.len());
+                                order(&a.0).cmp(&order(&b.0)).then_with(|| a.0.cmp(&b.0))
+                            });
+                            inline_table_entries.push(fields);
+                        }
+                    };
+                    for array_element in child.as_node().unwrap().children_with_tokens() {
+                        if array_element.kind() == INLINE_TABLE {
+                            process_inline_table(array_element.as_node().unwrap());
+                        } else if array_element.kind() == VALUE_WITH_COMMA_GROUP {
+                            for inner in array_element.as_node().unwrap().children_with_tokens() {
+                                if inner.kind() == INLINE_TABLE {
+                                    process_inline_table(inner.as_node().unwrap());
+                                }
                             }
                         }
                     }

--- a/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__ruff_tests__order_ruff.snap
+++ b/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__ruff_tests__order_ruff.snap
@@ -83,5 +83,6 @@ lint.pycodestyle.max-line-length = 100
 lint.pydocstyle.convention = "google"
 lint.pyflakes.extend-generics = [ "ALPHA", "Bar" ]
 lint.pylint.allow-dunder-method-names = [ "ALPHA", "Bar" ]
+lint.pyupgrade.keep-runtime-typing = true
 lint.extra.ok = 1
 lint.more.ok = 1

--- a/toml-fmt-common/src/toml_fmt_common/__init__.py
+++ b/toml-fmt-common/src/toml_fmt_common/__init__.py
@@ -137,35 +137,27 @@ def _cli_args(info: TOMLFormatter[T], args: Sequence[str]) -> list[_Config[T]]:
     """
     parser, type_conversion = _build_cli(info)
     parser.parse_args(namespace=info.opt, args=args)
-
-    explicit_config = info.opt.config
-    if explicit_config is not None and not explicit_config.is_file():
+    if (explicit_config := info.opt.config) is not None and not explicit_config.is_file():
         parser.error(f"config file does not exist: {explicit_config}")
-
     res = []
     for pyproject_toml in info.opt.inputs:
         raw_pyproject_toml = sys.stdin.read() if pyproject_toml is None else pyproject_toml.read_text(encoding="utf-8")
+        config: dict[str, Any] | None = tomllib.loads(raw_pyproject_toml)
 
-        override_opt = deepcopy(info.opt)
-
-        if explicit_config is not None:
-            shared = _load_shared_config(explicit_config)
-        elif found := _find_config_file(info.prog, pyproject_toml.parent if pyproject_toml is not None else Path.cwd()):
-            shared = _load_shared_config(found)
-        else:
-            shared = {}
-        _apply_config(override_opt, shared, type_conversion)
-
-        file_config: dict[str, Any] | None = tomllib.loads(raw_pyproject_toml)
         parts = deque(info.override_cli_from_section)
         while parts:  # pragma: no branch
             part = parts.popleft()
-            if not isinstance(file_config, dict) or part not in file_config:
-                file_config = None
+            if not isinstance(config, dict) or part not in config:
+                config = None
                 break
-            file_config = file_config[part]
-        if isinstance(file_config, dict):
-            _apply_config(override_opt, file_config, type_conversion)
+            config = config[part]
+        override_opt = deepcopy(info.opt)
+        if explicit_config is not None:
+            _apply_config(override_opt, _load_shared_config(explicit_config), type_conversion)
+        elif found := _find_config_file(info.prog, pyproject_toml.parent if pyproject_toml is not None else Path.cwd()):
+            _apply_config(override_opt, _load_shared_config(found), type_conversion)
+        if isinstance(config, dict):
+            _apply_config(override_opt, config, type_conversion)
 
         res.append(
             _Config(
@@ -194,11 +186,9 @@ def _apply_config(opt: T, config: dict[str, Any], type_conversion: Mapping[str, 
 def _find_config_file(prog: str, start: Path) -> Path | None:
     current = start.resolve()
     while True:
-        candidate = current / f"{prog}.toml"
-        if candidate.is_file():
+        if (candidate := current / f"{prog}.toml").is_file():
             return candidate
-        parent = current.parent
-        if parent == current:
+        if (parent := current.parent) == current:
             return None
         current = parent
 

--- a/toml-fmt-common/src/toml_fmt_common/__init__.py
+++ b/toml-fmt-common/src/toml_fmt_common/__init__.py
@@ -39,6 +39,7 @@ class FmtNamespace(Namespace):
     stdout: bool
     check: bool
     no_print_diff: bool
+    config: Path | None
 
     column_width: int
     indent: int
@@ -136,25 +137,36 @@ def _cli_args(info: TOMLFormatter[T], args: Sequence[str]) -> list[_Config[T]]:
     """
     parser, type_conversion = _build_cli(info)
     parser.parse_args(namespace=info.opt, args=args)
+
+    explicit_config = info.opt.config
+    if explicit_config is not None and not explicit_config.is_file():
+        parser.error(f"config file does not exist: {explicit_config}")
+
     res = []
     for pyproject_toml in info.opt.inputs:
         raw_pyproject_toml = sys.stdin.read() if pyproject_toml is None else pyproject_toml.read_text(encoding="utf-8")
-        config: dict[str, Any] | None = tomllib.loads(raw_pyproject_toml)
 
+        override_opt = deepcopy(info.opt)
+
+        if explicit_config is not None:
+            shared = _load_shared_config(explicit_config)
+        elif found := _find_config_file(info.prog, pyproject_toml.parent if pyproject_toml is not None else Path.cwd()):
+            shared = _load_shared_config(found)
+        else:
+            shared = {}
+        _apply_config(override_opt, shared, type_conversion)
+
+        file_config: dict[str, Any] | None = tomllib.loads(raw_pyproject_toml)
         parts = deque(info.override_cli_from_section)
         while parts:  # pragma: no branch
             part = parts.popleft()
-            if not isinstance(config, dict) or part not in config:
-                config = None
+            if not isinstance(file_config, dict) or part not in file_config:
+                file_config = None
                 break
-            config = config[part]
-        override_opt = deepcopy(info.opt)
-        if isinstance(config, dict):
-            for key in set(vars(override_opt).keys()) - {"inputs", "stdout", "check", "no_print_diff"}:
-                if key in config:
-                    raw = config[key]
-                    converted = type_conversion[key](raw) if key in type_conversion else raw
-                    setattr(override_opt, key, converted)
+            file_config = file_config[part]
+        if isinstance(file_config, dict):
+            _apply_config(override_opt, file_config, type_conversion)
+
         res.append(
             _Config(
                 toml_filename=pyproject_toml,
@@ -167,6 +179,32 @@ def _cli_args(info: TOMLFormatter[T], args: Sequence[str]) -> list[_Config[T]]:
         )
 
     return res
+
+
+_NON_FORMAT_KEYS = frozenset({"inputs", "stdout", "check", "no_print_diff", "config"})
+
+
+def _apply_config(opt: T, config: dict[str, Any], type_conversion: Mapping[str, Callable[[Any], Any]]) -> None:
+    for key in set(vars(opt).keys()) - _NON_FORMAT_KEYS:
+        if key in config:
+            raw = config[key]
+            setattr(opt, key, type_conversion[key](raw) if key in type_conversion else raw)
+
+
+def _find_config_file(prog: str, start: Path) -> Path | None:
+    current = start.resolve()
+    while True:
+        candidate = current / f"{prog}.toml"
+        if candidate.is_file():
+            return candidate
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
+
+def _load_shared_config(path: Path) -> dict[str, Any]:
+    return tomllib.loads(path.read_text(encoding="utf-8"))
 
 
 def _build_cli(of: TOMLFormatter[T]) -> tuple[ArgumentParser, Mapping[str, Callable[[Any], Any]]]:
@@ -193,6 +231,13 @@ def _build_cli(of: TOMLFormatter[T]) -> tuple[ArgumentParser, Mapping[str, Calla
         "--no-print-diff",
         action="store_true",
         help="Flag indicating to print diff for the check mode",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help=f"path to a shared {of.prog}.toml config file",
+        metavar="path",
     )
 
     format_group = parser.add_argument_group("formatting behavior")

--- a/toml-fmt-common/tests/test_app.py
+++ b/toml-fmt-common/tests/test_app.py
@@ -290,3 +290,80 @@ def test_writes_lf_line_endings(tmp_path: Path) -> None:
     raw = dumb.read_bytes()
     assert b"\r\n" not in raw
     assert b"\n" in raw
+
+
+def test_config_flag_explicit(tmp_path: Path) -> None:
+    config_file = tmp_path / "toml-fmt-common.toml"
+    config_file.write_text("extra = 'FROM_CONFIG'")
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_text("")
+
+    exit_code = run(Dumb(), ["E", str(dumb), "--config", str(config_file)])
+    assert exit_code == 1
+    assert dumb.read_text() == "\nextras = 'FROM_CONFIG'"
+
+
+def test_config_flag_nonexistent(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_text("")
+
+    with pytest.raises(SystemExit):
+        run(Dumb(), ["E", str(dumb), "--config", str(tmp_path / "missing.toml")])
+
+    out, err = capsys.readouterr()
+    assert "config file does not exist" in err
+    assert not out
+
+
+def test_config_auto_discovery(tmp_path: Path) -> None:
+    config_file = tmp_path / "toml-fmt-common.toml"
+    config_file.write_text("extra = 'DISCOVERED'")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    dumb = sub / "dumb.toml"
+    dumb.write_text("")
+
+    exit_code = run(Dumb(), ["E", str(dumb)])
+    assert exit_code == 1
+    assert dumb.read_text() == "\nextras = 'DISCOVERED'"
+
+
+def test_config_auto_discovery_not_found(tmp_path: Path) -> None:
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_text("")
+
+    exit_code = run(Dumb(), ["E", str(dumb)])
+    assert exit_code == 1
+    assert dumb.read_text() == "\nextras = 'E'"
+
+
+def test_config_per_file_overrides_shared(tmp_path: Path) -> None:
+    config_file = tmp_path / "toml-fmt-common.toml"
+    config_file.write_text("extra = 'SHARED'")
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_text("[start.sub]\nextra = 'IN_FILE'")
+
+    exit_code = run(Dumb(), ["E", str(dumb)])
+    assert exit_code == 1
+    assert dumb.read_text() == "[start.sub]\nextra = 'IN_FILE'\nextras = 'IN_FILE'"
+
+
+def test_config_stdin_uses_cwd(mocker: MockerFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    config_file = tmp_path / "toml-fmt-common.toml"
+    config_file.write_text("extra = 'CWD_CONFIG'")
+    mocker.patch("sys.stdin", StringIO("ok = 1"))
+
+    exit_code = run(Dumb(), ["E", "-"])
+    assert exit_code == 1
+
+
+def test_config_shared_custom_type(tmp_path: Path) -> None:
+    config_file = tmp_path / "toml-fmt-common.toml"
+    config_file.write_text("tuple_magic = '1.2.3'")
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_text("")
+
+    exit_code = run(Dumb(), ["E", str(dumb), "--config", str(config_file)])
+    assert exit_code == 1
+    assert dumb.read_text() == "\nextras = 'E'\nmagic = '1,2,3'"

--- a/tox-toml-fmt/docs/configuration.rst
+++ b/tox-toml-fmt/docs/configuration.rst
@@ -23,6 +23,31 @@ The ``[tox-toml-fmt]`` table is used when present in the ``tox.toml`` file:
 If not set they will default to values from the CLI. The example above shows the defaults (except ``pin_envs``
 which defaults to an empty list).
 
+Shared configuration file
+-------------------------
+
+You can place formatting settings in a standalone ``tox-toml-fmt.toml`` file instead of (or in addition to) the
+``[tox-toml-fmt]`` table. This is useful for monorepos or when you want to share the same configuration across multiple
+projects without duplicating it in each ``tox.toml``.
+
+The formatter searches for ``tox-toml-fmt.toml`` starting from the directory of the file being formatted and walking up
+to the filesystem root. The first match wins. You can also pass an explicit path via ``--config``:
+
+.. code-block:: bash
+
+    tox-toml-fmt --config /path/to/tox-toml-fmt.toml tox.toml
+
+The shared config file uses the same keys as the ``[tox-toml-fmt]`` table, but without the table header:
+
+.. code-block:: toml
+
+    column_width = 120
+    indent = 2
+    pin_envs = ["fix", "type"]
+
+When both a shared config file and a ``[tox-toml-fmt]`` table exist, per-file settings from the ``[tox-toml-fmt]``
+table take precedence over the shared config file.
+
 Command line interface
 ----------------------
 

--- a/tox-toml-fmt/rust/src/global.rs
+++ b/tox-toml-fmt/rust/src/global.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use lexical_sort::natural_lexical_cmp;
 use regex::Regex;
-use tombi_syntax::SyntaxKind::{ARRAY, BASIC_STRING, INLINE_TABLE};
+use tombi_syntax::SyntaxKind::{ARRAY, BASIC_STRING, INLINE_TABLE, VALUE_WITH_COMMA_GROUP};
 use tombi_syntax::{SyntaxElement, SyntaxNode};
 
 use common::array::{sort, sort_strings, transform};
@@ -343,6 +343,13 @@ fn get_env_list_order(tables: &Tables) -> Vec<String> {
                         if array_child.kind() == BASIC_STRING {
                             let env_name = load_text(&array_child.to_string(), BASIC_STRING);
                             env_order.push(format!("env.{env_name}"));
+                        } else if array_child.kind() == VALUE_WITH_COMMA_GROUP {
+                            for inner in array_child.as_node().unwrap().children_with_tokens() {
+                                if inner.kind() == BASIC_STRING {
+                                    let env_name = load_text(&inner.to_string(), BASIC_STRING);
+                                    env_order.push(format!("env.{env_name}"));
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In monorepos with multiple `pyproject.toml` files there is currently no way to share formatter
configuration — every file needs its own `[tool.pyproject-fmt]` section, or you resort to long CLI
invocations. This mirrors the gap that tools like ruff, mypy, and eslint solved with hierarchical
config discovery.

This change introduces a `{prog}.toml` shared config file (e.g. `pyproject-fmt.toml`) that is
discovered by walking up parent directories from each input file, similar to `ruff.toml`. An explicit
`--config <path>` flag is also available to point at a specific file, which overrides the walk-up
discovery for all inputs. Settings live at the **top level** of the file since it is already
namespaced by its filename. ✨ The priority order is: per-file TOML section > shared config file >
CLI defaults, preserving backward compatibility with the existing in-file override behavior.

For stdin input (`-`), the discovery starts from `CWD`. Passing `--config` with a non-existent path
produces a clear error. When no shared config file is found, behavior is identical to before this
change.

This PR also includes the tombi v0.8.0 compatibility fix (#259) and documentation for the shared
config feature in both `pyproject-fmt` and `tox-toml-fmt`. 📖 Each project's configuration docs now
cover auto-discovery, the `--config` flag, file format, and the precedence rules between shared and
per-file settings.

Closes #255