### PR TITLE
✨ feat(pyproject-fmt): add pixi support

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -32,8 +32,8 @@ Tables are reordered into a consistent structure:
 4. ``[tool.*]`` sections in the order:
 
    1. Build backends: ``poetry``, ``poetry-dynamic-versioning``, ``pdm``, ``setuptools``, ``distutils``,
-      ``setuptools_scm``, ``hatch``, ``flit``, ``scikit-build``, ``meson-python``, ``maturin``, ``whey``,
-      ``py-build-cmake``, ``sphinx-theme-builder``, ``uv``
+      ``setuptools_scm``, ``hatch``, ``flit``, ``scikit-build``, ``meson-python``, ``maturin``, ``pixi``,
+      ``whey``, ``py-build-cmake``, ``sphinx-theme-builder``, ``uv``
    2. Builders: ``cibuildwheel``, ``nuitka``
    3. Linters/formatters: ``autopep8``, ``black``, ``ruff``, ``isort``, ``flake8``, ``pycln``, ``nbqa``,
       ``pylint``, ``repo-review``, ``codespell``, ``docformatter``, ``pydoclint``, ``tomlsort``,
@@ -422,6 +422,31 @@ Plugin arrays:
   ``lint.pep8-naming.ignore-names``, ``lint.pep8-naming.staticmethod-decorators``,
   ``lint.pydocstyle.ignore-decorators``, ``lint.pydocstyle.property-decorators``, ``lint.pyflakes.extend-generics``,
   ``lint.pylint.allow-dunder-method-names``, ``lint.pylint.allow-magic-value-types``
+
+``[tool.pixi]``
+~~~~~~~~~~~~~~~
+
+**Key ordering:**
+
+Keys are grouped by functionality:
+
+1. Workspace metadata: ``workspace.name`` → ``workspace.version`` → ``workspace.description`` →
+   ``workspace.authors`` → ``workspace.license`` → ``workspace.license-file`` → ``workspace.readme`` →
+   ``workspace.homepage`` → ``workspace.repository`` → ``workspace.documentation``
+2. Workspace configuration: ``workspace.channels`` → ``workspace.platforms`` → ``workspace.channel-priority`` →
+   ``workspace.solve-strategy`` → ``workspace.conda-pypi-map`` → ``workspace.requires-pixi`` →
+   ``workspace.exclude-newer`` → ``workspace.preview`` → ``workspace.build-variants`` →
+   ``workspace.build-variants-files``
+3. Dependencies: ``dependencies`` → ``host-dependencies`` → ``build-dependencies`` → ``run-dependencies`` →
+   ``constraints`` → ``pypi-dependencies`` → ``pypi-options``
+4. Development: ``dev``
+5. Environment setup: ``system-requirements`` → ``activation`` → ``tasks``
+6. Targeting: ``target`` → ``feature`` → ``environments``
+7. Package build: ``package``
+
+**Sorted arrays:**
+
+``workspace.channels``, ``workspace.platforms``, ``workspace.preview``, ``workspace.build-variants-files``
 
 ``[tool.uv]``
 ~~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/global.rs
+++ b/pyproject-fmt/rust/src/global.rs
@@ -21,6 +21,7 @@ pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables) {
             "tool.scikit-build",
             "tool.meson-python",
             "tool.maturin",
+            "tool.pixi",
             "tool.whey",
             "tool.py-build-cmake",
             "tool.sphinx-theme-builder",

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -15,6 +15,7 @@ mod project;
 
 mod coverage;
 mod global;
+mod pixi;
 mod ruff;
 #[cfg(test)]
 mod tests;
@@ -150,6 +151,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     dependency_groups::fix(&mut tables, opt.keep_full_version);
     ruff::fix(&mut tables);
     uv::fix(&mut tables);
+    pixi::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);

--- a/pyproject-fmt/rust/src/pixi.rs
+++ b/pyproject-fmt/rust/src/pixi.rs
@@ -1,0 +1,91 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    "workspace.name",
+    "workspace.version",
+    "workspace.description",
+    "workspace.authors",
+    "workspace.license",
+    "workspace.license-file",
+    "workspace.readme",
+    "workspace.homepage",
+    "workspace.repository",
+    "workspace.documentation",
+    "workspace.channels",
+    "workspace.platforms",
+    "workspace.channel-priority",
+    "workspace.solve-strategy",
+    "workspace.conda-pypi-map",
+    "workspace.requires-pixi",
+    "workspace.exclude-newer",
+    "workspace.preview",
+    "workspace.build-variants",
+    "workspace.build-variants-files",
+    "workspace",
+    "dependencies",
+    "host-dependencies",
+    "build-dependencies",
+    "run-dependencies",
+    "constraints",
+    "pypi-dependencies",
+    "pypi-options",
+    "dev",
+    "system-requirements",
+    "activation",
+    "tasks",
+    "target",
+    "feature",
+    "environments",
+    "package",
+];
+
+const WORKSPACE_KEY_ORDER: &[&str] = &[
+    "",
+    "name",
+    "version",
+    "description",
+    "authors",
+    "license",
+    "license-file",
+    "readme",
+    "homepage",
+    "repository",
+    "documentation",
+    "channels",
+    "platforms",
+    "channel-priority",
+    "solve-strategy",
+    "conda-pypi-map",
+    "requires-pixi",
+    "exclude-newer",
+    "preview",
+    "build-variants",
+    "build-variants-files",
+];
+
+pub fn fix(tables: &mut Tables) {
+    if let Some(table_elements) = tables.get("tool.pixi") {
+        let table = &mut table_elements.first().unwrap().borrow_mut();
+        for_entries(table, &mut |key, entry| match key.as_str() {
+            "workspace.channels" | "workspace.platforms" | "workspace.preview" | "workspace.build-variants-files" => {
+                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            }
+            _ => {}
+        });
+        reorder_table_keys(table, KEY_ORDER);
+    }
+
+    if let Some(workspace_elements) = tables.get("tool.pixi.workspace") {
+        let workspace_table = &mut workspace_elements.first().unwrap().borrow_mut();
+        for_entries(workspace_table, &mut |key, entry| match key.as_str() {
+            "channels" | "platforms" | "preview" | "build-variants-files" => {
+                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            }
+            _ => {}
+        });
+        reorder_table_keys(workspace_table, WORKSPACE_KEY_ORDER);
+    }
+}

--- a/pyproject-fmt/rust/src/tests/global_tests.rs
+++ b/pyproject-fmt/rust/src/tests/global_tests.rs
@@ -108,6 +108,34 @@ fn test_reorder_table_reorder() {
 }
 
 #[test]
+fn test_reorder_pixi_as_build_backend() {
+    let start = indoc! {r#"
+    [tool.ruff]
+    mr="vr"
+    [tool.pixi.project]
+    pk="pv"
+    [tool.pixi]
+    pk="pv"
+    [tool.mypy]
+    mk="mv"
+    "#};
+    let res = reorder_table_helper(start);
+    insta::assert_snapshot!(res, @r#"
+    [tool.pixi]
+    pk = "pv"
+
+    [tool.pixi.project]
+    pk = "pv"
+
+    [tool.ruff]
+    mr = "vr"
+
+    [tool.mypy]
+    mk = "mv"
+    "#);
+}
+
+#[test]
 fn test_reorder_bandit_as_linter() {
     let start = indoc! {r#"
     [tool.mypy]

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod coverage_tests;
 mod dependency_groups_tests;
 mod global_tests;
 mod main_tests;
+mod pixi_tests;
 mod project_tests;
 mod ruff_tests;
 mod uv_tests;

--- a/pyproject-fmt/rust/src/tests/pixi_tests.rs
+++ b/pyproject-fmt/rust/src/tests/pixi_tests.rs
@@ -1,0 +1,172 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+use indoc::indoc;
+use insta::assert_snapshot;
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::pixi::fix;
+
+fn evaluate_core(start: &str, collapse: bool) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| collapse, &["tool.pixi"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    format_syntax(root_ast, 120)
+}
+
+fn evaluate(start: &str) -> String {
+    let result = evaluate_core(start, true);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_no_pixi_section() {
+    let start = indoc! {r#"
+    [tool.ruff]
+    line-length = 120
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @"
+    [tool.ruff]
+    line-length = 120
+    ");
+}
+
+#[test]
+fn test_order_pixi_top_level() {
+    let start = indoc! {r#"
+    [tool.pixi]
+    environments.default = { solve-group = "default" }
+    tasks.test = "pytest"
+    activation.scripts = ["setup.sh"]
+    dependencies.python = ">=3.11"
+    pypi-dependencies.requests = ">=2"
+    workspace.channels = ["conda-forge"]
+    workspace.platforms = ["linux-64"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.pixi]
+    workspace.channels = [ "conda-forge" ]
+    workspace.platforms = [ "linux-64" ]
+    dependencies.python = ">=3.11"
+    pypi-dependencies.requests = ">=2"
+    activation.scripts = [ "setup.sh" ]
+    tasks.test = "pytest"
+    environments.default = { solve-group = "default" }
+    "#);
+}
+
+#[test]
+fn test_order_pixi_workspace_collapsed() {
+    let start = indoc! {r#"
+    [tool.pixi]
+    workspace.platforms = ["osx-arm64", "linux-64"]
+    workspace.channels = ["conda-forge", "bioconda"]
+    workspace.name = "my-project"
+    workspace.requires-pixi = ">=0.30"
+    workspace.version = "1.0.0"
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.pixi]
+    workspace.name = "my-project"
+    workspace.version = "1.0.0"
+    workspace.channels = [ "bioconda", "conda-forge" ]
+    workspace.platforms = [ "linux-64", "osx-arm64" ]
+    workspace.requires-pixi = ">=0.30"
+    "#);
+}
+
+#[test]
+fn test_sort_workspace_channels() {
+    let start = indoc! {r#"
+    [tool.pixi]
+    workspace.channels = ["pytorch", "conda-forge", "bioconda"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.pixi]
+    workspace.channels = [ "bioconda", "conda-forge", "pytorch" ]
+    "#);
+}
+
+#[test]
+fn test_sort_workspace_platforms() {
+    let start = indoc! {r#"
+    [tool.pixi]
+    workspace.platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.pixi]
+    workspace.platforms = [ "linux-64", "osx-64", "osx-arm64", "win-64" ]
+    "#);
+}
+
+#[test]
+fn test_sort_workspace_preview() {
+    let start = indoc! {r#"
+    [tool.pixi]
+    workspace.preview = ["pixi-build", "conda-build"]
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.pixi]
+    workspace.preview = [ "conda-build", "pixi-build" ]
+    "#);
+}
+
+#[test]
+fn test_pixi_workspace_expanded_table() {
+    let start = indoc! {r#"
+    [tool.pixi.workspace]
+    platforms = ["osx-arm64", "linux-64"]
+    channels = ["conda-forge"]
+    name = "my-project"
+    documentation = "https://docs.example.com"
+    homepage = "https://example.com"
+    "#};
+    let result = evaluate_core(start, false);
+    assert_valid_toml(&result);
+    assert_snapshot!(result, @r#"
+    [tool.pixi.workspace]
+    name = "my-project"
+    homepage = "https://example.com"
+    documentation = "https://docs.example.com"
+    channels = [ "conda-forge" ]
+    platforms = [ "linux-64", "osx-arm64" ]
+    "#);
+}
+
+#[test]
+fn test_pixi_preserves_subtables() {
+    let start = indoc! {r#"
+    [tool.pixi]
+    workspace.channels = ["conda-forge"]
+    workspace.platforms = ["linux-64"]
+
+    [tool.pixi.dependencies]
+    python = ">=3.11"
+    numpy = ">=1.24"
+
+    [tool.pixi.tasks]
+    test = "pytest"
+    lint = "ruff check ."
+    "#};
+    let result = evaluate(start);
+    assert_snapshot!(result, @r#"
+    [tool.pixi]
+    workspace.channels = [ "conda-forge" ]
+    workspace.platforms = [ "linux-64" ]
+    dependencies.numpy = ">=1.24"
+    dependencies.python = ">=3.11"
+    tasks.lint = "ruff check ."
+    tasks.test = "pytest"
+    "#);
+}


### PR DESCRIPTION
Pixi users currently have their `[tool.pixi]` configuration scattered during formatting because pyproject-fmt doesn't recognize pixi as a build backend or know how to order its keys. This is particularly frustrating since pixi is increasingly popular as a conda-based package manager that stores project configuration directly in `pyproject.toml`.

This adds pixi to the build backends table ordering list and implements a dedicated formatter for `[tool.pixi]` sections. The formatter handles key ordering for both the top-level table and `workspace` sub-table, and sorts arrays like `workspace.channels`, `workspace.platforms`, and `workspace.preview` alphabetically. The approach mirrors how `tool.uv` and `tool.ruff` formatters are structured.

Both collapsed (dotted keys under `[tool.pixi]`) and expanded (`[tool.pixi.workspace]`) table formats are supported. The workspace sub-keys are listed explicitly in the key order to ensure correct ordering in collapsed mode, with a trailing `workspace` catch-all for any unrecognized workspace keys.

Closes #282