### PR TITLE
🐛 fix(pyproject-fmt): produce valid TOML when sorting arrays with value on bracket line

### DIFF
--- a/common/src/array.rs
+++ b/common/src/array.rs
@@ -231,7 +231,6 @@ where
         .filter(|x| *x == COMMA || is_array_value(*x))
         .last()
         == Some(COMMA);
-    let multiline = array.children_with_tokens().any(|e| e.kind() == LINE_BREAK);
 
     let mut entries = Vec::<SyntaxElement>::new();
     let mut order_sets = Vec::<Vec<SyntaxElement>>::new();
@@ -317,7 +316,11 @@ where
 
     let remaining: Vec<SyntaxElement> = current_set.borrow_mut().drain(..).collect();
 
-    let trailing_content = entries.split_off(if multiline { 2 } else { 1 });
+    let leading_count = entries
+        .iter()
+        .take_while(|e| matches!(e.kind(), BRACKET_START | LINE_BREAK))
+        .count();
+    let trailing_content = entries.split_off(leading_count);
     let mut order: Vec<T> = key_to_order_set.keys().cloned().collect();
     order.sort_by(&cmp);
 

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -171,8 +171,9 @@ fn test_order_array_newline_single_comment() {
     "#};
     let res = sort_array_helper(start);
     insta::assert_snapshot!(res, @r#"
-    a = [] # comment
+    a = [  # comment
       "A"
+    ]
     "#);
 }
 
@@ -783,6 +784,20 @@ fn test_dedupe_with_value_wrapper() {
     items = [
       "foo",
       "bar",
+    ]
+    "#);
+}
+
+#[test]
+fn test_sort_multiline_value_on_same_line_as_opening_bracket() {
+    let start = "a = [\"foo\",\n\"bar\",]";
+    let root_ast = tombi_parser::parse(start).syntax_node().clone_for_update();
+    for_each_array(&root_ast, |array| {
+        sort_strings::<String, _, _>(array, |s| s.to_lowercase(), &|lhs, rhs| lhs.cmp(rhs));
+    });
+    let res = root_ast.to_string();
+    insta::assert_snapshot!(res, @r#"
+    a = ["bar","foo",
     ]
     "#);
 }

--- a/pyproject-fmt/rust/src/tests/dependency_groups_tests.rs
+++ b/pyproject-fmt/rust/src/tests/dependency_groups_tests.rs
@@ -433,6 +433,23 @@ fn test_dependency_groups_include_groups_sorted_alphabetically() {
 }
 
 #[test]
+fn test_dependency_groups_issue_291_value_on_bracket_line() {
+    let start = indoc! {r#"
+    [dependency-groups]
+    dev = ["foo",
+    "bar",]
+    "#};
+    let res = format_dependency_groups_helper(start, false);
+    insta::assert_snapshot!(res, @r#"
+    [dependency-groups]
+    dev = [
+      "bar",
+      "foo",
+    ]
+    "#);
+}
+
+#[test]
 fn test_dependency_groups_packages_before_include_groups() {
     let start = indoc! {r#"
         [dependency-groups]


### PR DESCRIPTION
Running `pyproject-fmt` on a `[dependency-groups]` value whose opening bracket sits on the same line as its first value, like `dev = ["foo",\n"bar",]`, produced invalid TOML such as `dev = []"bar","foo",`. 🐛 Anything downstream of `pyproject-fmt` then refused to parse the file, so the formatter effectively broke pyproject files it was meant to clean up. Reported in #291.

The defect lives in `common::array::sort`, which rebuilds the array by collecting a leading prefix into one vec, sortable values into per-key buckets, and a trailing slice (closing bracket plus whatever followed) into a third vec. The split between leading and trailing was computed from a hardcoded offset (`if multiline { 2 } else { 1 }`) that assumed `[` was followed by a `\n` whenever any line break appeared anywhere in the array. With the line break between values rather than after the bracket, the trailing slice came back empty and the sorted values landed after `]`. The fix replaces the heuristic with a `take_while` over the actual leading run of `BRACKET_START` and `LINE_BREAK` tokens at the head of the rebuilt vec, so the boundary tracks reality regardless of where line breaks happen to fall.

The new logic is a strict superset of the old one for canonical single-line and multi-line shapes, and it preserves the placement of unsortable trailing values that some callers (notably `dependency-groups` arrays mixing `BASIC_STRING` and `LITERAL_STRING`) rely on. ✨ One pre-existing snapshot in `array_tests.rs` was passively accepting the same bug class — its expected output was itself invalid TOML — and now captures the corrected, well-formed result.