### PR TITLE
✨ feat(common): strip redundant key quotes and reorder inline tables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,9 +330,14 @@ fn test_load_text(#[case] input: &str, #[case] kind: SyntaxKind, #[case] expecte
 
 ### Coverage Goals and Measurement
 
-We require **98% line coverage for Rust code** and **100% coverage for Python code**. To generate an HTML coverage
-report for Rust code, run `tox r -e coverage` from the repository root. This generates lcov output and opens an HTML
-report in your browser. For a quick summary, use `cargo llvm-cov --workspace --no-default-features --summary-only`.
+We require **98% line coverage for Rust code** and **100% coverage for Python code**. Additionally, **diff coverage must
+be 100% per test suite** — changes to `common/src/` must be fully covered by the common test suite alone, and changes to
+`tox-toml-fmt/rust/src/` must be fully covered by the tox-toml-fmt test suite alone. Use per-package coverage checks to
+verify: `cargo llvm-cov -p common --summary-only` or `cargo llvm-cov -p tox-toml-fmt --summary-only`.
+
+To generate an HTML coverage report for Rust code, run `tox r -e coverage` from the repository root. This generates lcov
+output and opens an HTML report in your browser. For a quick summary, use
+`cargo llvm-cov --workspace --no-default-features --summary-only`.
 
 #### Testing PyO3 Code from Rust
 
@@ -414,27 +419,30 @@ fn test_format(#[case] input: &str, #[case] expected: &str) {
 }
 ```
 
-Snapshot testing approach (preferred):
+Snapshot testing approach (preferred, using inline snapshots):
 
 ```rust
 #[rstest]
 #[case::simple("input")]
 fn test_format(#[case] input: &str) {
     let result = format_toml(input);
-    insta::assert_snapshot!(result);
+    insta::assert_snapshot!(result, @"");
 }
 ```
 
+The `@""` syntax creates an **inline snapshot** where the expected value is stored directly in the test file. This is
+preferred over file-based snapshots because it keeps the expected output next to the test input, making tests easier to
+read and review.
+
 Snapshot testing workflow:
 
-- Run tests with `cargo insta test` to generate snapshots
-- Review changes with `cargo insta review` (interactive) or view diffs manually
+- Run tests with `cargo insta test --accept` to populate inline snapshots
+- Review changes with `cargo insta review` (interactive) or view diffs in the test file directly
 - Accept all changes with `cargo insta test --accept`
 - Reject changes with `cargo insta reject`
 
 When formatter behavior changes (like switching parsers), you can update all test expectations with a single
-`cargo insta test --accept` instead of manually updating hundreds of inline strings. Snapshots are stored in
-`src/tests/snapshots/` and committed to git.
+`cargo insta test --accept` instead of manually updating hundreds of inline strings.
 
 ## Common Patterns
 
@@ -466,6 +474,25 @@ use common::string::update_content;
 update_content(value_node, |text| {
     text.to_lowercase()  // Your transformation function
 });
+```
+
+### Reordering Inline Table Keys
+
+When a formatter needs to enforce a consistent key order within inline tables, use the `InlineTableSchema` and
+`reorder_inline_table_keys` from `common::table`. Each schema specifies a discriminator key (used to identify which
+schema applies) and the desired key order. Keys not listed in the schema are appended at the end.
+
+```rust
+use common::table::{reorder_inline_table_keys, InlineTableSchema};
+
+const SCHEMAS: &[InlineTableSchema] = &[
+    InlineTableSchema {
+        discriminator: "replace",
+        key_order: &["replace", "default", "extend"],
+    },
+];
+
+reorder_inline_table_keys(&root_ast, SCHEMAS);
 ```
 
 ### Creating New Nodes

--- a/common/src/string.rs
+++ b/common/src/string.rs
@@ -298,29 +298,57 @@ where
     }
 }
 
+fn is_valid_bare_key(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+fn normalize_key_segment(kind: SyntaxKind, text: &str) -> String {
+    match kind {
+        BARE_KEY => text.to_string(),
+        LITERAL_STRING => {
+            let inner = &text[1..text.len() - 1];
+            if is_valid_bare_key(inner) {
+                return inner.to_string();
+            }
+            let escaped = inner.replace('\\', "\\\\").replace('"', "\\\"");
+            format!("\"{escaped}\"")
+        }
+        BASIC_STRING => {
+            let inner = &text[1..text.len() - 1];
+            if is_valid_bare_key(inner) {
+                return inner.to_string();
+            }
+            text.to_string()
+        }
+        _ => text.to_string(),
+    }
+}
+
 pub fn normalize_key_quotes(root: &SyntaxNode) {
     use crate::create::make_key;
 
-    for descendant in root.descendants() {
-        if descendant.kind() != KEYS {
-            continue;
-        }
-        let has_literal = descendant.children_with_tokens().any(|c| c.kind() == LITERAL_STRING);
-        if !has_literal {
+    let keys_nodes: Vec<SyntaxNode> = root.descendants().filter(|n| n.kind() == KEYS).collect();
+    for descendant in keys_nodes {
+        let needs_normalization = descendant.children_with_tokens().any(|c| {
+            let kind = c.kind();
+            if kind == LITERAL_STRING {
+                return true;
+            }
+            if kind == BASIC_STRING {
+                let text = c.to_string();
+                let inner = &text[1..text.len() - 1];
+                return is_valid_bare_key(inner);
+            }
+            false
+        });
+        if !needs_normalization {
             continue;
         }
         let mut key_parts = Vec::new();
         for child in descendant.children_with_tokens() {
-            match child.kind() {
-                BARE_KEY => key_parts.push(child.to_string()),
-                LITERAL_STRING => {
-                    let text = child.to_string();
-                    let inner = &text[1..text.len() - 1];
-                    let escaped = inner.replace('\\', "\\\\").replace('"', "\\\"");
-                    key_parts.push(format!("\"{escaped}\""));
-                }
-                BASIC_STRING => key_parts.push(child.to_string()),
-                _ => {}
+            let kind = child.kind();
+            if matches!(kind, BARE_KEY | LITERAL_STRING | BASIC_STRING) {
+                key_parts.push(normalize_key_segment(kind, &child.to_string()));
             }
         }
         let new_key = make_key(&key_parts.join("."));

--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -5,8 +5,8 @@ use std::ops::Index;
 
 use tombi_syntax::SyntaxKind::{
     ARRAY_OF_TABLE, BARE_KEY, BASIC_STRING, BRACKET_END, BRACKET_START, COMMENT, DANGLING_COMMENT_GROUP,
-    DOUBLE_BRACKET_START, EQUAL, KEY_VALUE, KEY_VALUE_GROUP, KEY_VALUE_WITH_COMMA_GROUP, KEYS, LINE_BREAK,
-    LITERAL_STRING, TABLE, WHITESPACE,
+    DOUBLE_BRACKET_START, EQUAL, INLINE_TABLE, KEY_VALUE, KEY_VALUE_GROUP, KEY_VALUE_WITH_COMMA_GROUP, KEYS,
+    LINE_BREAK, LITERAL_STRING, TABLE, WHITESPACE,
 };
 use tombi_syntax::{SyntaxElement, SyntaxKind, SyntaxNode};
 
@@ -1061,5 +1061,80 @@ fn add_intermediate_parents(table_name: &str, prefix_dots: usize, result: &mut V
             result.push(String::from(parent));
         }
         current = parent;
+    }
+}
+
+pub struct InlineTableSchema {
+    pub discriminator: &'static str,
+    pub key_order: &'static [&'static str],
+}
+
+fn inline_table_key_name(kv_node: &SyntaxNode) -> String {
+    let raw = kv_node
+        .children_with_tokens()
+        .find(|c| c.kind() == KEYS)
+        .and_then(|c| c.as_node().map(|n| n.text().to_string().trim().to_string()))
+        .unwrap_or_default();
+    raw.strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .or_else(|| raw.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))
+        .unwrap_or(&raw)
+        .to_string()
+}
+
+fn detect_schema<'a>(keys: &[String], schemas: &'a [InlineTableSchema]) -> Option<&'a [&'static str]> {
+    schemas
+        .iter()
+        .find(|s| keys.iter().any(|k| k == s.discriminator))
+        .map(|s| s.key_order)
+}
+
+fn reorder_single_inline_table(node: &SyntaxNode, schemas: &[InlineTableSchema]) {
+    let kv_pairs: Vec<(String, String)> = node
+        .children()
+        .filter(|n| n.kind() == KEY_VALUE_WITH_COMMA_GROUP)
+        .flat_map(|group| {
+            group
+                .children()
+                .filter(|n| n.kind() == KEY_VALUE)
+                .map(|kv| (inline_table_key_name(&kv), kv.text().to_string().trim().to_string()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    if kv_pairs.len() < 2 {
+        return;
+    }
+
+    let keys: Vec<String> = kv_pairs.iter().map(|(k, _)| k.clone()).collect();
+    let Some(schema) = detect_schema(&keys, schemas) else {
+        return;
+    };
+
+    let key_position = |k: &str| -> usize { schema.iter().position(|s| *s == k).unwrap_or(usize::MAX) };
+    let mut sorted = kv_pairs.clone();
+    sorted.sort_by_key(|(k, _)| key_position(k));
+
+    if sorted.iter().map(|(k, _)| k).eq(kv_pairs.iter().map(|(k, _)| k)) {
+        return;
+    }
+
+    let entries: Vec<&str> = sorted.iter().map(|(_, v)| v.as_str()).collect();
+    let rebuilt = format!("_x = {{ {} }}\n", entries.join(", "));
+    let parsed = parse(&rebuilt);
+    let new_children: Option<Vec<SyntaxElement>> = parsed
+        .descendants()
+        .find(|n| n.kind() == INLINE_TABLE)
+        .map(|n| n.children_with_tokens().collect());
+
+    if let Some(children) = new_children {
+        node.splice_children(0..node.children_with_tokens().count(), children);
+    }
+}
+
+pub fn reorder_inline_table_keys(root_ast: &SyntaxNode, schemas: &[InlineTableSchema]) {
+    let inline_tables: Vec<SyntaxNode> = root_ast.descendants().filter(|n| n.kind() == INLINE_TABLE).collect();
+    for node in inline_tables {
+        reorder_single_inline_table(&node, schemas);
     }
 }

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -602,8 +602,8 @@ fn test_strip_quotes_triple_quotes() {
 fn test_normalize_key_quotes_simple_literal() {
     let root = parse("'key' = 1\n");
     normalize_key_quotes(&root);
-    insta::assert_snapshot!(root.to_string(), @r#""key" = 1
-"#);
+    insta::assert_snapshot!(root.to_string(), @"key = 1
+");
 }
 
 #[test]
@@ -615,11 +615,11 @@ fn test_normalize_key_quotes_bare_key_unchanged() {
 }
 
 #[test]
-fn test_normalize_key_quotes_basic_string_unchanged() {
+fn test_normalize_key_quotes_basic_string_stripped() {
     let root = parse("\"key\" = 1\n");
     normalize_key_quotes(&root);
-    insta::assert_snapshot!(root.to_string(), @r#""key" = 1
-"#);
+    insta::assert_snapshot!(root.to_string(), @"key = 1
+");
 }
 
 #[test]
@@ -674,15 +674,31 @@ fn test_normalize_key_quotes_literal_with_backslash_and_quote() {
 fn test_normalize_key_quotes_multiple_literal_segments() {
     let root = parse("'first'.'second' = 1\n");
     normalize_key_quotes(&root);
-    insta::assert_snapshot!(root.to_string(), @r#""first"."second" = 1
-"#);
+    insta::assert_snapshot!(root.to_string(), @"first.second = 1
+");
 }
 
 #[test]
 fn test_normalize_key_quotes_preserves_basic_in_dotted() {
     let root = parse("bare.\"basic\".'literal' = 1\n");
     normalize_key_quotes(&root);
-    insta::assert_snapshot!(root.to_string(), @r#"bare."basic"."literal" = 1
+    insta::assert_snapshot!(root.to_string(), @"bare.basic.literal = 1
+");
+}
+
+#[test]
+fn test_normalize_key_quotes_preserves_required_quotes() {
+    let root = parse("\"key with spaces\" = 1\n");
+    normalize_key_quotes(&root);
+    insta::assert_snapshot!(root.to_string(), @r#""key with spaces" = 1
+"#);
+}
+
+#[test]
+fn test_normalize_key_quotes_inline_table_keys() {
+    let root = parse("val = { \"else\" = \"no\", \"then\" = \"yes\" }\n");
+    normalize_key_quotes(&root);
+    insta::assert_snapshot!(root.to_string(), @r#"val = { else = "no", then = "yes" }
 "#);
 }
 

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -2,8 +2,9 @@ use indoc::indoc;
 
 use super::format_toml;
 use crate::table::{
-    Tables, apply_table_formatting, collapse_sub_table, collapse_sub_tables, collect_all_sub_tables, expand_sub_table,
-    expand_sub_tables, find_key, for_entries, get_table_name, reorder_table_keys,
+    InlineTableSchema, Tables, apply_table_formatting, collapse_sub_table, collapse_sub_tables, collect_all_sub_tables,
+    expand_sub_table, expand_sub_tables, find_key, for_entries, get_table_name, reorder_inline_table_keys,
+    reorder_table_keys,
 };
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
@@ -2118,5 +2119,244 @@ fn test_rename_keys_empty_aliases() {
     insta::assert_snapshot!(result, @r#"
     [project]
     name = "value"
+    "#);
+}
+
+fn reorder_inline_helper(start: &str, schemas: &[InlineTableSchema]) -> String {
+    let root_ast = parse(start);
+    reorder_inline_table_keys(&root_ast, schemas);
+    root_ast.to_string()
+}
+
+const TEST_SCHEMAS: &[InlineTableSchema] = &[
+    InlineTableSchema {
+        discriminator: "replace",
+        key_order: &["replace", "name", "default"],
+    },
+    InlineTableSchema {
+        discriminator: "prefix",
+        key_order: &["prefix", "start", "stop"],
+    },
+];
+
+#[test]
+fn test_reorder_inline_table_keys_basic() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            val = { default = "x", name = "Y", replace = "env" }
+        "#},
+        TEST_SCHEMAS,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    val = { replace = "env", name = "Y", default = "x" }
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_already_ordered() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            val = { replace = "env", name = "Y", default = "x" }
+        "#},
+        TEST_SCHEMAS,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    val = { replace = "env", name = "Y", default = "x" }
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_no_matching_schema() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            val = { z = 1, a = 2 }
+        "#},
+        TEST_SCHEMAS,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    val = { z = 1, a = 2 }
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_single_key() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            val = { replace = "env" }
+        "#},
+        TEST_SCHEMAS,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    val = { replace = "env" }
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_second_schema() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            val = { stop = 14, prefix = "py3", start = 10 }
+        "#},
+        TEST_SCHEMAS,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    val = { prefix = "py3", start = 10, stop = 14 }
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_quoted_key() {
+    let schemas = &[InlineTableSchema {
+        discriminator: "else",
+        key_order: &["condition", "then", "else"],
+    }];
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            val = { "else" = "no", "then" = "yes", condition = "true" }
+        "#},
+        schemas,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    val = { condition = "true", "then" = "yes", "else" = "no" }
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_multiple_inline_tables() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            a = { default = "x", replace = "env", name = "A" }
+            b = { name = "B", replace = "ref", default = "y" }
+        "#},
+        TEST_SCHEMAS,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    a = { replace = "env", name = "A", default = "x" }
+    b = { replace = "ref", name = "B", default = "y" }
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_in_array() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            items = [
+                { default = "x", replace = "env", name = "A" },
+                { stop = 14, prefix = "py3", start = 10 },
+            ]
+        "#},
+        TEST_SCHEMAS,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    items = [
+        { replace = "env", name = "A", default = "x" },{ prefix = "py3", start = 10, stop = 14 },
+    ]
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_no_inline_tables() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            name = "value"
+            count = 42
+        "#},
+        TEST_SCHEMAS,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    name = "value"
+    count = 42
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_empty_schemas() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            val = { b = 2, a = 1 }
+        "#},
+        &[],
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    val = { b = 2, a = 1 }
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_nested_inline_table() {
+    let schemas = &[InlineTableSchema {
+        discriminator: "replace",
+        key_order: &["replace", "default"],
+    }];
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            items = [
+                { default = "x", replace = "env" },
+                ["cmd", { default = "y", replace = "posargs" }],
+            ]
+        "#},
+        schemas,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    items = [
+        { replace = "env", default = "x" },
+        ["cmd", { replace = "posargs", default = "y" }],
+    ]
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_value_is_inline_table() {
+    let schemas = &[InlineTableSchema {
+        discriminator: "replace",
+        key_order: &["replace", "default"],
+    }];
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            val = { inner = { default = "x", replace = "env" } }
+        "#},
+        schemas,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    val = { inner = { replace = "env", default = "x" } }
+    "#);
+}
+
+#[test]
+fn test_reorder_inline_table_keys_unknown_keys_appended() {
+    let result = reorder_inline_helper(
+        indoc! {r#"
+            [section]
+            val = { extra = true, replace = "env", name = "X" }
+        "#},
+        TEST_SCHEMAS,
+    );
+    insta::assert_snapshot!(result, @r#"
+    [section]
+    val = { replace = "env", name = "X", extra = true }
     "#);
 }

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -64,18 +64,22 @@ All strings use double quotes by default. Single quotes are only used when the v
 Key Quotes
 ~~~~~~~~~~
 
-TOML keys using single-quoted (literal) strings are normalized to double-quoted (basic) strings with proper escaping.
-This ensures consistent formatting and deterministic key sorting regardless of the original quote style:
+TOML keys are normalized to the simplest valid form. Keys that are valid bare keys (containing only
+``A-Za-z0-9_-``) have redundant quotes stripped. Single-quoted (literal) keys that require quoting are
+converted to double-quoted (basic) strings with proper escaping. This applies to all keys: table headers,
+key-value pairs, and inline table keys:
 
 .. code-block:: toml
 
     # Before
+    [tool."ruff"]
+    "line-length" = 120
     lint.per-file-ignores.'tests/*' = ["S101"]
-    lint.per-file-ignores."src/*" = ["D100"]
 
     # After
+    [tool.ruff]
+    line-length = 120
     lint.per-file-ignores."tests/*" = ["S101"]
-    lint.per-file-ignores."src/*" = ["D100"]
 
 Backslashes and double quotes within literal keys are escaped during conversion:
 

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -217,8 +217,8 @@ fn test_table_format_long_with_entry_points() {
     [project]
     name = "example"
     [project.entry-points]
-    "console_scripts".mycli = "pkg:main"
-    "console_scripts".othercli = "pkg:other"
+    console_scripts.mycli = "pkg:main"
+    console_scripts.othercli = "pkg:other"
     "#);
 }
 

--- a/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__main_tests__issue_217_full_pyproject_idempotent.snap
+++ b/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__main_tests__issue_217_full_pyproject_idempotent.snap
@@ -69,10 +69,10 @@ dependencies = [
   "werkzeug~=3.1",
   "zxcvbn~=4.4",
 ]
-urls."Forum" = "https://github.com/Flexget/Flexget/discussions"
-urls."Homepage" = "https://flexget.com"
 urls."Issue Tracker" = "https://github.com/Flexget/Flexget/issues"
-urls."Repository" = "https://github.com/Flexget/Flexget"
+urls.Forum = "https://github.com/Flexget/Flexget/discussions"
+urls.Homepage = "https://flexget.com"
+urls.Repository = "https://github.com/Flexget/Flexget"
 scripts.flexget = "flexget:main"
 gui-scripts.flexget-headless = "flexget:main"  # This is useful on Windows to avoid a cmd popup
 

--- a/tox-toml-fmt/CHANGELOG.md
+++ b/tox-toml-fmt/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.8.0 - 2026-03-01
 
+- ✨ feat(tox-toml-fmt): reorder inline table keys and add missing env keys by
+  [@gaborbernat](https://github.com/gaborbernat) in [#264](https://github.com/tox-dev/toml-fmt/pull/264)
 - ✨ feat(common): add shared config file support by [@gaborbernat](https://github.com/gaborbernat) in
   [#258](https://github.com/tox-dev/toml-fmt/pull/258)
 - 🐛 fix(parser): adapt to tombi v0.8.0 AST changes by [@gaborbernat](https://github.com/gaborbernat) in
@@ -155,7 +157,7 @@
   [#140](https://github.com/tox-dev/toml-fmt/pull/140)
 - Sort subtables alphabetically within the same tool by [@gaborbernat](https://github.com/gaborbernat) in
   [#139](https://github.com/tox-dev/toml-fmt/pull/139)
-- Collapse [[project.authors]] array of tables to inline format by [@gaborbernat](https://github.com/gaborbernat) in
+- Collapse \[[project.authors]\] array of tables to inline format by [@gaborbernat](https://github.com/gaborbernat) in
   [#137](https://github.com/tox-dev/toml-fmt/pull/137)
 - Bump toml-fmt-common to 1.2 by [@gaborbernat](https://github.com/gaborbernat) in
   [#138](https://github.com/tox-dev/toml-fmt/pull/138)

--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -37,18 +37,22 @@ All strings use double quotes by default. Single quotes are only used when the v
 Key Quotes
 ~~~~~~~~~~
 
-TOML keys using single-quoted (literal) strings are normalized to double-quoted (basic) strings with proper escaping.
-This ensures consistent formatting and deterministic key sorting regardless of the original quote style:
+TOML keys are normalized to the simplest valid form. Keys that are valid bare keys (containing only
+``A-Za-z0-9_-``) have redundant quotes stripped. Single-quoted (literal) keys that require quoting are
+converted to double-quoted (basic) strings with proper escaping. This applies to all keys: table headers,
+key-value pairs, and inline table keys:
 
 .. code-block:: toml
 
     # Before
     [env.'my-env']
-    deps = ["pytest"]
+    "description" = "run tests"
+    pass_env = [{ "else" = "no" }]
 
     # After
     [env."my-env"]
-    deps = ["pytest"]
+    description = "run tests"
+    pass_env = [{ else = "no" }]
 
 Backslashes and double quotes within literal keys are escaped during conversion.
 
@@ -198,8 +202,10 @@ Tables are reordered into a consistent structure:
 1. Root-level keys (``min_version``, ``requires``, ``env_list``, etc.)
 2. ``[env_run_base]``
 3. ``[env_pkg_base]``
-4. ``[env.NAME]`` sections ordered by ``env_list`` if specified
-5. Any remaining ``[env.*]`` sections not in ``env_list``
+4. ``[env_base.*]`` sections (shared base configurations)
+5. ``[env.NAME]`` sections ordered by ``env_list`` if specified
+6. Any remaining ``[env.*]`` sections not in ``env_list``, sorted alphabetically
+7. ``[env]`` (catch-all environment table, if present)
 
 .. code-block:: toml
 
@@ -211,6 +217,9 @@ Tables are reordered into a consistent structure:
 
     [env_pkg_base]
     # ...
+
+    [env_base.ci]
+    # shared base config
 
     # Environments appear in env_list order:
     [env.lint]
@@ -225,7 +234,7 @@ Tables are reordered into a consistent structure:
     [env.py313]
     # ...
 
-Environments not listed in ``env_list`` are placed at the end.
+Environments not listed in ``env_list`` are placed at the end, sorted alphabetically.
 
 Alias Normalization
 ~~~~~~~~~~~~~~~~~~~
@@ -299,16 +308,18 @@ Environment Key Ordering
 Keys within ``[env_run_base]``, ``[env_pkg_base]``, and ``[env.*]`` tables are reordered to group related
 settings:
 
-``runner`` → ``description`` → ``base_python`` → ``system_site_packages`` → ``always_copy`` →
-``download`` → ``package`` → ``package_env`` → ``wheel_build_env`` → ``package_tox_env_type`` →
-``package_root`` → ``skip_install`` → ``use_develop`` → ``meta_dir`` → ``pkg_dir`` → ``pip_pre`` →
+``factors`` → ``runner`` → ``description`` → ``base_python`` → ``default_base_python`` →
+``system_site_packages`` → ``always_copy`` → ``download`` → ``virtualenv_spec`` → ``package`` →
+``package_env`` → ``wheel_build_env`` → ``package_tox_env_type`` → ``package_root`` →
+``skip_install`` → ``use_develop`` → ``meta_dir`` → ``pkg_dir`` → ``pip_pre`` →
 ``install_command`` → ``list_dependencies_command`` → ``deps`` → ``dependency_groups`` →
-``constraints`` → ``constrain_package_deps`` → ``use_frozen_constraints`` → ``extras`` → ``recreate`` →
-``parallel_show_output`` → ``skip_missing_interpreters`` → ``pass_env`` → ``disallow_pass_env`` →
-``set_env`` → ``change_dir`` → ``platform`` → ``args_are_paths`` → ``ignore_errors`` →
-``ignore_outcome`` → ``commands_pre`` → ``commands`` → ``commands_post`` → ``allowlist_externals`` →
-``labels`` → ``suicide_timeout`` → ``interrupt_timeout`` → ``terminate_timeout`` → ``depends`` →
-``env_dir`` → ``env_tmp_dir`` → ``env_log_dir``
+``pylock`` → ``constraints`` → ``constrain_package_deps`` → ``use_frozen_constraints`` → ``extras`` →
+``recreate`` → ``recreate_commands`` → ``parallel_show_output`` → ``skip_missing_interpreters`` →
+``fail_fast`` → ``pass_env`` → ``disallow_pass_env`` → ``set_env`` → ``change_dir`` →
+``platform`` → ``args_are_paths`` → ``ignore_errors`` → ``commands_retry`` → ``ignore_outcome`` →
+``extra_setup_commands`` → ``commands_pre`` → ``commands`` → ``commands_post`` →
+``allowlist_externals`` → ``labels`` → ``suicide_timeout`` → ``interrupt_timeout`` →
+``terminate_timeout`` → ``depends`` → ``env_dir`` → ``env_tmp_dir`` → ``env_log_dir``
 
 .. code-block:: toml
 
@@ -347,6 +358,9 @@ The ``env_list`` array is sorted with a specific ordering:
 2. **CPython versions** (matching ``py3.12``, ``py312``, ``3.12``, etc.) sorted descending (newest first)
 3. **PyPy versions** (matching ``pypy3.10``, ``pypy310``, etc.) sorted descending
 4. **Named environments** (``lint``, ``type``, ``docs``, etc.) sorted alphabetically
+
+Inline table entries (such as ``{ product = ... }``) in ``env_list`` are excluded from sorting and remain
+in their original positions.
 
 Compound environment names separated by ``-`` are classified by their first recognized part:
 
@@ -391,19 +405,22 @@ Certain arrays within environment tables are sorted automatically:
 
 **Sorted by canonical PEP 508 package name:**
 
-- ``deps`` — dependencies normalized and sorted by package name
+- ``deps``, ``constraints`` — dependencies normalized and sorted by package name
+
+Pip file references (``-r requirements.txt``, ``-c constraints.txt``) are preserved as-is without
+PEP 508 normalization, but still participate in sorting by their lowercased value:
 
 .. code-block:: toml
 
     # Before
-    deps = ["Pytest >= 7", "coverage", "pytest-mock"]
+    deps = ["Pytest >= 7", "-r requirements.txt", "coverage", "pytest-mock"]
 
     # After
-    deps = ["coverage", "pytest>=7", "pytest-mock"]
+    deps = ["-r requirements.txt", "coverage", "pytest>=7", "pytest-mock"]
 
 **Sorted alphabetically:**
 
-- ``dependency_groups``, ``allowlist_externals``, ``extras``, ``labels``, ``depends``, ``constraints``
+- ``dependency_groups``, ``allowlist_externals``, ``extras``, ``labels``, ``depends``
 
 **Special handling for ``pass_env``:**
 
@@ -422,6 +439,32 @@ then string entries are sorted alphabetically:
 
 - ``commands``, ``commands_pre``, ``commands_post`` — execution order matters
 - ``base_python`` — first entry takes priority
+
+Inline Table Key Reordering
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Keys within inline tables are reordered into a consistent order based on the inline table's type. The type
+is detected by the presence of a discriminator key:
+
+- **``replace``** — ``replace`` → ``condition`` → ``of`` → ``env`` → ``key`` → ``name`` → ``pattern`` →
+  ``then`` → ``else`` → ``default`` → ``extend`` → ``marker``
+- **``prefix``** — ``prefix`` → ``start`` → ``stop``
+- **``product``** — ``product`` → ``exclude``
+- **``value``** — ``value`` → ``marker``
+
+Keys not listed in the schema are appended at the end in their original order.
+
+.. code-block:: toml
+
+    # Before
+    pass_env = [{ default = ".", replace = "default", extend = true }]
+    env_list = [{ exclude = ["py38-django50"], product = ["py38", "py310", "django42", "django50"] }]
+
+    # After
+    pass_env = [{ replace = "default", default = ".", extend = true }]
+    env_list = [{ product = ["py38", "py310", "django42", "django50"], exclude = ["py38-django50"] }]
+
+This reordering applies to all inline tables in the file, including those nested inside arrays.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/tox-toml-fmt/rust/src/global.rs
+++ b/tox-toml-fmt/rust/src/global.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::collections::HashSet;
 
 use lexical_sort::natural_lexical_cmp;
 use regex::Regex;
@@ -9,10 +10,16 @@ use common::array::{sort, sort_strings, transform};
 use common::create::make_entry_of_string;
 use common::pep508::Requirement;
 use common::string::load_text;
-use common::table::{for_entries, rename_keys, reorder_table_keys, Tables};
+use common::table::{
+    count_unquoted_dots, for_entries, rename_keys, reorder_inline_table_keys, reorder_table_keys, InlineTableSchema,
+    Tables,
+};
 
 fn is_env_table(key: &str) -> bool {
-    key == "env_run_base" || key == "env_pkg_base" || (key.starts_with("env.") && !key["env.".len()..].contains('.'))
+    key == "env_run_base"
+        || key == "env_pkg_base"
+        || (key.starts_with("env.") && count_unquoted_dots(key) == 1)
+        || (key.starts_with("env_base.") && count_unquoted_dots(key) == 1)
 }
 
 fn env_tables(tables: &Tables) -> Vec<(&String, Vec<&RefCell<Vec<SyntaxElement>>>)> {
@@ -68,12 +75,15 @@ const ROOT_KEY_ORDER: &[&str] = &[
 
 const ENV_KEY_ORDER: &[&str] = &[
     "",
+    "factors",
     "runner",
     "description",
     "base_python",
+    "default_base_python",
     "system_site_packages",
     "always_copy",
     "download",
+    "virtualenv_spec",
     "package",
     "package_env",
     "wheel_build_env",
@@ -88,13 +98,16 @@ const ENV_KEY_ORDER: &[&str] = &[
     "list_dependencies_command",
     "deps",
     "dependency_groups",
+    "pylock",
     "constraints",
     "constrain_package_deps",
     "use_frozen_constraints",
     "extras",
     "recreate",
+    "recreate_commands",
     "parallel_show_output",
     "skip_missing_interpreters",
+    "fail_fast",
     "pass_env",
     "disallow_pass_env",
     "set_env",
@@ -102,7 +115,9 @@ const ENV_KEY_ORDER: &[&str] = &[
     "platform",
     "args_are_paths",
     "ignore_errors",
+    "commands_retry",
     "ignore_outcome",
+    "extra_setup_commands",
     "commands_pre",
     "commands",
     "commands_post",
@@ -214,17 +229,33 @@ fn upgrade_use_develop(table: &mut Vec<SyntaxElement>) {
     }
 }
 
+fn is_pip_file_ref(s: &str) -> bool {
+    s.starts_with("-r ") || s.starts_with("-c ")
+}
+
+fn normalize_and_sort_requirements(entry: &SyntaxNode) {
+    transform(entry, &|s| {
+        if is_pip_file_ref(s) {
+            return s.to_string();
+        }
+        Requirement::new(s).unwrap().normalize(false).to_string()
+    });
+    sort_strings::<String, _, _>(
+        entry,
+        |s| {
+            if is_pip_file_ref(&s) {
+                return s.to_lowercase();
+            }
+            Requirement::new(s.as_str()).unwrap().canonical_name()
+        },
+        &|lhs, rhs| natural_lexical_cmp(lhs, rhs),
+    );
+}
+
 fn fix_env_entry(key: &str, entry: &SyntaxNode) {
     match key {
-        "deps" => {
-            transform(entry, &|s| Requirement::new(s).unwrap().normalize(false).to_string());
-            sort_strings::<String, _, _>(
-                entry,
-                |s| Requirement::new(s.as_str()).unwrap().canonical_name(),
-                &|lhs, rhs| natural_lexical_cmp(lhs, rhs),
-            );
-        }
-        "dependency_groups" | "allowlist_externals" | "extras" | "labels" | "depends" | "constraints" => {
+        "deps" | "constraints" => normalize_and_sort_requirements(entry),
+        "dependency_groups" | "allowlist_externals" | "extras" | "labels" | "depends" => {
             sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
         }
         "pass_env" => sort_pass_env(entry),
@@ -279,6 +310,9 @@ pub fn sort_env_list(tables: &Tables, pin_envs: &[String]) {
                 entry,
                 |node| {
                     let kind = node.kind();
+                    if kind == INLINE_TABLE {
+                        return None;
+                    }
                     let text = node.text().to_string();
                     let val = load_text(&text, kind);
                     let lower = val.to_lowercase();
@@ -362,15 +396,58 @@ fn get_env_list_order(tables: &Tables) -> Vec<String> {
 
 pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables) {
     let env_list_order = get_env_list_order(tables);
-    let has_env_list = !env_list_order.is_empty();
-
-    let mut order: Vec<&str> = vec!["", "env_run_base", "env_pkg_base"];
+    let mut order: Vec<&str> = vec!["", "env_run_base", "env_pkg_base", "env_base"];
 
     let env_refs: Vec<&str> = env_list_order.iter().map(|s| s.as_str()).collect();
+    let env_list_set: HashSet<&str> = env_refs.iter().copied().collect();
     order.extend(env_refs);
+
+    let mut remaining_envs: Vec<&String> = tables
+        .header_to_pos
+        .keys()
+        .filter(|k| k.starts_with("env.") && count_unquoted_dots(k) == 1 && !env_list_set.contains(k.as_str()))
+        .collect();
+    remaining_envs.sort_by_key(|a| a.to_lowercase());
+    let remaining_env_refs: Vec<&str> = remaining_envs.iter().map(|s| s.as_str()).collect();
+    order.extend(remaining_env_refs);
 
     order.push("env");
 
-    let multi_level_prefixes: &[&str] = if has_env_list { &["env"] } else { &[] };
-    tables.reorder(root_ast, &order, multi_level_prefixes);
+    tables.reorder(root_ast, &order, &["env_base", "env"]);
+}
+
+const TOX_INLINE_TABLE_SCHEMAS: &[InlineTableSchema] = &[
+    InlineTableSchema {
+        discriminator: "replace",
+        key_order: &[
+            "replace",
+            "condition",
+            "of",
+            "env",
+            "key",
+            "name",
+            "pattern",
+            "then",
+            "else",
+            "default",
+            "extend",
+            "marker",
+        ],
+    },
+    InlineTableSchema {
+        discriminator: "prefix",
+        key_order: &["prefix", "start", "stop"],
+    },
+    InlineTableSchema {
+        discriminator: "product",
+        key_order: &["product", "exclude"],
+    },
+    InlineTableSchema {
+        discriminator: "value",
+        key_order: &["value", "marker"],
+    },
+];
+
+pub fn reorder_inline_tables(root_ast: &SyntaxNode) {
+    reorder_inline_table_keys(root_ast, TOX_INLINE_TABLE_SCHEMAS);
 }

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -7,7 +7,9 @@ use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyR
 use tombi_config::TomlVersion;
 use tombi_syntax::SyntaxKind::KEY_VALUE;
 
-use crate::global::{fix_envs, fix_root, normalize_aliases, normalize_strings, reorder_tables, sort_env_list};
+use crate::global::{
+    fix_envs, fix_root, normalize_aliases, normalize_strings, reorder_inline_tables, reorder_tables, sort_env_list,
+};
 use common::array::ensure_all_arrays_multiline;
 use common::table::{apply_table_formatting, count_unquoted_dots, first_unquoted_dot, split_table_name, Tables};
 
@@ -151,6 +153,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     fix_envs(&tables);
     sort_env_list(&tables, &opt.pin_envs);
     normalize_strings(&tables);
+    reorder_inline_tables(&root_ast);
     reorder_tables(&root_ast, &tables);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);
 

--- a/tox-toml-fmt/rust/src/tests/doc_examples_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/doc_examples_tests.rs
@@ -1,0 +1,1499 @@
+use indoc::indoc;
+use insta::assert_snapshot;
+
+use super::assert_valid_toml;
+use crate::{format_toml, Settings};
+
+fn format_toml_helper(start: &str, indent: usize) -> String {
+    let settings = Settings {
+        column_width: 120,
+        indent,
+        table_format: String::from("short"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+        pin_envs: vec![],
+    };
+    let got = format_toml(start, &settings);
+    assert_valid_toml(&got);
+    let second = format_toml(got.as_str(), &settings);
+    assert_eq!(second, got, "formatting should be idempotent");
+    got
+}
+
+// --- reference/config.rst examples ---
+
+#[test]
+fn test_doc_conditional_deps_and_commands() {
+    let start = indoc! {r#"
+        [env_run_base]
+        deps = [
+            "pytest",
+            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
+            { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
+            { replace = "if", condition = "not factor.lint", then = ["coverage"] },
+        ]
+        commands = [
+            { replace = "if", condition = "factor.linux", then = [["python", "-c", "print('on linux')"]] },
+            { replace = "if", condition = "factor.darwin", then = [["python", "-c", "print('on mac')"]] },
+            { replace = "if", condition = "factor.win32", then = [["python", "-c", "print('on windows')"]] },
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    deps = [
+      "pytest",
+      { replace = "if", condition = "factor.django50", then = [ "Django>=5.0,<5.1" ] },
+      { replace = "if", condition = "factor.django42", then = [ "Django>=4.2,<4.3" ] },
+      { replace = "if", condition = "not factor.lint", then = [ "coverage" ] },
+    ]
+    commands = [
+      { replace = "if", condition = "factor.linux", then = [ [ "python", "-c", "print('on linux')" ] ] },
+      { replace = "if", condition = "factor.darwin", then = [ [ "python", "-c", "print('on mac')" ] ] },
+      { replace = "if", condition = "factor.win32", then = [ [ "python", "-c", "print('on windows')" ] ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_cartesian_product_env_list() {
+    let start = indoc! {r#"
+        env_list = [
+            { product = [["py312", "py313", "py314"], ["django42", "django50"]] },
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      { product = [ [ "py312", "py313", "py314" ], [ "django42", "django50" ] ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_env_base_with_conditional() {
+    let start = indoc! {r#"
+        [env_base.build]
+        factors = [["py312", "py313"], ["x86", "x64"]]
+        env_dir = { replace = "if", condition = "factor.x86", then = ".venv-x86", "else" = ".venv-x64" }
+        commands = [["python", "-c", "print('ok')"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_base.build]
+    factors = [ [ "py312", "py313" ], [ "x86", "x64" ] ]
+    commands = [ [ "python", "-c", "print('ok')" ] ]
+    env_dir = { replace = "if", condition = "factor.x86", then = ".venv-x86", else = ".venv-x64" }
+    "#);
+}
+
+#[test]
+fn test_doc_simple_env_base_template() {
+    let start = indoc! {r#"
+        [env_base.test]
+        factors = [["3.13", "3.14"]]
+        deps = ["pytest>=8"]
+        commands = [["pytest"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_base.test]
+    factors = [ [ "3.13", "3.14" ] ]
+    deps = [ "pytest>=8" ]
+    commands = [ [ "pytest" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_multi_dimensional_env_base() {
+    let start = indoc! {r#"
+        [env_base.django]
+        factors = [["py312", "py313"], ["django42", "django50"]]
+        deps = [
+            "pytest",
+            { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
+            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
+        ]
+        commands = [["pytest"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_base.django]
+    factors = [ [ "py312", "py313" ], [ "django42", "django50" ] ]
+    deps = [
+      "pytest",
+      { replace = "if", condition = "factor.django42", then = [ "Django>=4.2,<4.3" ] },
+      { replace = "if", condition = "factor.django50", then = [ "Django>=5.0,<5.1" ] },
+    ]
+    commands = [ [ "pytest" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_tox_toml_dedicated() {
+    let start = indoc! {r#"
+        requires = ["tox>=4.19"]
+        env_list = ["3.14t", "3.14", "3.13", "3.12", "type"]
+
+        [env_run_base]
+        description = "Run test under {base_python}"
+        commands = [["pytest"]]
+
+        [env.type]
+        description = "run type check on code base"
+        deps = ["mypy==1.18.2", "types-cachetools>=5.5.0.20240820", "types-chardet>=5.0.4.6"]
+        commands = [["mypy", "src{/}tox"], ["mypy", "tests"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    requires = [ "tox>=4.19" ]
+    env_list = [ "3.14", "3.13", "3.12", "3.14t", "type" ]
+
+    [env_run_base]
+    description = "Run test under {base_python}"
+    commands = [ [ "pytest" ] ]
+
+    [env.type]
+    description = "run type check on code base"
+    deps = [ "mypy==1.18.2", "types-cachetools>=5.5.0.20240820", "types-chardet>=5.0.4.6" ]
+    commands = [ [ "mypy", "src{/}tox" ], [ "mypy", "tests" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_requires_multi_deps() {
+    let start = indoc! {r#"
+        requires = [
+          "tox>=4",
+          "virtualenv>20.2",
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    requires = [
+      "tox>=4",
+      "virtualenv>20.2",
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_labels() {
+    let start = indoc! {r#"
+        labels = { test = ["3.14t", "3.14", "3.13", "3.12"], static = ["ruff", "mypy"] }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"labels = { test = [ "3.14t", "3.14", "3.13", "3.12" ], static = [ "ruff", "mypy" ] }"#);
+}
+
+#[test]
+fn test_doc_pass_env() {
+    let start = indoc! {r#"
+        [env_run_base]
+        pass_env = ["FOO_*"]
+        disallow_pass_env = ["FOO_SECRET"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    pass_env = [ "FOO_*" ]
+    disallow_pass_env = [ "FOO_SECRET" ]
+    "#);
+}
+
+#[test]
+fn test_doc_set_env_marker() {
+    let start = indoc! {r#"
+        [env_run_base]
+        set_env.LINUX_VAR = { value = "1", marker = "sys_platform == 'linux'" }
+        set_env.WIN_VAR = { value = "1", marker = "sys_platform == 'win32'" }
+        set_env.CONDITIONAL = { replace = "env", name = "MY_VAR", default = "fallback", marker = "sys_platform == 'linux'" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    set_env.CONDITIONAL = { replace = "env", name = "MY_VAR", default = "fallback", marker = "sys_platform == 'linux'" }
+    set_env.LINUX_VAR = { value = "1", marker = "sys_platform == 'linux'" }
+    set_env.WIN_VAR = { value = "1", marker = "sys_platform == 'win32'" }
+    "#);
+}
+
+#[test]
+fn test_doc_env_labels() {
+    let start = indoc! {r#"
+        [env_run_base]
+        labels = ["test", "core"]
+
+        [env.flake8]
+        labels = ["mypy"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    labels = [ "core", "test" ]
+
+    [env.flake8]
+    labels = [ "mypy" ]
+    "#);
+}
+
+#[test]
+fn test_doc_depends() {
+    let start = indoc! {r#"
+        [env.coverage]
+        depends = ["3.*"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.coverage]
+    depends = [ "3.*" ]
+    "#);
+}
+
+#[test]
+fn test_doc_extra_setup_commands() {
+    let start = indoc! {r#"
+        [env_run_base]
+        deps = ["pre-commit"]
+        extra_setup_commands = [
+          ["pre-commit", "install-hooks"],
+        ]
+        commands = [
+          ["pre-commit", "run", "--all-files"],
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    deps = [ "pre-commit" ]
+    extra_setup_commands = [
+      [ "pre-commit", "install-hooks" ],
+    ]
+    commands = [
+      [ "pre-commit", "run", "--all-files" ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_recreate_commands() {
+    let start = indoc! {r#"
+        [env_run_base]
+        deps = ["pre-commit"]
+        recreate_commands = [["{env_python}", "-Im", "pre_commit", "clean"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    deps = [ "pre-commit" ]
+    recreate_commands = [ [ "{env_python}", "-Im", "pre_commit", "clean" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_commands_retry() {
+    let start = indoc! {r#"
+        [env_run_base]
+        commands_retry = 2
+        commands = [["pytest", "tests"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    commands_retry = 2
+    commands = [ [ "pytest", "tests" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_default_base_python() {
+    let start = indoc! {r#"
+        [env_run_base]
+        default_base_python = ["3.14", "3.13"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    default_base_python = [ "3.14", "3.13" ]
+    "#);
+}
+
+#[test]
+fn test_doc_pylock() {
+    let start = indoc! {r#"
+        [env_run_base]
+        pylock = "pylock.toml"
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    pylock = "pylock.toml"
+    "#);
+}
+
+#[test]
+fn test_doc_deps_with_requirements_file() {
+    let start = indoc! {r#"
+        [env_run_base]
+        deps = [
+          "pytest>=8",
+          "-r requirements.txt",
+          "-c constraints.txt",
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    deps = [
+      "-c constraints.txt",
+      "-r requirements.txt",
+      "pytest>=8",
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_ref_extend_env_key() {
+    let start = indoc! {r#"
+        [env.src]
+        extras = ["A", "{env_name}"]
+        [env.dest]
+        extras = [{ replace = "ref", env = "src", key = "extras", extend = true }, "B"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.dest]
+    extras = [ { replace = "ref", env = "src", key = "extras", extend = true }, "B" ]
+
+    [env.src]
+    extras = [ "{env_name}", "A" ]
+    "#);
+}
+
+#[test]
+fn test_doc_ref_extend_of() {
+    let start = indoc! {r#"
+        [env.src]
+        extras = ["A", "{env_name}"]
+        [env.dest]
+        extras = [{ replace = "ref", of = ["env", "extras"], extend = true }, "B"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.dest]
+    extras = [ { replace = "ref", of = [ "env", "extras" ], extend = true }, "B" ]
+
+    [env.src]
+    extras = [ "{env_name}", "A" ]
+    "#);
+}
+
+#[test]
+fn test_doc_posargs_default_extend() {
+    let start = indoc! {r#"
+        [env.A]
+        commands = [["python", { replace = "posargs", default = ["a", "b"], extend = true } ]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    commands = [ [ "python", { replace = "posargs", default = [ "a", "b" ], extend = true } ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_posargs_as_default_command() {
+    let start = indoc! {r#"
+        [env.A]
+        commands = [
+            { replace = "posargs", default = ["python", "patch.py"]},
+            ["pytest"]
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    commands = [ { replace = "posargs", default = [ "python", "patch.py" ] }, [ "pytest" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_env_replacement() {
+    let start = indoc! {r#"
+        [env.A]
+        set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "ok" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "ok" }
+    "#);
+}
+
+#[test]
+fn test_doc_ref_merging() {
+    let start = indoc! {r#"
+        [env_run_base]
+        set_env = { A = "1", B = "2"}
+
+        [env.magic]
+        set_env = [
+            { replace = "ref", of = ["env_run_base", "set_env"]},
+            { C = "3", D = "4"},
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    set_env = { A = "1", B = "2" }
+
+    [env.magic]
+    set_env = [
+      { replace = "ref", of = [ "env_run_base", "set_env" ] },
+      { C = "3", D = "4" },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_glob_pattern() {
+    let start = indoc! {r#"
+        [env.A]
+        commands = [["twine", "upload", { replace = "glob", pattern = "dist/*.whl", extend = true }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    commands = [ [ "twine", "upload", { replace = "glob", pattern = "dist/*.whl", extend = true } ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_glob_with_default() {
+    let start = indoc! {r#"
+        [env.A]
+        commands = [["twine", "upload", { replace = "glob", pattern = "dist/*.whl", default = ["fallback.whl"], extend = true }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    commands = [
+      [ "twine", "upload", { replace = "glob", pattern = "dist/*.whl", default = [ "fallback.whl" ], extend = true } ]
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_if_env_var() {
+    let start = indoc! {r#"
+        [env.A]
+        set_env.MATURITY = { replace = "if", condition = "env.TAG_NAME", then = "production", "else" = "testing" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    set_env.MATURITY = { replace = "if", condition = "env.TAG_NAME", then = "production", else = "testing" }
+    "#);
+}
+
+#[test]
+fn test_doc_if_equality_check() {
+    let start = indoc! {r#"
+        [env.A]
+        set_env.MODE = { replace = "if", condition = "env.CI == 'true'", then = "ci", "else" = "local" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    set_env.MODE = { replace = "if", condition = "env.CI == 'true'", then = "ci", else = "local" }
+    "#);
+}
+
+#[test]
+fn test_doc_if_boolean_logic() {
+    let start = indoc! {r#"
+        [env.A]
+        description = { replace = "if", condition = "env.CI and env.DEPLOY", then = "deploying", "else" = "skipped" }
+
+        [env.B]
+        description = { replace = "if", condition = "env.CI or env.LOCAL", then = "active", "else" = "inactive" }
+
+        [env.C]
+        description = { replace = "if", condition = "not env.CI", then = "local dev", "else" = "CI build" }
+
+        [env.D]
+        description = { replace = "if", condition = "env.MODE != 'prod'", then = "non-production", "else" = "production" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    description = { replace = "if", condition = "env.CI and env.DEPLOY", then = "deploying", else = "skipped" }
+
+    [env.B]
+    description = { replace = "if", condition = "env.CI or env.LOCAL", then = "active", else = "inactive" }
+
+    [env.C]
+    description = { replace = "if", condition = "not env.CI", then = "local dev", else = "CI build" }
+
+    [env.D]
+    description = { replace = "if", condition = "env.MODE != 'prod'", then = "non-production", else = "production" }
+    "#);
+}
+
+#[test]
+fn test_doc_if_no_else() {
+    let start = indoc! {r#"
+        [env.A]
+        description = { replace = "if", condition = "env.DEPLOY", then = "deployment mode" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    description = { replace = "if", condition = "env.DEPLOY", then = "deployment mode" }
+    "#);
+}
+
+#[test]
+fn test_doc_if_with_env_name() {
+    let start = indoc! {r#"
+        [env.A]
+        description = { replace = "if", condition = "env.DEPLOY", then = "{env_name}", "else" = "none" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    description = { replace = "if", condition = "env.DEPLOY", then = "{env_name}", else = "none" }
+    "#);
+}
+
+#[test]
+fn test_doc_if_list_values_extend() {
+    let start = indoc! {r#"
+        [env.A]
+        commands = [["pytest", { replace = "if", condition = "env.VERBOSE", then = ["--verbose", "--debug"], "else" = ["--quiet"], extend = true }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.A]
+    commands = [
+      [
+        "pytest",
+        { replace = "if", condition = "env.VERBOSE", then = [ "--verbose", "--debug" ], else = [ "--quiet" ], extend = true },
+      ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_factor_based_commands() {
+    let start = indoc! {r#"
+        [env_run_base]
+        commands = [
+            { replace = "if", condition = "factor.linux", then = [["pytest", "--numprocesses=auto"]] },
+            { replace = "if", condition = "not factor.linux", then = [["pytest"]] },
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    commands = [
+      { replace = "if", condition = "factor.linux", then = [ [ "pytest", "--numprocesses=auto" ] ] },
+      { replace = "if", condition = "not factor.linux", then = [ [ "pytest" ] ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_factor_and_env_combined() {
+    let start = indoc! {r#"
+        [env_run_base]
+        commands = [["pytest", { replace = "if", condition = "factor.linux and env.CI", then = ["--numprocesses=auto"], "else" = [], extend = true }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    commands = [
+      [
+        "pytest",
+        { replace = "if", condition = "factor.linux and env.CI", then = [ "--numprocesses=auto" ], else = [], extend = true },
+      ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_complex_matrix_three_factors() {
+    let start = indoc! {r#"
+        env_list = [
+            "lint",
+            { product = [
+                { prefix = "py3", start = 9, stop = 11 },
+                ["django41", "django40"],
+                ["sqlite", "mysql"],
+            ] },
+        ]
+
+        [env_run_base]
+        deps = [
+            { replace = "if", condition = "factor.django41", then = ["Django>=4.1,<4.2"] },
+            { replace = "if", condition = "factor.django40", then = ["Django>=4.0,<4.1"] },
+            { replace = "if", condition = "factor.py311 and factor.mysql", then = ["PyMySQL"] },
+            { replace = "if", condition = "factor.py311 or factor.py310", then = ["urllib3"] },
+            { replace = "if", condition = "(factor.py311 or factor.py310) and factor.sqlite", then = ["mock"] },
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      "lint",
+      { product = [
+        { prefix = "py3", start = 9, stop = 11 },
+        [ "django41", "django40" ],
+        [ "sqlite", "mysql" ],
+      ] },
+    ]
+
+    [env_run_base]
+    deps = [
+      { replace = "if", condition = "factor.django41", then = [ "Django>=4.1,<4.2" ] },
+      { replace = "if", condition = "factor.django40", then = [ "Django>=4.0,<4.1" ] },
+      { replace = "if", condition = "factor.py311 and factor.mysql", then = [ "PyMySQL" ] },
+      { replace = "if", condition = "factor.py311 or factor.py310", then = [ "urllib3" ] },
+      { replace = "if", condition = "(factor.py311 or factor.py310) and factor.sqlite", then = [ "mock" ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_range_env_list() {
+    let start = indoc! {r#"
+        env_list = [
+            { product = [{ prefix = "py3", start = 10 }, ["django42"]] },
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      { product = [ { prefix = "py3", start = 10 }, [ "django42" ] ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_product_with_exclude() {
+    let start = indoc! {r#"
+        env_list = [
+            { product = [["py312", "py313"], ["django42", "django50"]], exclude = ["py312-django50"] },
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      { product = [ [ "py312", "py313" ], [ "django42", "django50" ] ], exclude = [ "py312-django50" ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_arch_specific_config() {
+    let start = indoc! {r#"
+        [env_base.py311-venv]
+        factors = [["x86", "x64"]]
+        base_python = { replace = "if", condition = "factor.x86", then = "python3.11-32", "else" = "python3.11-64" }
+        env_dir = { replace = "if", condition = "factor.x86", then = ".venv-x86", "else" = ".venv-x64" }
+        commands = [["pytest"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_base.py311-venv]
+    factors = [ [ "x86", "x64" ] ]
+    base_python = { replace = "if", condition = "factor.x86", then = "python3.11-32", else = "python3.11-64" }
+    commands = [ [ "pytest" ] ]
+    env_dir = { replace = "if", condition = "factor.x86", then = ".venv-x86", else = ".venv-x64" }
+    "#);
+}
+
+#[test]
+fn test_doc_env_pkg_base_pass_env() {
+    let start = indoc! {r#"
+        [env_pkg_base]
+        pass_env = ["PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_SYSROOT_DIR"]
+
+        [env.".pkg-cpython311"]
+        pass_env = ["PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_SYSROOT_DIR", "IS_311"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_pkg_base]
+    pass_env = [ "PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_SYSROOT_DIR" ]
+
+    [env.".pkg-cpython311"]
+    pass_env = [ "IS_311", "PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_SYSROOT_DIR" ]
+    "#);
+}
+
+#[test]
+fn test_doc_virtualenv_spec() {
+    let start = indoc! {r#"
+        [env.legacy]
+        base_python = ["python3.6"]
+        virtualenv_spec = "virtualenv<20.22.0"
+        commands = [["python", "-c", "import sys; print(sys.version)"]]
+
+        [env.modern]
+        base_python = ["python3.15"]
+        commands = [["python", "-c", "import sys; print(sys.version)"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.legacy]
+    base_python = [ "python3.6" ]
+    virtualenv_spec = "virtualenv<20.22.0"
+    commands = [ [ "python", "-c", "import sys; print(sys.version)" ] ]
+
+    [env.modern]
+    base_python = [ "python3.15" ]
+    commands = [ [ "python", "-c", "import sys; print(sys.version)" ] ]
+    "#);
+}
+
+// --- how-to/usage.rst examples ---
+
+#[test]
+fn test_doc_basic_pytest() {
+    let start = indoc! {r#"
+        env_list = ["3.13", "3.12"]
+
+        [env_run_base]
+        deps = ["pytest>=8"]
+        commands = [["pytest", { replace = "posargs", default = ["tests"], extend = true }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [ "3.13", "3.12" ]
+
+    [env_run_base]
+    deps = [ "pytest>=8" ]
+    commands = [ [ "pytest", { replace = "posargs", default = [ "tests" ], extend = true } ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_coverage_collection() {
+    let start = indoc! {r#"
+        env_list = ["3.13", "3.12", "coverage"]
+
+        [env_run_base]
+        deps = ["pytest", "coverage[toml]"]
+        commands = [["coverage", "run", "-p", "-m", "pytest", "tests"]]
+
+        [env.coverage]
+        skip_install = true
+        deps = ["coverage[toml]"]
+        depends = ["3.*"]
+        commands = [
+            ["coverage", "combine"],
+            ["coverage", "report", "--fail-under=80"],
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [ "3.13", "3.12", "coverage" ]
+
+    [env_run_base]
+    deps = [ "coverage[toml]", "pytest" ]
+    commands = [ [ "coverage", "run", "-p", "-m", "pytest", "tests" ] ]
+
+    [env.coverage]
+    skip_install = true
+    deps = [ "coverage[toml]" ]
+    commands = [
+      [ "coverage", "combine" ],
+      [ "coverage", "report", "--fail-under=80" ],
+    ]
+    depends = [ "3.*" ]
+    "#);
+}
+
+#[test]
+fn test_doc_labels_grouping() {
+    let start = indoc! {r#"
+        env_list = ["3.13", "3.12", "lint", "type"]
+
+        [env_run_base]
+        labels = ["test"]
+        commands = [["pytest", "tests"]]
+
+        [env.lint]
+        labels = ["check"]
+        skip_install = true
+        deps = ["ruff"]
+        commands = [["ruff", "check", "."]]
+
+        [env.type]
+        labels = ["check"]
+        deps = ["mypy"]
+        commands = [["mypy", "src"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [ "3.13", "3.12", "lint", "type" ]
+
+    [env_run_base]
+    commands = [ [ "pytest", "tests" ] ]
+    labels = [ "test" ]
+
+    [env.lint]
+    skip_install = true
+    deps = [ "ruff" ]
+    commands = [ [ "ruff", "check", "." ] ]
+    labels = [ "check" ]
+
+    [env.type]
+    deps = [ "mypy" ]
+    commands = [ [ "mypy", "src" ] ]
+    labels = [ "check" ]
+    "#);
+}
+
+#[test]
+fn test_doc_platform_specific_deps() {
+    let start = indoc! {r#"
+        [env_run_base]
+        deps = [
+            "pytest",
+            { replace = "if", condition = "factor.linux or factor.darwin", then = ["platformdirs>=3"] },
+            { replace = "if", condition = "factor.win32", then = ["platformdirs>=2"] },
+        ]
+        commands = [
+            { replace = "if", condition = "factor.linux", then = [["python", "-c", "print('Running on Linux')"]] },
+            { replace = "if", condition = "factor.darwin", then = [["python", "-c", "print('Running on macOS')"]] },
+            { replace = "if", condition = "factor.win32", then = [["python", "-c", "print('Running on Windows')"]] },
+            ["python", "-m", "pytest"],
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    deps = [
+      "pytest",
+      { replace = "if", condition = "factor.linux or factor.darwin", then = [ "platformdirs>=3" ] },
+      { replace = "if", condition = "factor.win32", then = [ "platformdirs>=2" ] },
+    ]
+    commands = [
+      { replace = "if", condition = "factor.linux", then = [ [ "python", "-c", "print('Running on Linux')" ] ] },
+      { replace = "if", condition = "factor.darwin", then = [ [ "python", "-c", "print('Running on macOS')" ] ] },
+      { replace = "if", condition = "factor.win32", then = [ [ "python", "-c", "print('Running on Windows')" ] ] },
+      [ "python", "-m", "pytest" ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_multi_dim_platform_django() {
+    let start = indoc! {r#"
+        env_list = [
+            { product = [["py312", "py313"], ["django42", "django50"]] },
+        ]
+
+        [env_run_base]
+        deps = [
+            { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
+            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
+            { replace = "if", condition = "factor.py312 and factor.linux", then = ["pytest-xdist"] },
+            { replace = "if", condition = "factor.darwin", then = ["pyobjc-framework-Cocoa"] },
+        ]
+        commands = [
+            { replace = "if", condition = "factor.win32", then = [["python", "-c", "import winreg"]] },
+            ["pytest"],
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      { product = [ [ "py312", "py313" ], [ "django42", "django50" ] ] },
+    ]
+
+    [env_run_base]
+    deps = [
+      { replace = "if", condition = "factor.django42", then = [ "Django>=4.2,<4.3" ] },
+      { replace = "if", condition = "factor.django50", then = [ "Django>=5.0,<5.1" ] },
+      { replace = "if", condition = "factor.py312 and factor.linux", then = [ "pytest-xdist" ] },
+      { replace = "if", condition = "factor.darwin", then = [ "pyobjc-framework-Cocoa" ] },
+    ]
+    commands = [
+      { replace = "if", condition = "factor.win32", then = [ [ "python", "-c", "import winreg" ] ] },
+      [ "pytest" ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_negated_platform_factors() {
+    let start = indoc! {r#"
+        [env_run_base]
+        deps = [
+            { replace = "if", condition = "not factor.win32", then = ["uvloop"] },
+            { replace = "if", condition = "not factor.darwin", then = ["pyinotify"] },
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    deps = [
+      { replace = "if", condition = "not factor.win32", then = [ "uvloop" ] },
+      { replace = "if", condition = "not factor.darwin", then = [ "pyinotify" ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_platform_specific_commands() {
+    let start = indoc! {r#"
+        [env_run_base]
+        commands = [
+            { replace = "if", condition = "factor.linux", then = [["pytest", "--numprocesses=auto"]] },
+            { replace = "if", condition = "factor.darwin or factor.win32", then = [["pytest"]] },
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    commands = [
+      { replace = "if", condition = "factor.linux", then = [ [ "pytest", "--numprocesses=auto" ] ] },
+      { replace = "if", condition = "factor.darwin or factor.win32", then = [ [ "pytest" ] ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_conditional_set_env() {
+    let start = indoc! {r#"
+        [env_run_base]
+        set_env.MATURITY = { replace = "if", condition = "env.CI", then = "release", "else" = "dev" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    set_env.MATURITY = { replace = "if", condition = "env.CI", then = "release", else = "dev" }
+    "#);
+}
+
+#[test]
+fn test_doc_conditional_command_args() {
+    let start = indoc! {r#"
+        [env_run_base]
+        commands = [["pytest", { replace = "if", condition = "env.DEBUG", then = ["-vv", "--tb=long"], "else" = [], extend = true }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    commands = [
+      [ "pytest", { replace = "if", condition = "env.DEBUG", then = [ "-vv", "--tb=long" ], else = [], extend = true } ]
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_conditional_deps_with_else() {
+    let start = indoc! {r#"
+        [env_run_base]
+        deps = [
+            "pytest",
+            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"], "else" = ["Django>=4.2,<4.3"] },
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    deps = [
+      "pytest",
+      { replace = "if", condition = "factor.django50", then = [ "Django>=5.0,<5.1" ], else = [ "Django>=4.2,<4.3" ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_complex_boolean_conditions() {
+    let start = indoc! {r#"
+        [env.deploy]
+        commands = [["deploy", { replace = "if", condition = "env.CI and env.TAG_NAME != ''", then = ["--production"], "else" = ["--dry-run"], extend = true }]]
+
+        [env_run_base]
+        commands = [["pytest", { replace = "if", condition = "factor.linux and not env.CI", then = ["--numprocesses=auto"], "else" = [], extend = true }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    commands = [
+      [
+        "pytest",
+        { replace = "if", condition = "factor.linux and not env.CI", then = [ "--numprocesses=auto" ], else = [], extend = true },
+      ],
+    ]
+
+    [env.deploy]
+    commands = [
+      [
+        "deploy",
+        { replace = "if", condition = "env.CI and env.TAG_NAME != ''", then = [ "--production" ], else = [ "--dry-run" ], extend = true },
+      ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_custom_pypi_with_env_fallback() {
+    let start = indoc! {r#"
+        [env_run_base]
+        set_env.PIP_INDEX_URL = { replace = "env", name = "PIP_INDEX_URL", default = "https://my.pypi.example/simple" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    set_env.PIP_INDEX_URL = { replace = "env", name = "PIP_INDEX_URL", default = "https://my.pypi.example/simple" }
+    "#);
+}
+
+#[test]
+fn test_doc_multiple_pypi_servers() {
+    let start = indoc! {r#"
+        [env_run_base]
+        set_env.PIP_INDEX_URL = { replace = "env", name = "PIP_INDEX_URL", default = "https://primary.example/simple" }
+        set_env.PIP_EXTRA_INDEX_URL = { replace = "env", name = "PIP_EXTRA_INDEX_URL", default = "https://secondary.example/simple" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    set_env.PIP_EXTRA_INDEX_URL = { replace = "env", name = "PIP_EXTRA_INDEX_URL", default = "https://secondary.example/simple" }
+    set_env.PIP_INDEX_URL = { replace = "env", name = "PIP_INDEX_URL", default = "https://primary.example/simple" }
+    "#);
+}
+
+#[test]
+fn test_doc_extras() {
+    let start = indoc! {r#"
+        [env_run_base]
+        extras = ["testing"]
+
+        [env.docs]
+        extras = ["docs"]
+        commands = [["sphinx-build", "-W", "docs", "docs/_build/html"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    extras = [ "testing" ]
+
+    [env.docs]
+    extras = [ "docs" ]
+    commands = [ [ "sphinx-build", "-W", "docs", "docs/_build/html" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_generative_matrix_with_range() {
+    let start = indoc! {r#"
+        env_list = [
+            "lint",
+            { product = [
+                { prefix = "py3", start = 12, stop = 14 },
+                ["django42", "django50"],
+            ] },
+        ]
+
+        [env_run_base]
+        package = "skip"
+        deps = [
+            "pytest",
+            { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
+            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
+        ]
+        commands = [["pytest"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      "lint",
+      { product = [
+        { prefix = "py3", start = 12, stop = 14 },
+        [ "django42", "django50" ],
+      ] },
+    ]
+
+    [env_run_base]
+    package = "skip"
+    deps = [
+      "pytest",
+      { replace = "if", condition = "factor.django42", then = [ "Django>=4.2,<4.3" ] },
+      { replace = "if", condition = "factor.django50", then = [ "Django>=5.0,<5.1" ] },
+    ]
+    commands = [ [ "pytest" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_env_base_range_factors() {
+    let start = indoc! {r#"
+        [env_base.django]
+        factors = [
+            { prefix = "py3", start = 13, stop = 14 },
+            ["django42", "django50"],
+        ]
+        package = "skip"
+        deps = [
+            "pytest",
+            { replace = "if", condition = "factor.django42", then = ["Django>=4.2,<4.3"] },
+            { replace = "if", condition = "factor.django50", then = ["Django>=5.0,<5.1"] },
+        ]
+        commands = [["pytest"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_base.django]
+    factors = [
+      { prefix = "py3", start = 13, stop = 14 },
+      [ "django42", "django50" ],
+    ]
+    package = "skip"
+    deps = [
+      "pytest",
+      { replace = "if", condition = "factor.django42", then = [ "Django>=4.2,<4.3" ] },
+      { replace = "if", condition = "factor.django50", then = [ "Django>=5.0,<5.1" ] },
+    ]
+    commands = [ [ "pytest" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_open_ended_range_start() {
+    let start = indoc! {r#"
+        env_list = [
+            { product = [{ prefix = "py3", start = 10 }] },
+            "lint",
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      { product = [ { prefix = "py3", start = 10 } ] },
+      "lint",
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_open_ended_range_stop() {
+    let start = indoc! {r#"
+        env_list = [
+            { product = [{ prefix = "py3", stop = 13 }] },
+            "lint",
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      { product = [ { prefix = "py3", stop = 13 } ] },
+      "lint",
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_ignore_exit_code() {
+    let start = indoc! {r#"
+        [env_run_base]
+        commands = [
+            ["-", "python", "-c", "import sys; sys.exit(1)"],
+            ["python", "--version"],
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    commands = [
+      [ "-", "python", "-c", "import sys; sys.exit(1)" ],
+      [ "python", "--version" ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_invert_exit_code() {
+    let start = indoc! {r#"
+        [env_run_base]
+        commands = [
+            ["!", "python", "-c", "import sys; sys.exit(1)"],
+            ["python", "--version"],
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    commands = [
+      [ "!", "python", "-c", "import sys; sys.exit(1)" ],
+      [ "python", "--version" ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_sphinx_build() {
+    let start = indoc! {r#"
+        [env.docs]
+        description = "build documentation"
+        deps = ["sphinx>=7"]
+        commands = [
+            ["sphinx-build", "-d", "{env_tmp_dir}/doctree", "docs", "{work_dir}/docs_out", "--color", "-b", "html"],
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.docs]
+    description = "build documentation"
+    deps = [ "sphinx>=7" ]
+    commands = [
+      [
+        "sphinx-build",
+        "-d",
+        "{env_tmp_dir}/doctree",
+        "docs",
+        "{work_dir}/docs_out",
+        "--color",
+        "-b",
+        "html"
+      ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_doc_mkdocs() {
+    let start = indoc! {r#"
+        [env.docs]
+        description = "run a development server for documentation"
+        deps = [
+            "mkdocs>=1.3",
+            "mkdocs-material",
+        ]
+        commands = [
+            ["mkdocs", "build", "--clean"],
+            ["mkdocs", "serve", "-a", "localhost:8080"],
+        ]
+
+        [env.docs-deploy]
+        description = "build and deploy documentation"
+        deps = [
+            "mkdocs>=1.3",
+            "mkdocs-material",
+        ]
+        commands = [["mkdocs", "gh-deploy", "--clean"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.docs]
+    description = "run a development server for documentation"
+    deps = [
+      "mkdocs>=1.3",
+      "mkdocs-material",
+    ]
+    commands = [
+      [ "mkdocs", "build", "--clean" ],
+      [ "mkdocs", "serve", "-a", "localhost:8080" ],
+    ]
+
+    [env.docs-deploy]
+    description = "build and deploy documentation"
+    deps = [
+      "mkdocs>=1.3",
+      "mkdocs-material",
+    ]
+    commands = [ [ "mkdocs", "gh-deploy", "--clean" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_virtualenv_per_env() {
+    let start = indoc! {r#"
+        env_list = ["3.6", "3.15", "3.13"]
+
+        [env_run_base]
+        deps = ["pytest"]
+        commands = [["pytest"]]
+
+        [env."3.6"]
+        virtualenv_spec = "virtualenv<20.22.0"
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [ "3.15", "3.13", "3.6" ]
+
+    [env_run_base]
+    deps = [ "pytest" ]
+    commands = [ [ "pytest" ] ]
+
+    [env."3.6"]
+    virtualenv_spec = "virtualenv<20.22.0"
+    "#);
+}
+
+#[test]
+fn test_doc_pylock_with_extras_and_groups() {
+    let start = indoc! {r#"
+        [env.docs]
+        pylock = "pylock.toml"
+        extras = ["docs"]
+
+        [env.dev]
+        pylock = "pylock.toml"
+        dependency_groups = ["dev"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.dev]
+    dependency_groups = [ "dev" ]
+    pylock = "pylock.toml"
+
+    [env.docs]
+    pylock = "pylock.toml"
+    extras = [ "docs" ]
+    "#);
+}
+
+#[test]
+fn test_doc_clean_cache_recreate() {
+    let start = indoc! {r#"
+        [env_run_base]
+        deps = ["pre-commit"]
+        recreate_commands = [["{env_python}", "-Im", "pre_commit", "clean"]]
+        commands = [["pre-commit", "run", "--all-files"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    deps = [ "pre-commit" ]
+    recreate_commands = [ [ "{env_python}", "-Im", "pre_commit", "clean" ] ]
+    commands = [ [ "pre-commit", "run", "--all-files" ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_arch_specific_interpreters() {
+    let start = indoc! {r#"
+        env_list = ["arm64", "x86_64"]
+
+        [env.arm64]
+        base_python = ["cpython3.12-64-arm64"]
+        commands = [["pytest"]]
+
+        [env.x86_64]
+        base_python = ["cpython3.12-64-x86_64"]
+        commands = [["pytest"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [ "arm64", "x86_64" ]
+
+    [env.arm64]
+    base_python = [ "cpython3.12-64-arm64" ]
+    commands = [ [ "pytest" ] ]
+
+    [env.x86_64]
+    base_python = [ "cpython3.12-64-x86_64" ]
+    commands = [ [ "pytest" ] ]
+    "#);
+}
+
+// --- tutorial/getting-started.rst examples ---
+
+#[test]
+fn test_doc_getting_started() {
+    let start = indoc! {r#"
+        env_list = ["3.13", "3.12", "lint"]
+
+        [env_run_base]
+        description = "run the test suite with pytest"
+        deps = [
+            "pytest>=8",
+        ]
+        commands = [["pytest", { replace = "posargs", default = ["tests"], extend = true }]]
+
+        [env.lint]
+        description = "run linters"
+        skip_install = true
+        deps = ["ruff"]
+        commands = [["ruff", "check", { replace = "posargs", default = ["."], extend = true }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [ "3.13", "3.12", "lint" ]
+
+    [env_run_base]
+    description = "run the test suite with pytest"
+    deps = [
+      "pytest>=8",
+    ]
+    commands = [ [ "pytest", { replace = "posargs", default = [ "tests" ], extend = true } ] ]
+
+    [env.lint]
+    description = "run linters"
+    skip_install = true
+    deps = [ "ruff" ]
+    commands = [ [ "ruff", "check", { replace = "posargs", default = [ "." ], extend = true } ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_full_tox_toml_structure() {
+    let start = indoc! {r#"
+        # tox.toml - values at root level are core settings
+        requires = ["tox>=4.20"]
+        env_list = ["3.13", "3.12", "lint"]
+
+        # base settings for run environments
+        [env_run_base]
+        deps = ["pytest>=8"]
+        commands = [["pytest", "tests"]]
+
+        # environment-specific overrides
+        [env.lint]
+        skip_install = true
+        deps = ["ruff"]
+        commands = [["ruff", "check", "."]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    # tox.toml - values at root level are core settings
+    requires = [ "tox>=4.20" ]
+    env_list = [ "3.13", "3.12", "lint" ]
+
+    # base settings for run environments
+    [env_run_base]
+    deps = [ "pytest>=8" ]
+    commands = [ [ "pytest", "tests" ] ]
+
+    # environment-specific overrides
+    [env.lint]
+    skip_install = true
+    deps = [ "ruff" ]
+    commands = [ [ "ruff", "check", "." ] ]
+    "#);
+}
+
+#[test]
+fn test_doc_env_base_tutorial() {
+    let start = indoc! {r#"
+        [env_base.test]
+        factors = [["3.13", "3.14"]]
+        deps = ["pytest>=8"]
+        commands = [["pytest"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_base.test]
+    factors = [ [ "3.13", "3.14" ] ]
+    deps = [ "pytest>=8" ]
+    commands = [ [ "pytest" ] ]
+    "#);
+}

--- a/tox-toml-fmt/rust/src/tests/global_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/global_tests.rs
@@ -104,11 +104,11 @@ fn test_reorder_table_reorder_env_list_partial() {
     [env.type]
     description = "type"
 
-    [env.lint]
-    description = "lint"
-
     [env.docs]
     description = "docs"
+
+    [env.lint]
+    description = "lint"
     "#);
 }
 

--- a/tox-toml-fmt/rust/src/tests/main_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/main_tests.rs
@@ -1123,6 +1123,179 @@ fn test_env_quoted_key_dotted_expand() {
 }
 
 #[test]
+fn test_deps_r_c_flags_not_normalized() {
+    let start = indoc! {r#"
+        [env.test]
+        deps = ["-r requirements-test.txt", "-c constraints.txt", "pytest"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    deps = [ "-c constraints.txt", "-r requirements-test.txt", "pytest" ]
+    "#);
+}
+
+#[test]
+fn test_constraints_normalize_and_sort() {
+    let start = indoc! {r#"
+        [env.test]
+        constraints = ["urllib3<2", "Certifi>=2023"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    constraints = [ "certifi>=2023", "urllib3<2" ]
+    "#);
+}
+
+#[test]
+fn test_constraints_r_c_flags_not_normalized() {
+    let start = indoc! {r#"
+        [env.test]
+        constraints = ["-c base-constraints.txt", "-r requirements.txt", "urllib3<2"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    constraints = [ "-c base-constraints.txt", "-r requirements.txt", "urllib3<2" ]
+    "#);
+}
+
+#[test]
+fn test_env_base_key_ordering() {
+    let start = indoc! {r#"
+        [env_base.test]
+        commands = [["pytest"]]
+        deps = ["pytest"]
+        description = "run tests"
+        factors = [["py312", "py313"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_base.test]
+    factors = [ [ "py312", "py313" ] ]
+    description = "run tests"
+    deps = [ "pytest" ]
+    commands = [ [ "pytest" ] ]
+    "#);
+}
+
+#[test]
+fn test_env_base_table_ordering() {
+    let start = indoc! {r#"
+        requires = ["tox>=4"]
+
+        [env.lint]
+        description = "lint"
+
+        [env_base.test]
+        factors = [["py312", "py313"]]
+        description = "test"
+
+        [env_run_base]
+        description = "base"
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    requires = [ "tox>=4" ]
+
+    [env_run_base]
+    description = "base"
+
+    [env.lint]
+    description = "lint"
+
+    [env_base.test]
+    factors = [ [ "py312", "py313" ] ]
+    description = "test"
+    "#);
+}
+
+#[test]
+fn test_env_base_alias_normalization() {
+    let start = indoc! {r#"
+        [env_base.test]
+        factors = [["py312"]]
+        basepython = "python3"
+        passenv = ["HOME"]
+        setenv = { FOO = "bar" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_base.test]
+    factors = [ [ "py312" ] ]
+    base_python = "python3"
+    pass_env = [ "HOME" ]
+    set_env = { FOO = "bar" }
+    "#);
+}
+
+#[test]
+fn test_env_base_deps_normalization() {
+    let start = indoc! {r#"
+        [env_base.test]
+        factors = [["py312"]]
+        deps = ["Pytest-Cov>=3", "-r requirements.txt", "pytest>=7"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_base.test]
+    factors = [ [ "py312" ] ]
+    deps = [ "-r requirements.txt", "pytest>=7", "pytest-cov>=3" ]
+    "#);
+}
+
+#[test]
+fn test_env_list_with_product_expansion() {
+    let start = indoc! {r#"
+        env_list = [
+            "lint",
+            { product = [["py312", "py313"], ["django42"]] },
+            "docs",
+        ]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      { product = [ [ "py312", "py313" ], [ "django42" ] ] },
+      "docs",
+      "lint",
+    ]
+    "#);
+}
+
+#[test]
+fn test_new_env_key_ordering() {
+    let start = indoc! {r#"
+        [env.test]
+        commands = [["pytest"]]
+        commands_retry = 2
+        fail_fast = true
+        recreate_commands = [["rm", "-rf", ".cache"]]
+        recreate = true
+        pylock = "pylock.toml"
+        deps = ["pytest"]
+        virtualenv_spec = "virtualenv<20.22.0"
+        default_base_python = ["python3.12"]
+        extra_setup_commands = [["echo", "setup"]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    default_base_python = [ "python3.12" ]
+    virtualenv_spec = "virtualenv<20.22.0"
+    deps = [ "pytest" ]
+    pylock = "pylock.toml"
+    recreate = true
+    recreate_commands = [ [ "rm", "-rf", ".cache" ] ]
+    fail_fast = true
+    commands_retry = 2
+    extra_setup_commands = [ [ "echo", "setup" ] ]
+    commands = [ [ "pytest" ] ]
+    "#);
+}
+
+#[test]
 fn test_env_multiple_quoted_keys_not_collapsed() {
     let start = indoc! {r#"
         [env."3.13t"]
@@ -1136,13 +1309,179 @@ fn test_env_multiple_quoted_keys_not_collapsed() {
         "#};
     let got = format_toml_helper(start, 2);
     assert_snapshot!(got, @r#"
+    [env.fix]
+    description = "fix"
+
     [env."3.13t"]
     base_python = "3.13t"
 
     [env."3.14t"]
     base_python = "3.14t"
+    "#);
+}
 
-    [env.fix]
-    description = "fix"
+#[test]
+fn test_inline_table_reorder_substitution() {
+    let start = indoc! {r#"
+        [env_run_base]
+        set_env.UV_INDEX_URL = { default = "https://pypi.org/simple", name = "UV_INDEX_URL", replace = "env" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    set_env.UV_INDEX_URL = { replace = "env", name = "UV_INDEX_URL", default = "https://pypi.org/simple" }
+    "#);
+}
+
+#[test]
+fn test_inline_table_reorder_substitution_ref() {
+    let start = indoc! {r#"
+        [env_pkg_base]
+        set_env = { of = ["env_run_base", "set_env"], replace = "ref" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_pkg_base]
+    set_env = { replace = "ref", of = [ "env_run_base", "set_env" ] }
+    "#);
+}
+
+#[test]
+fn test_inline_table_reorder_posargs() {
+    let start = indoc! {r#"
+        [env.test]
+        commands = [["pytest", { default = [], extend = true, replace = "posargs" }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    commands = [
+      [ "pytest", { replace = "posargs", default = [], extend = true } ]
+    ]
+    "#);
+}
+
+#[test]
+fn test_inline_table_reorder_range() {
+    let start = indoc! {r#"
+        env_list = [{ product = [{ stop = 14, prefix = "py3", start = 12 }] }]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [ { product = [ { prefix = "py3", start = 12, stop = 14 } ] } ]
+    "#);
+}
+
+#[test]
+fn test_inline_table_reorder_product() {
+    let start = indoc! {r#"
+        env_list = [{ exclude = ["py312-django50"], product = [["py312", "py313"], ["django42", "django50"]] }]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    env_list = [
+      { product = [ [ "py312", "py313" ], [ "django42", "django50" ] ], exclude = [
+        "py312-django50"
+      ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_inline_table_already_ordered() {
+    let start = indoc! {r#"
+        [env_run_base]
+        set_env.FOO = { replace = "env", name = "FOO", default = "bar" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    set_env.FOO = { replace = "env", name = "FOO", default = "bar" }
+    "#);
+}
+
+#[test]
+fn test_inline_table_unknown_schema_not_reordered() {
+    let start = indoc! {r#"
+        [env.test]
+        set_env = { ZZZ = "last", AAA = "first" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    set_env = { ZZZ = "last", AAA = "first" }
+    "#);
+}
+
+#[test]
+fn test_inline_table_reorder_if_conditional() {
+    let start = indoc! {r#"
+        [env.test]
+        deps = [{ "else" = "no", extend = true, then = ["Django>=5.0"], condition = "factor.django50", replace = "if" }]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    deps = [
+      { replace = "if", condition = "factor.django50", then = [ "Django>=5.0" ], else = "no", extend = true },
+    ]
+    "#);
+}
+
+#[test]
+fn test_inline_table_reorder_ref() {
+    let start = indoc! {r#"
+        [env.test]
+        extras = [{ extend = true, key = "extras", env = "src", replace = "ref" }]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    extras = [ { replace = "ref", env = "src", key = "extras", extend = true } ]
+    "#);
+}
+
+#[test]
+fn test_inline_table_reorder_glob() {
+    let start = indoc! {r#"
+        [env.test]
+        commands = [["twine", "upload", { extend = true, pattern = "dist/*.whl", replace = "glob" }]]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    commands = [
+      [
+        "twine",
+        "upload",
+        { replace = "glob", pattern = "dist/*.whl", extend = true }
+      ],
+    ]
+    "#);
+}
+
+#[test]
+fn test_inline_table_reorder_value_marker() {
+    let start = indoc! {r#"
+        [env_run_base]
+        set_env.LINUX_VAR = { marker = "sys_platform == 'linux'", value = "1" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    set_env.LINUX_VAR = { value = "1", marker = "sys_platform == 'linux'" }
+    "#);
+}
+
+#[test]
+fn test_inline_table_reorder_env_with_marker() {
+    let start = indoc! {r#"
+        [env_run_base]
+        set_env.X = { marker = "sys_platform == 'linux'", default = "fallback", name = "MY_VAR", replace = "env" }
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env_run_base]
+    set_env.X = { replace = "env", name = "MY_VAR", default = "fallback", marker = "sys_platform == 'linux'" }
     "#);
 }

--- a/tox-toml-fmt/rust/src/tests/mod.rs
+++ b/tox-toml-fmt/rust/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub use common::test_util::{assert_valid_toml, format_syntax, parse};
 
+mod doc_examples_tests;
 mod global_tests;
 mod main_tests;


### PR DESCRIPTION
Both formatters lacked two pieces of TOML normalization that left files looking inconsistent. Quoted keys like `"description"` or `"else"` that are valid bare keys stayed quoted, and inline table keys like `{ default = ".", replace = "default" }` appeared in whatever order the author typed them. 🔑 These inconsistencies made diffs noisier and code reviews harder.

The key quote normalization in `normalize_key_quotes` now strips redundant double-quoted and single-quoted keys down to bare keys when the value contains only `A-Za-z0-9_-`. This runs on the entire AST, so it applies to table headers, key-value pairs, dotted keys, and inline table keys for both `pyproject-fmt` and `tox-toml-fmt`. For inline table key reordering, a new `InlineTableSchema` abstraction in `common::table` lets each formatter define discriminator-based schemas — tox-toml-fmt uses this to enforce consistent ordering for `replace`, `prefix`, `product`, and `value` inline tables.

The PR also adds 8 missing environment keys to the tox-toml-fmt key ordering (`factors`, `default_base_python`, `virtualenv_spec`, `pylock`, `recreate_commands`, `fail_fast`, `commands_retry`, `extra_setup_commands`), supports `env_base.*` tables, handles pip file references (`-r`/`-c`) in `deps`/`constraints` sorting, excludes inline tables from `env_list` sorting, and sorts remaining `env.*` sections alphabetically. ✨ Documentation for both formatters and `CONTRIBUTING.md` are updated to reflect all changes.