### PR TITLE
🐛 fix(common): skip empty tables in Tables::get

### DIFF
--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -127,15 +127,13 @@ pub struct Tables {
 
 impl Tables {
     pub fn get(&self, key: &str) -> Option<Vec<&RefCell<Vec<SyntaxElement>>>> {
-        if self.header_to_pos.contains_key(key) {
-            let mut res = Vec::<&RefCell<Vec<SyntaxElement>>>::new();
-            for pos in &self.header_to_pos[key] {
-                res.push(&self.table_set[*pos]);
-            }
-            Some(res)
-        } else {
-            None
-        }
+        let positions = self.header_to_pos.get(key)?;
+        let res: Vec<&RefCell<Vec<SyntaxElement>>> = positions
+            .iter()
+            .map(|pos| &self.table_set[*pos])
+            .filter(|cell| !cell.borrow().is_empty())
+            .collect();
+        if res.is_empty() { None } else { Some(res) }
     }
 
     pub fn from_ast(root_ast: &SyntaxNode) -> Self {

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -918,11 +918,9 @@ fn test_collapse_sub_table_converts_array_tables_to_inline() {
 
     collapse_sub_table(&mut tables, "project", "authors", 120);
 
-    let authors = tables.get("project.authors").unwrap();
-    let authors_table = authors[0].borrow();
     assert!(
-        authors_table.is_empty(),
-        "array tables should be collapsed to inline array"
+        tables.get("project.authors").is_none(),
+        "array tables should be collapsed and no longer accessible via get"
     );
 
     let project = tables.get("project").unwrap();

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -935,6 +935,49 @@ fn test_issue_217_full_pyproject_idempotent() {
 }
 
 #[test]
+fn test_issue_299_pixi_workspace_collapse_with_keys() {
+    let start = indoc! {r#"
+    [project]
+    name = "x"
+    version = "0.1.0"
+
+    [tool.pixi.workspace]
+    name = "my-project"
+    "#};
+    let got = format_toml(start, &default_settings());
+    assert_valid_toml(&got);
+    assert_snapshot!(got, @r#"
+    [project]
+    name = "x"
+    version = "0.1.0"
+
+    [tool.pixi]
+    workspace.name = "my-project"
+    "#);
+}
+
+#[test]
+fn test_issue_299_pixi_workspace_collapse_empty() {
+    let start = indoc! {r#"
+    [project]
+    name = "x"
+    version = "0.1.0"
+
+    [tool.pixi.workspace]
+    "#};
+    let got = format_toml(start, &default_settings());
+    assert_valid_toml(&got);
+    assert_snapshot!(got, @r#"
+    [project]
+    name = "x"
+    version = "0.1.0"
+
+    [tool.pixi]
+    workspace = {}
+    "#);
+}
+
+#[test]
 fn test_issue_202_preserve_inline_comment_after_array() {
     let start = indoc! {r#"
     [tool.uv]


### PR DESCRIPTION
Since `pyproject-fmt` 2.21.0, formatting any `pyproject.toml` containing `[tool.pixi.workspace]` under the default `--table-format=short` panics with `called Option::unwrap() on a None value` at `common/src/table.rs:408`. 🐛 This blocks every Pixi user following the canonical dotted sub-header style documented at https://pixi.sh, with the only workarounds being to pin `pyproject-fmt==2.20.0`, pass `--expand-tables=tool.pixi.workspace`, or switch to `--table-format=long`. Closes #299.

The root cause is a long-standing invariant violation that 2.21.0 surfaced. `collapse_sub_table` empties a sub-table's vec via `sub.clear()` but leaves the entry registered in `header_to_pos`. Until 2.21.0 nothing ever looked up a collapsed sub-table by name, so the dangling entry was harmless. The new `pixi::fix` calls `tables.get(\"tool.pixi.workspace\")` after the collapse pass and hits the empty cell, and `reorder_table_keys` → `load_keys` then unwraps `table.last()` on an empty slice. ✨ Filtering empty entries inside `Tables::get` makes the lookup return `None` when every position points at a cleared vec, mirroring the behavior already present in `calculate_order` and removing the asymmetry between the two access paths without touching the collapse logic itself.

Reviewers should note that `Tables::get` callers that previously received `Some(vec_of_empty_cells)` now receive `None`. The only test relying on that behavior was an assertion that a collapsed entry remained accessible as an empty cell, which has been updated to assert the entry is gone.