### PR TITLE
🐛 fix(common): panic on non-array nodes in array ops

### DIFF
--- a/common/src/array.rs
+++ b/common/src/array.rs
@@ -201,6 +201,9 @@ pub fn transform<F>(array: &SyntaxNode, transform: &F)
 where
     F: Fn(&str) -> String,
 {
+    if array.kind() != ARRAY {
+        return;
+    }
     flatten_array_in_place(array);
     for entry in array.children_with_tokens() {
         if (entry.kind() == BASIC_STRING || entry.kind() == LITERAL_STRING)
@@ -218,6 +221,9 @@ where
     C: Fn(&T, &T) -> Ordering,
     T: Clone + Eq + Hash,
 {
+    if array.kind() != ARRAY {
+        return;
+    }
     flatten_array_in_place(array);
     let has_trailing_comma = array
         .children_with_tokens()
@@ -374,6 +380,9 @@ pub fn dedupe_strings<K>(array: &SyntaxNode, to_key: K)
 where
     K: Fn(&str) -> String,
 {
+    if array.kind() != ARRAY {
+        return;
+    }
     flatten_array_in_place(array);
     let mut seen: HashSet<String> = HashSet::new();
     let mut to_insert: Vec<SyntaxElement> = Vec::new();

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -1,5 +1,5 @@
 use indoc::indoc;
-use tombi_syntax::SyntaxKind::{ARRAY, KEY_VALUE, KEY_VALUE_GROUP};
+use tombi_syntax::SyntaxKind::{ARRAY, KEY_VALUE, KEY_VALUE_GROUP, KEYS};
 use tombi_syntax::SyntaxNode;
 
 use crate::array::{
@@ -1003,4 +1003,43 @@ fn test_sort_preserves_trailing_comment_after_bracket_end_multiline() {
       "b",
     ]  # trailing comment
     "#);
+}
+
+fn find_first_value(root: &SyntaxNode) -> SyntaxNode {
+    root.descendants()
+        .find(|n| {
+            n.kind() != root.kind()
+                && n.kind() != KEY_VALUE
+                && n.kind() != KEY_VALUE_GROUP
+                && n.kind() != KEYS
+                && n.kind() != ARRAY
+        })
+        .unwrap()
+}
+
+#[test]
+fn test_sort_on_non_array_is_noop() {
+    let input = r#"a = "src""#;
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
+    let value_node = find_first_value(&root_ast);
+    sort_strings::<String, _, _>(&value_node, |s| s.to_lowercase(), &|lhs, rhs| lhs.cmp(rhs));
+    insta::assert_snapshot!(root_ast.to_string(), @r#"a = "src""#);
+}
+
+#[test]
+fn test_transform_on_non_array_is_noop() {
+    let input = r#"a = "src""#;
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
+    let value_node = find_first_value(&root_ast);
+    transform(&value_node, &|s| s.to_uppercase());
+    insta::assert_snapshot!(root_ast.to_string(), @r#"a = "src""#);
+}
+
+#[test]
+fn test_dedupe_on_non_array_is_noop() {
+    let input = r#"a = "src""#;
+    let root_ast = tombi_parser::parse(input).syntax_node().clone_for_update();
+    let value_node = find_first_value(&root_ast);
+    dedupe_strings(&value_node, |s| s.to_lowercase());
+    insta::assert_snapshot!(root_ast.to_string(), @r#"a = "src""#);
 }

--- a/pyproject-fmt/rust/src/tests/coverage_tests.rs
+++ b/pyproject-fmt/rust/src/tests/coverage_tests.rs
@@ -195,6 +195,21 @@ fn test_coverage_trailing_comment_on_single_line_array() {
 }
 
 #[test]
+fn test_coverage_string_include_not_array() {
+    let start = indoc::indoc! {r#"
+    [tool.coverage.run]
+    branch = true
+    include = "src"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.coverage]
+    run.branch = true
+    run.include = "src"
+    "#);
+}
+
+#[test]
 fn test_coverage_paths_not_sorted() {
     let start = indoc::indoc! {r#"
     [tool.coverage]


### PR DESCRIPTION
pyproject-fmt crashes with a `PanicException` when formatting a `pyproject.toml` that uses a string value for keys like `include` under `[tool.coverage.run]` (e.g. `include = "src"`). This is valid TOML — coverage.py accepts both string and array forms — but the formatter unconditionally passes the value node to array manipulation functions that assume a `BRACKET_START`/`BRACKET_END` structure.

The `for_entries` callback in `table.rs` hands whatever value node it finds to callers like `sort_strings`, `transform`, and `dedupe_strings`. When that node is a `BASIC_STRING` instead of an `ARRAY`, `sort` panics at `entries.split_off(1)` because no bracket tokens were collected. The fix adds an early return guard (`if array.kind() != ARRAY`) at the top of `sort`, `transform`, and `dedupe_strings` so they gracefully skip non-array nodes. This is the minimal defensive check — it protects all existing callers and any future ones without changing the `for_entries` contract.

🔒 The same guard pattern is applied to all three public functions that share this assumption, preventing both the reported panic and potential silent node corruption from the other two functions.

Closes #265