### PR TITLE
✨ feat(build): support free-threaded Python wheels

### DIFF
--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -144,7 +144,9 @@ jobs:
       matrix:
         platform:
           - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
-          - { runner: windows-2025, target: x64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          # 3.15t Windows wheel skipped: python3-dll-a (pulled in by generate-import-lib) only
+          # has .def files up to 3.14t (https://github.com/PyO3/python3-dll-a/blob/main/src/lib.rs).
+          # Re-enable when https://github.com/PyO3/pyo3/issues/6012 finishes 3.15 ABI support.
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -113,6 +113,10 @@ jobs:
           - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.10 3.13t 3.14t" }
           - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.10 3.13t 3.14t" }
           - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
+          # 3.15t needs explicit no-abi3 build (PEP 803 incomplete in 3.15.0a8)
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -122,13 +126,13 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
+          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
           path: dist
 
   windows:
@@ -140,6 +144,7 @@ jobs:
       matrix:
         platform:
           - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
+          - { runner: windows-2025, target: x64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -154,12 +159,12 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target
+          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: wheels-windows-${{ matrix.platform.target }}
+          name: wheels-windows-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
           path: dist
 
   macos:
@@ -170,8 +175,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: macos-15, target: x86_64 }
-          - { runner: macos-15, target: aarch64 }
+          - { runner: macos-15, target: x86_64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
+          - { runner: macos-15, target: aarch64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
+          - { runner: macos-15, target: x86_64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: macos-15, target: aarch64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -181,12 +188,12 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 3.13t 3.14t pypy3.11" --target-dir target
+          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter }} ${{ matrix.platform.extra || '' }} --target-dir target
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: wheels-macos-${{ matrix.platform.target }}
+          name: wheels-macos-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
           path: dist
 
   sdist:

--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -109,9 +109,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 pypy3.11" }
-          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2 }
-          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true }
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 3.13t 3.14t pypy3.11" }
+          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.10 3.13t 3.14t" }
+          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.10 3.13t 3.14t" }
           - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
     steps:
       - name: 📥 Download source
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: windows-2025, target: x64 }
+          - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -181,7 +181,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 pypy3.11" --target-dir target
+          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 3.13t 3.14t pypy3.11" --target-dir target
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: ["3.14", "3.13", "3.12", "3.11", "3.10"]
+        py: ["3.15", "3.15t", "3.14", "3.14t", "3.13", "3.13t", "3.12", "3.11", "3.10"]
         os: [ubuntu-24.04, windows-2025, macos-15]
     defaults:
       run:

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -109,9 +109,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 pypy3.11" }
-          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2 }
-          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true }
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 3.13t 3.14t pypy3.11" }
+          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.10 3.13t 3.14t" }
+          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.10 3.13t 3.14t" }
           - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
     steps:
       - name: 📥 Download source
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: windows-2025, target: x64 }
+          - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -181,7 +181,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 pypy3.11" --target-dir target
+          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 3.13t 3.14t pypy3.11" --target-dir target
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -144,7 +144,9 @@ jobs:
       matrix:
         platform:
           - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
-          - { runner: windows-2025, target: x64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          # 3.15t Windows wheel skipped: python3-dll-a (pulled in by generate-import-lib) only
+          # has .def files up to 3.14t (https://github.com/PyO3/python3-dll-a/blob/main/src/lib.rs).
+          # Re-enable when https://github.com/PyO3/pyo3/issues/6012 finishes 3.15 ABI support.
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -113,6 +113,10 @@ jobs:
           - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.10 3.13t 3.14t" }
           - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.10 3.13t 3.14t" }
           - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
+          # 3.15t needs explicit no-abi3 build (PEP 803 incomplete in 3.15.0a8)
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -122,13 +126,13 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
+          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
           path: dist
 
   windows:
@@ -140,6 +144,7 @@ jobs:
       matrix:
         platform:
           - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
+          - { runner: windows-2025, target: x64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -154,12 +159,12 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} --target-dir target
+          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: wheels-windows-${{ matrix.platform.target }}
+          name: wheels-windows-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
           path: dist
 
   macos:
@@ -170,8 +175,10 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: macos-15, target: x86_64 }
-          - { runner: macos-15, target: aarch64 }
+          - { runner: macos-15, target: x86_64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
+          - { runner: macos-15, target: aarch64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
+          - { runner: macos-15, target: x86_64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: macos-15, target: aarch64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
     steps:
       - name: 📥 Download source
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -181,12 +188,12 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter "3.10 3.13t 3.14t pypy3.11" --target-dir target
+          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter }} ${{ matrix.platform.extra || '' }} --target-dir target
           sccache: true
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: wheels-macos-${{ matrix.platform.target }}
+          name: wheels-macos-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
           path: dist
 
   sdist:

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: ["3.14", "3.13", "3.12", "3.11", "3.10"]
+        py: ["3.15", "3.15t", "3.14", "3.14t", "3.13", "3.13t", "3.12", "3.11", "3.10"]
         os: [ubuntu-24.04, windows-2025, macos-15]
     defaults:
       run:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
+ "python3-dll-a",
  "target-lexicon",
 ]
 
@@ -1357,6 +1358,15 @@ dependencies = [
  "tombi-schema-store",
  "tombi-syntax",
  "toml",
+]
+
+[[package]]
+name = "python3-dll-a"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/pyproject-fmt/Cargo.toml
+++ b/pyproject-fmt/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 common = {path = "../common" }
 regex = { version = "1.12.3" }
-pyo3 = { version = "0.28.3", features = ["abi3-py39"] } # integration with Python
+pyo3 = { version = "0.28.3" } # integration with Python
 lexical-sort = { version = "0.3.1" }
 tombi-parser = { workspace = true }
 tombi-syntax = { workspace = true }
@@ -25,7 +25,8 @@ tokio = { version = "1", features = ["rt"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]
-default = ["extension-module"]
+abi3 = ["pyo3/abi3-py39"]
+default = ["extension-module", "abi3"]
 
 [dev-dependencies]
 common = { path = "../common", features = ["test-util"] }

--- a/pyproject-fmt/Cargo.toml
+++ b/pyproject-fmt/Cargo.toml
@@ -25,7 +25,9 @@ tokio = { version = "1", features = ["rt"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]
-abi3 = ["pyo3/abi3-py39"]
+# `abi3` can be disabled to produce per-version wheels (needed for free-threaded 3.15t until
+# CPython lands PEP 803 abi3t loader: https://github.com/python/cpython/issues/146636).
+abi3 = ["pyo3/abi3-py310"]
 default = ["extension-module", "abi3"]
 
 [dev-dependencies]

--- a/pyproject-fmt/Cargo.toml
+++ b/pyproject-fmt/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 common = {path = "../common" }
 regex = { version = "1.12.3" }
-pyo3 = { version = "0.28.3" } # integration with Python
+pyo3 = { version = "0.28.3", features = ["generate-import-lib"] } # integration with Python
 lexical-sort = { version = "0.3.1" }
 tombi-parser = { workspace = true }
 tombi-syntax = { workspace = true }

--- a/pyproject-fmt/build.rs
+++ b/pyproject-fmt/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    if std::env::var_os("CARGO_FEATURE_EXTENSION_MODULE").is_some()
+        && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos")
+    {
+        println!("cargo:rustc-link-arg=-undefined");
+        println!("cargo:rustc-link-arg=dynamic_lookup");
+    }
+}

--- a/pyproject-fmt/pyproject.toml
+++ b/pyproject-fmt/pyproject.toml
@@ -95,12 +95,6 @@ exclude = [
   "**/*.pyo",
 ]
 
-[tool.cibuildwheel]
-skip = [
-  "pp*",
-  "*musl*",
-]
-
 [tool.pyproject-fmt]
 max_supported_python = "3.15"
 

--- a/pyproject-fmt/pyproject.toml
+++ b/pyproject-fmt/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
+  "Programming Language :: Python :: Free Threading :: 1 - Unstable",
 ]
 dynamic = [
   "version",
@@ -100,7 +102,7 @@ skip = [
 ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.mypy]
 show_error_codes = true

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -252,7 +252,7 @@ fn get_table_key(name: &str, multi_level_prefixes: &[&str]) -> String {
 /// # Errors
 ///
 /// Will return `PyErr` if an error is raised during formatting.
-#[pymodule]
+#[pymodule(gil_used = false)]
 #[pyo3(name = "_lib")]
 pub fn _lib(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(format_toml, m)?)?;

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::string::String;
 
 use pyo3::prelude::{PyModule, PyModuleMethods};
-use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult};
+use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult, Python};
 
 use crate::global::reorder_tables;
 use common::array::ensure_all_arrays_multiline;
@@ -112,9 +112,14 @@ async fn format_with_tombi(content: &str, column_width: usize, indent: usize) ->
     formatter.format(content).await.unwrap_or_else(|_| content.to_string())
 }
 
+#[pyfunction]
+#[pyo3(name = "format_toml")]
+fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
+    py.detach(|| format_toml(content, opt))
+}
+
 /// Format toml file
 #[must_use]
-#[pyfunction]
 pub fn format_toml(content: &str, opt: &Settings) -> String {
     let root_ast = parse(content);
     common::string::normalize_key_quotes(&root_ast);
@@ -255,7 +260,7 @@ fn get_table_key(name: &str, multi_level_prefixes: &[&str]) -> String {
 #[pymodule(gil_used = false)]
 #[pyo3(name = "_lib")]
 pub fn _lib(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(format_toml, m)?)?;
+    m.add_function(wrap_pyfunction!(format_toml_py, m)?)?;
     m.add_class::<Settings>()?;
     Ok(())
 }

--- a/pyproject-fmt/tox.toml
+++ b/pyproject-fmt/tox.toml
@@ -11,6 +11,10 @@ dependency_groups = ["test"]
 pass_env = ["PYTEST_*", "SSL_CERT_FILE"]
 set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{work_dir}{/}.coverage.{env_name}" }
 set_env.COVERAGE_FILECOVERAGE_PROCESS_START = "{tox_root}{/}pyproject.toml"
+
+[env."3.15t"]
+description = "run tests under free-threaded 3.15 (no abi3 — PEP 803 abi3t not yet implemented in 3.15.0a8)"
+set_env.MATURIN_PEP517_ARGS = "--no-default-features --features extension-module"
 commands = [
     [
         "pytest",

--- a/tox-toml-fmt/Cargo.toml
+++ b/tox-toml-fmt/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 common = { path = "../common" }
 lexical-sort = { version = "0.3.1" }
-pyo3 = { version = "0.28.3", features = ["abi3-py39"] }
+pyo3 = { version = "0.28.3" }
 regex = { version = "1.12.3" }
 tombi-parser = { workspace = true }
 tombi-syntax = { workspace = true }
@@ -25,7 +25,8 @@ tokio = { version = "1", features = ["rt"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]
-default = ["extension-module"]
+abi3 = ["pyo3/abi3-py39"]
+default = ["extension-module", "abi3"]
 
 [dev-dependencies]
 common = { path = "../common", features = ["test-util"] }

--- a/tox-toml-fmt/Cargo.toml
+++ b/tox-toml-fmt/Cargo.toml
@@ -25,7 +25,9 @@ tokio = { version = "1", features = ["rt"] }
 
 [features]
 extension-module = ["pyo3/extension-module"]
-abi3 = ["pyo3/abi3-py39"]
+# `abi3` can be disabled to produce per-version wheels (needed for free-threaded 3.15t until
+# CPython lands PEP 803 abi3t loader: https://github.com/python/cpython/issues/146636).
+abi3 = ["pyo3/abi3-py310"]
 default = ["extension-module", "abi3"]
 
 [dev-dependencies]

--- a/tox-toml-fmt/Cargo.toml
+++ b/tox-toml-fmt/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 [dependencies]
 common = { path = "../common" }
 lexical-sort = { version = "0.3.1" }
-pyo3 = { version = "0.28.3" }
+pyo3 = { version = "0.28.3", features = ["generate-import-lib"] }
 regex = { version = "1.12.3" }
 tombi-parser = { workspace = true }
 tombi-syntax = { workspace = true }

--- a/tox-toml-fmt/build.rs
+++ b/tox-toml-fmt/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    if std::env::var_os("CARGO_FEATURE_EXTENSION_MODULE").is_some()
+        && std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos")
+    {
+        println!("cargo:rustc-link-arg=-undefined");
+        println!("cargo:rustc-link-arg=dynamic_lookup");
+    }
+}

--- a/tox-toml-fmt/pyproject.toml
+++ b/tox-toml-fmt/pyproject.toml
@@ -95,12 +95,6 @@ exclude = [
   "**/*.pyo",
 ]
 
-[tool.cibuildwheel]
-skip = [
-  "pp*",
-  "*musl*",
-]
-
 [tool.pyproject-fmt]
 max_supported_python = "3.15"
 

--- a/tox-toml-fmt/pyproject.toml
+++ b/tox-toml-fmt/pyproject.toml
@@ -27,6 +27,8 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
+  "Programming Language :: Python :: Free Threading :: 1 - Unstable",
 ]
 dynamic = [
   "version",
@@ -100,7 +102,7 @@ skip = [
 ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.mypy]
 show_error_codes = true

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::string::String;
 
 use pyo3::prelude::{PyModule, PyModuleMethods};
-use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult};
+use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult, Python};
 
 use tombi_config::TomlVersion;
 use tombi_syntax::SyntaxKind::KEY_VALUE;
@@ -99,8 +99,13 @@ async fn format_with_tombi(content: &str, column_width: usize, indent: usize) ->
     formatter.format(content).await.unwrap_or_else(|_| content.to_string())
 }
 
-#[must_use]
 #[pyfunction]
+#[pyo3(name = "format_toml")]
+fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
+    py.detach(|| format_toml(content, opt))
+}
+
+#[must_use]
 pub fn format_toml(content: &str, opt: &Settings) -> String {
     let root_ast = parse(content);
     common::string::normalize_key_quotes(&root_ast);
@@ -181,7 +186,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
 #[pymodule(gil_used = false)]
 #[pyo3(name = "_lib")]
 pub fn _lib(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(format_toml, m)?)?;
+    m.add_function(wrap_pyfunction!(format_toml_py, m)?)?;
     m.add_class::<Settings>()?;
     Ok(())
 }

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -178,7 +178,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
 /// # Errors
 ///
 /// Will return `PyErr` if an error is raised during formatting.
-#[pymodule]
+#[pymodule(gil_used = false)]
 #[pyo3(name = "_lib")]
 pub fn _lib(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(format_toml, m)?)?;

--- a/tox-toml-fmt/tox.toml
+++ b/tox-toml-fmt/tox.toml
@@ -11,6 +11,10 @@ dependency_groups = ["test"]
 pass_env = ["PYTEST_*", "SSL_CERT_FILE"]
 set_env.COVERAGE_FILE = { replace = "env", name = "COVERAGE_FILE", default = "{work_dir}{/}.coverage.{env_name}" }
 set_env.COVERAGE_FILECOVERAGE_PROCESS_START = "{tox_root}{/}pyproject.toml"
+
+[env."3.15t"]
+description = "run tests under free-threaded 3.15 (no abi3 — PEP 803 abi3t not yet implemented in 3.15.0a8)"
+set_env.MATURIN_PEP517_ARGS = "--no-default-features --features extension-module"
 commands = [
     [
         "pytest",


### PR DESCRIPTION
Installing `pyproject-fmt` or `tox-toml-fmt` under [free-threaded CPython](https://docs.python.org/3/howto/free-threading-python.html) failed because the published `cp39-abi3` wheel is rejected by free-threaded interpreters, and [PEP 803 (`abi3t`)](https://peps.python.org/pep-0803/) is still in progress in CPython 3.15 (tracked in [python/cpython#146636](https://github.com/python/cpython/issues/146636), with the related loader bug at [python/cpython#120901](https://github.com/python/cpython/issues/120901)). 🧵 Users on `python3.15t` saw `The built wheel pyproject_fmt-2.21.1-cp39-abi3-linux_x86_64.whl is not compatible with the current Python 3.15t`, and `3.13t`/`3.14t` had no compatible wheel either.

The PyO3 modules are now marked with [`gil_used = false`](https://pyo3.rs/v0.28.3/free-threading) since the format pipeline is pure Rust with no shared Python state, so they run without re-enabling the GIL on free-threaded interpreters. `abi3` becomes a [Cargo feature](https://doc.rust-lang.org/cargo/reference/features.html) rather than a hardcoded dependency flag, which lets [maturin](https://www.maturin.rs/) produce version-specific wheels for `3.15t` (where its abi3 [auto-fallback heuristic](https://github.com/PyO3/maturin/pull/2310) is currently too eager because PEP 803 isn't fully landed in `3.15.0a8`) by setting [`MATURIN_PEP517_ARGS`](https://www.maturin.rs/distribution#cross-compiling)`=--no-default-features --features extension-module` in the per-env tox config; for `3.13t`/`3.14t` maturin already auto-falls-back to per-version builds.

The build matrices now ship `cp313t`/`cp314t` wheels alongside the existing abi3 wheel, and the test matrix covers `3.15`, `3.13t`, `3.14t`, and `3.15t`. `max_supported_python` moves to `3.15` and the [trove classifiers](https://pypi.org/classifiers/) gain `Free Threading :: 1 - Unstable`. A small `build.rs` per package emits the macOS [`-undefined dynamic_lookup`](https://pyo3.rs/v0.28.3/building-and-distribution#macos) linker flag only when `extension-module` is active, so local `cargo build` works on Apple Silicon. ✨

Closes #305