### PR TITLE
✨ feat(pyproject-fmt): add bandit to recognized linters

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -37,7 +37,8 @@ Tables are reordered into a consistent structure:
    2. Builders: ``cibuildwheel``, ``nuitka``
    3. Linters/formatters: ``autopep8``, ``black``, ``ruff``, ``isort``, ``flake8``, ``pycln``, ``nbqa``,
       ``pylint``, ``repo-review``, ``codespell``, ``docformatter``, ``pydoclint``, ``tomlsort``,
-      ``check-manifest``, ``check-sdist``, ``check-wheel-contents``, ``deptry``, ``pyproject-fmt``, ``typos``
+      ``check-manifest``, ``check-sdist``, ``check-wheel-contents``, ``deptry``, ``pyproject-fmt``, ``typos``,
+      ``bandit``
    4. Type checkers: ``mypy``, ``pyrefly``, ``pyright``, ``ty``, ``django-stubs``
    5. Testing: ``pytest``, ``pytest_env``, ``pytest-enabler``, ``coverage``
    6. Task runners: ``doit``, ``spin``, ``tox``

--- a/pyproject-fmt/rust/src/global.rs
+++ b/pyproject-fmt/rust/src/global.rs
@@ -48,6 +48,7 @@ pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables) {
             "tool.deptry",
             "tool.pyproject-fmt",
             "tool.typos",
+            "tool.bandit",
             // Type checking
             "tool.mypy",
             "tool.pyrefly",

--- a/pyproject-fmt/rust/src/tests/global_tests.rs
+++ b/pyproject-fmt/rust/src/tests/global_tests.rs
@@ -106,3 +106,31 @@ fn test_reorder_table_reorder() {
     ed = "ed"
     "#);
 }
+
+#[test]
+fn test_reorder_bandit_as_linter() {
+    let start = indoc! {r#"
+    [tool.mypy]
+    mk="mv"
+    [tool.bandit]
+    skips=["B101"]
+    [tool.pytest]
+    mk="mv"
+    [tool.ruff]
+    mr="vr"
+    "#};
+    let res = reorder_table_helper(start);
+    insta::assert_snapshot!(res, @r#"
+    [tool.ruff]
+    mr = "vr"
+
+    [tool.bandit]
+    skips = [ "B101" ]
+
+    [tool.mypy]
+    mk = "mv"
+
+    [tool.pytest]
+    mk = "mv"
+    "#);
+}


### PR DESCRIPTION
Projects using [bandit](https://bandit.readthedocs.io/) for security linting currently have their `[tool.bandit]` section sorted as an unknown tool, landing at the bottom of the file alongside unrecognized entries. Since bandit is a widely adopted Python security linter, it belongs in the linters/formatters group so it gets placed consistently between other linters and the type checkers section.

Adding `tool.bandit` to the end of the linters list in the table reordering logic ensures it's grouped with tools like `ruff`, `pylint`, and `flake8` rather than being treated as an unknown tool section.

Closes #275