### PR TITLE
Fix release job git push authentication

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -225,7 +225,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -225,7 +225,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
## Summary
- Remove `persist-credentials: false` from the release job checkout step in both `pyproject_fmt_build.yaml` and `tox_toml_fmt_build.yaml`
- The flag was stripping git credentials after checkout, causing `git push` to fail with `fatal: could not read Username` when creating the release commit and tag
- This is why pyproject-fmt 2.21.0 was published to PyPI but has no corresponding git tag or GitHub release

Fixes #284