### PR TITLE
♻️ refactor(pyproject-fmt): sort type checkers after linters

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -38,10 +38,10 @@ Tables are reordered into a consistent structure:
    3. Linters/formatters: ``autopep8``, ``black``, ``ruff``, ``isort``, ``flake8``, ``pycln``, ``nbqa``,
       ``pylint``, ``repo-review``, ``codespell``, ``docformatter``, ``pydoclint``, ``tomlsort``,
       ``check-manifest``, ``check-sdist``, ``check-wheel-contents``, ``deptry``, ``pyproject-fmt``, ``typos``
-   4. Testing: ``pytest``, ``pytest_env``, ``pytest-enabler``, ``coverage``
-   5. Task runners: ``doit``, ``spin``, ``tox``
-   6. Release tools: ``bumpversion``, ``jupyter-releaser``, ``tbump``, ``towncrier``, ``vendoring``
-   7. Type checkers: ``mypy``, ``pyrefly``, ``pyright``, ``ty``, ``django-stubs``
+   4. Type checkers: ``mypy``, ``pyrefly``, ``pyright``, ``ty``, ``django-stubs``
+   5. Testing: ``pytest``, ``pytest_env``, ``pytest-enabler``, ``coverage``
+   6. Task runners: ``doit``, ``spin``, ``tox``
+   7. Release tools: ``bumpversion``, ``jupyter-releaser``, ``tbump``, ``towncrier``, ``vendoring``
    8. Any other ``tool.*`` in alphabetical order
 
 5. Any other tables (alphabetically)

--- a/pyproject-fmt/rust/src/global.rs
+++ b/pyproject-fmt/rust/src/global.rs
@@ -48,6 +48,12 @@ pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables) {
             "tool.deptry",
             "tool.pyproject-fmt",
             "tool.typos",
+            // Type checking
+            "tool.mypy",
+            "tool.pyrefly",
+            "tool.pyright",
+            "tool.ty",
+            "tool.django-stubs",
             // Testing
             "tool.pytest",
             "tool.pytest_env",
@@ -63,12 +69,6 @@ pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables) {
             "tool.tbump",
             "tool.towncrier",
             "tool.vendoring",
-            // Type checking
-            "tool.mypy",
-            "tool.pyrefly",
-            "tool.pyright",
-            "tool.ty",
-            "tool.django-stubs",
         ],
         &["tool"], // Treat tool.* as distinct base keys (e.g., tool.black != tool.ruff)
     );

--- a/pyproject-fmt/rust/src/tests/global_tests.rs
+++ b/pyproject-fmt/rust/src/tests/global_tests.rs
@@ -78,6 +78,9 @@ fn test_reorder_table_reorder() {
     [tool.ruff.test]
     mrt = "vrt"
 
+    [tool.mypy]
+    mk = "mv"
+
     [tool.pytest]
     mk = "mv"
 
@@ -92,9 +95,6 @@ fn test_reorder_table_reorder() {
 
     [tool.coverage.run]
     ef = "fg"
-
-    [tool.mypy]
-    mk = "mv"
 
     [tool.undefined]
     mu = "mu"


### PR DESCRIPTION
Type checkers (`mypy`, `pyright`, `pyrefly`, `ty`, `django-stubs`) were previously sorted at the very end of the `[tool.*]` ordering, after release tools like `towncrier` and `tbump`. This felt semantically wrong — type checking is part of static analysis and naturally belongs alongside linters and formatters, not after release tooling.

Moving type checkers between linters/formatters and testing better reflects the typical CI pipeline order where static analysis (linting + type checking) runs before tests. This matches the mental model most developers have when reading a `pyproject.toml`.

Closes #273