### PR TITLE
🐛 fix(tox-toml-fmt): skip normalization for paths and substitutions in deps

### DIFF
--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -407,16 +407,17 @@ Certain arrays within environment tables are sorted automatically:
 
 - ``deps``, ``constraints`` — dependencies normalized and sorted by package name
 
-Pip file references (``-r requirements.txt``, ``-c constraints.txt``) are preserved as-is without
-PEP 508 normalization, but still participate in sorting by their lowercased value:
+Pip file references (``-r``, ``-c``), editable installs (``-e``), local paths (``./``, ``../``,
+``/``), and entries containing tox substitution variables (``{tox_root}``, etc.) are preserved as-is
+without PEP 508 normalization, but still participate in sorting by their lowercased value:
 
 .. code-block:: toml
 
     # Before
-    deps = ["Pytest >= 7", "-r requirements.txt", "coverage", "pytest-mock"]
+    deps = ["Pytest >= 7", "-r requirements.txt", "coverage", "-e ./my-pkg[test]"]
 
     # After
-    deps = ["-r requirements.txt", "coverage", "pytest>=7", "pytest-mock"]
+    deps = ["-e ./my-pkg[test]", "-r requirements.txt", "coverage", "pytest>=7"]
 
 **Sorted alphabetically:**
 

--- a/tox-toml-fmt/rust/src/global.rs
+++ b/tox-toml-fmt/rust/src/global.rs
@@ -229,13 +229,19 @@ fn upgrade_use_develop(table: &mut Vec<SyntaxElement>) {
     }
 }
 
-fn is_pip_file_ref(s: &str) -> bool {
-    s.starts_with("-r ") || s.starts_with("-c ")
+fn should_skip_normalization(s: &str) -> bool {
+    s.starts_with("-r ")
+        || s.starts_with("-c ")
+        || s.starts_with("-e ")
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.starts_with('/')
+        || s.contains('{')
 }
 
 fn normalize_and_sort_requirements(entry: &SyntaxNode) {
     transform(entry, &|s| {
-        if is_pip_file_ref(s) {
+        if should_skip_normalization(s) {
             return s.to_string();
         }
         Requirement::new(s).unwrap().normalize(false).to_string()
@@ -243,7 +249,7 @@ fn normalize_and_sort_requirements(entry: &SyntaxNode) {
     sort_strings::<String, _, _>(
         entry,
         |s| {
-            if is_pip_file_ref(&s) {
+            if should_skip_normalization(&s) {
                 return s.to_lowercase();
             }
             Requirement::new(s.as_str()).unwrap().canonical_name()

--- a/tox-toml-fmt/rust/src/tests/main_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/main_tests.rs
@@ -1485,3 +1485,97 @@ fn test_inline_table_reorder_env_with_marker() {
     set_env.X = { replace = "env", name = "MY_VAR", default = "fallback", marker = "sys_platform == 'linux'" }
     "#);
 }
+
+#[test]
+fn test_deps_editable_local_path_not_normalized() {
+    let start = indoc! {r#"
+        [env.test]
+        deps = ["-e ./opentelemetry-python-lineage-api[dtp]", "-e ./opentelemetry-python-lineage-sdk[dtp,fastapi]"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    deps = [
+      "-e ./opentelemetry-python-lineage-api[dtp]",
+      "-e ./opentelemetry-python-lineage-sdk[dtp,fastapi]",
+    ]
+    "#);
+}
+
+#[test]
+fn test_deps_tox_substitution_not_normalized() {
+    let start = indoc! {r#"
+        [env.test]
+        deps = ["{tox_root}/subproject[extras]", "pytest"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    deps = [ "{tox_root}/subproject[extras]", "pytest" ]
+    "#);
+}
+
+#[test]
+fn test_deps_editable_with_tox_substitution_not_normalized() {
+    let start = indoc! {r#"
+        [env.test]
+        deps = ["-e {tox_root}/subproject[extras]", "pytest"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    deps = [ "-e {tox_root}/subproject[extras]", "pytest" ]
+    "#);
+}
+
+#[test]
+fn test_deps_relative_path_not_normalized() {
+    let start = indoc! {r#"
+        [env.test]
+        deps = ["./my.package[test]", "pytest"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    deps = [ "./my.package[test]", "pytest" ]
+    "#);
+}
+
+#[test]
+fn test_deps_parent_path_not_normalized() {
+    let start = indoc! {r#"
+        [env.test]
+        deps = ["../my.package[test]", "pytest"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    deps = [ "../my.package[test]", "pytest" ]
+    "#);
+}
+
+#[test]
+fn test_deps_absolute_path_not_normalized() {
+    let start = indoc! {r#"
+        [env.test]
+        deps = ["/opt/my.package[test]", "pytest"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    deps = [ "/opt/my.package[test]", "pytest" ]
+    "#);
+}
+
+#[test]
+fn test_constraints_editable_and_paths_not_normalized() {
+    let start = indoc! {r#"
+        [env.test]
+        constraints = ["-e ./local_pkg[dev]", "{tox_root}/constraints.txt"]
+        "#};
+    let got = format_toml_helper(start, 2);
+    assert_snapshot!(got, @r#"
+    [env.test]
+    constraints = [ "-e ./local_pkg[dev]", "{tox_root}/constraints.txt" ]
+    "#);
+}


### PR DESCRIPTION
PEP 503 package name canonicalization in `deps` and `constraints` arrays was being applied to all entries indiscriminately. This corrupted local file paths and tox substitution variables: `-e ./pkg[extras]` became `-e -/pkg[extras]` (dot replaced with hyphen), and `{tox_root}` became `{tox-root}` (underscore replaced with hyphen). Both produce broken tox configurations that fail at runtime.

The fix expands the normalization guard to recognize entries that aren't PyPI package names: editable installs (`-e`), file paths (`./`, `../`, `/`), and tox substitution variables (`{...}`). These are now passed through unchanged, while regular package names continue to be normalized per PEP 503 as before.

Reported by a user migrating from `tox.ini` to `tox.toml` who had editable local installs in their deps. The only workaround was using `{toxinidir}` (which lacks dots or underscores to corrupt), but that's a legacy alias that shouldn't be required.