### PR TITLE
🐛 fix(common): include tests in sdist

### DIFF
--- a/toml-fmt-common/pyproject.toml
+++ b/toml-fmt-common/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "uv-build<0.8,>=0.7.22" ]
 
 [project]
 name = "toml-fmt-common"
-version = "1.3.0"
+version = "1.3.1"
 description = "Common logic to the TOML formatter."
 readme = "README.md"
 license = "MIT"
@@ -57,6 +57,9 @@ pkg-meta = [
   "twine>=6.2",
   "uv>=0.10.7",
 ]
+
+[tool.uv.build-backend]
+source-include = [ "tests/**", "tox.toml" ]
 
 [tool.pyproject-fmt]
 max_supported_python = "3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1617,7 +1617,7 @@ wheels = [
 
 [[package]]
 name = "toml-fmt-common"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "toml-fmt-common" }
 dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
The `toml-fmt-common` 1.3.0 source distribution lost test files and `tox.toml` compared to 1.2.0, breaking downstream packagers who run tests from the sdist. This happened because the move to `uv_build` as the build backend only includes the source package by default, unlike the previous standalone repo setup which included everything.

Adding `source-include` to `[tool.uv.build-backend]` brings back `tests/**` and `tox.toml` in the sdist. Version bumped to 1.3.1 since 1.3.0 is already published on PyPI.

Fixes #260