### PR TITLE
👷 ci(build): consolidate build workflows and add new targets

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -119,8 +119,8 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
-          - { runner: windows-11-arm, target: aarch64, interpreter: "3.10 3.13t 3.14t" }
+          - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t", python: "3.10" }
+          - { runner: windows-11-arm, target: aarch64, interpreter: "3.11 3.13t 3.14t", python: "3.11" }
           # 3.15t Windows wheel skipped: python3-dll-a (pulled in by generate-import-lib) only
           # has .def files up to 3.14t (https://github.com/PyO3/python3-dll-a/blob/main/src/lib.rs).
           # Re-enable when https://github.com/PyO3/pyo3/issues/6012 finishes 3.15 ABI support.
@@ -129,10 +129,10 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: source
-      - name: 🐍 Setup Python 3.10
+      - name: 🐍 Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.platform.python }}
           architecture: ${{ matrix.platform.target == 'x86' && 'x86' || matrix.platform.target == 'aarch64' && 'arm64' || 'x64' }}
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -10,6 +10,9 @@ on:
         type: string
         description: "Pre-commit mirror repo (e.g. tox-dev/pyproject-fmt)"
 
+permissions:
+  contents: read
+
 jobs:
   bump:
     name: 🔖 bump
@@ -21,7 +24,7 @@ jobs:
       changelog: ${{ steps.v.outputs.changelog }}
     steps:
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: 📦 Install cargo-edit
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
         with:
@@ -52,7 +55,7 @@ jobs:
         with:
           python-version: "3.14"
       - name: 🎨 Run pre-commit
-        uses: tox-dev/action-pre-commit-uv@246b66536e366bb885f52d61983bf32f7c95e8b1 # v1.0.3
+        uses: tox-dev/action-pre-commit-uv@246b66536e366bb885f52d61983bf32f7c95e8b1 # 1.0.3
         continue-on-error: true
       - name: 📝 Generate README.rst
         run: python tasks/generate_readme.py "$PACKAGE"
@@ -98,7 +101,8 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: -m ${{ inputs.package-name }}/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
+          args:
+            -m ${{ inputs.package-name }}/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
           sccache: true
       - name: 📤 Upload wheels

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,0 +1,273 @@
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        required: true
+        type: string
+        description: "Package name (e.g. pyproject-fmt)"
+      pre-commit-mirror:
+        required: true
+        type: string
+        description: "Pre-commit mirror repo (e.g. tox-dev/pyproject-fmt)"
+
+jobs:
+  bump:
+    name: 🔖 bump
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      changelog: ${{ steps.v.outputs.changelog }}
+    steps:
+      - name: 🦀 Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+      - name: 📦 Install cargo-edit
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
+        with:
+          crate: cargo-edit
+      - name: 📥 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: 🔖 Bump version
+        run: cargo set-version -p "$PACKAGE" --bump "$RELEASE_TYPE"
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+          RELEASE_TYPE: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null && 'patch' || github.event.inputs.release }}
+      - name: 📦 Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "tasks/changelog.py"
+      - name: 📝 Generate changelog
+        id: v
+        run: uv run tasks/changelog.py "$PACKAGE" "${{ github.event.number }}" "${{ github.event.pull_request.base.sha }}"
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.14"
+      - name: 🎨 Run pre-commit
+        uses: tox-dev/action-pre-commit-uv@246b66536e366bb885f52d61983bf32f7c95e8b1 # v1.0.3
+        continue-on-error: true
+      - name: 📝 Generate README.rst
+        run: python tasks/generate_readme.py "$PACKAGE"
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+      - name: 👀 Show changes
+        run: git diff HEAD -u
+      - name: 📤 Upload source
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: source
+          path: |
+            .
+            !.git
+          compression-level: 9
+          retention-days: 1
+          if-no-files-found: "error"
+
+  linux:
+    name: 🐧 ${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
+    needs: [bump]
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 3.13t 3.14t pypy3.11" }
+          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.10 3.13t 3.14t" }
+          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.10 3.13t 3.14t" }
+          - { runner: ubuntu-24.04, target: aarch64-unknown-linux-musl, manylinux: musllinux_1_2, zig: true, interpreter: "3.10 3.13t 3.14t" }
+          - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
+          # 3.15t needs explicit no-abi3 build (PEP 803 incomplete in 3.15.0a8)
+          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: ubuntu-24.04, target: aarch64-unknown-linux-musl, manylinux: musllinux_1_2, zig: true, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+    steps:
+      - name: 📥 Download source
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: source
+      - name: 🔨 Build wheels
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.platform.target }}
+          args: -m ${{ inputs.package-name }}/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
+          manylinux: ${{ matrix.platform.manylinux || 'auto' }}
+          sccache: true
+      - name: 📤 Upload wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: wheels-linux-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
+          path: dist
+
+  windows:
+    name: 🪟 ${{ matrix.platform.target }}
+    needs: [bump]
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
+          - { runner: windows-11-arm, target: aarch64, interpreter: "3.10 3.13t 3.14t" }
+          # 3.15t Windows wheel skipped: python3-dll-a (pulled in by generate-import-lib) only
+          # has .def files up to 3.14t (https://github.com/PyO3/python3-dll-a/blob/main/src/lib.rs).
+          # Re-enable when https://github.com/PyO3/pyo3/issues/6012 finishes 3.15 ABI support.
+    steps:
+      - name: 📥 Download source
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: source
+      - name: 🐍 Setup Python 3.10
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+          architecture: ${{ matrix.platform.target == 'x86' && 'x86' || matrix.platform.target == 'aarch64' && 'arm64' || 'x64' }}
+      - name: 🔨 Build wheels
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.platform.target }}
+          args: -m ${{ inputs.package-name }}/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target
+          sccache: true
+      - name: 📤 Upload wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: wheels-windows-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
+          path: dist
+
+  macos:
+    name: 🍎 ${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
+    needs: [bump]
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { runner: macos-15, target: x86_64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
+          - { runner: macos-15, target: aarch64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
+          - { runner: macos-15, target: x86_64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+          - { runner: macos-15, target: aarch64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
+    steps:
+      - name: 📥 Download source
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: source
+      - name: 🔨 Build wheels
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          target: ${{ matrix.platform.target }}
+          args: -m ${{ inputs.package-name }}/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter }} ${{ matrix.platform.extra || '' }} --target-dir target
+          sccache: true
+      - name: 📤 Upload wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
+          path: dist
+
+  sdist:
+    name: 📦 sdist
+    needs: [bump]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 📥 Download source
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: source
+      - name: 📦 Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          command: sdist
+          args: -m ${{ inputs.package-name }}/Cargo.toml --out dist
+      - name: 📤 Upload sdist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: wheels-sdist
+          path: dist
+
+  release:
+    name: 🚀 release
+    runs-on: ubuntu-24.04
+    environment:
+      name: release
+      url: https://pypi.org/project/${{ inputs.package-name }}/${{ needs.bump.outputs.version }}
+    permissions:
+      id-token: write
+      contents: write
+    if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
+    needs: [bump, sdist, linux, macos, windows]
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: true
+      - name: 📥 Download source
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: source
+          path: .
+      - name: 👀 Show changes
+        run: git diff HEAD -u
+      - name: 💾 Commit release
+        run: |
+          git config --global user.name 'Bernat Gabor'
+          git config --global user.email 'gaborbernat@users.noreply.github.com'
+          git commit -am "Release ${PACKAGE} ${VERSION} [skip ci]"
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+          VERSION: ${{ needs.bump.outputs.version }}
+      - name: 📥 Download wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: "true"
+      - name: 👀 Show wheels
+        run: ls -lth dist
+      - name: 🚀 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+      - name: 📢 Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          PACKAGE: ${{ inputs.package-name }}
+          VERSION: ${{ needs.bump.outputs.version }}
+          CHANGELOG: ${{ needs.bump.outputs.changelog }}
+        run: |
+          git pull --rebase origin main
+          git tag "${PACKAGE}/${VERSION}"
+          git push
+          git push --tags
+          gh release create "${PACKAGE}/${VERSION}" \
+              --title="${PACKAGE}/${VERSION}" --verify-tag \
+            --notes "$(cat << 'EOM'
+          ${CHANGELOG}
+          EOM
+          )"
+      - name: 🔄 Trigger pre-commit mirror sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          MIRROR: ${{ inputs.pre-commit-mirror }}
+        run: gh workflow run main.yaml --repo "$MIRROR"
+
+  all-pass:
+    name: ✅ ${{ inputs.package-name }}-build
+    if: always()
+    needs: [bump, linux, windows, macos, sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether all jobs passed or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs failed or were canceled"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped"

--- a/.github/workflows/common.yaml
+++ b/.github/workflows/common.yaml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: clippy
       - name: 📎 Run Clippy
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: rustfmt
       - name: 🎨 Check formatting
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: 🔨 Build
         run: cargo build -p common --locked
 
@@ -72,17 +72,17 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: llvm-tools-preview
       - name: 📦 Install cargo-llvm-cov
-        uses: taiki-e/install-action@711e1c3275189d76dcc4d34ddea63bf96ac49090 # v2
+        uses: taiki-e/install-action@711e1c3275189d76dcc4d34ddea63bf96ac49090 # v2.76.0
         with:
           tool: cargo-llvm-cov
       - name: ✅ Run tests with coverage
         run: cargo llvm-cov -p common --no-default-features --locked --codecov --output-path coverage.json --ignore-filename-regex 'create\.rs'
       - name: 📤 Upload coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.json

--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       package-name: pyproject-fmt
       pre-commit-mirror: tox-dev/pyproject-fmt
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -10,7 +10,19 @@ on:
         options: ["no", patch, minor, major]
   push:
     branches: ["main"]
+    paths:
+      - "common/**"
+      - "toml-fmt-common/**"
+      - "pyproject-fmt/**"
+      - ".github/workflows/pyproject_fmt_build.yaml"
+      - ".github/workflows/_build.yaml"
   pull_request:
+    paths:
+      - "common/**"
+      - "toml-fmt-common/**"
+      - "pyproject-fmt/**"
+      - ".github/workflows/pyproject_fmt_build.yaml"
+      - ".github/workflows/_build.yaml"
   schedule:
     - cron: "0 8 * * *"
 
@@ -18,280 +30,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ github.event.inputs.release && github.event.inputs.release != 'no' && '-release' || '' }}
   cancel-in-progress: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null }}
 
-permissions:
-  contents: read
-
 jobs:
-  changes:
-    name: 🔍 changes
-    runs-on: ubuntu-latest
-    outputs:
-      run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.run == 'true' }}
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: 🔍 Check for changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
-        id: filter
-        with:
-          filters: |
-            run:
-              - 'common/**'
-              - 'toml-fmt-common/**'
-              - 'pyproject-fmt/**'
-              - '.github/workflows/pyproject_fmt_build.yaml'
-
-  bump:
-    name: 🔖 bump
-    needs: changes
-    if: needs.changes.outputs.run == 'true'
-    runs-on: ubuntu-24.04
+  build:
+    uses: ./.github/workflows/_build.yaml
+    with:
+      package-name: pyproject-fmt
+      pre-commit-mirror: tox-dev/pyproject-fmt
+    secrets: inherit
     permissions:
-      pull-requests: read
-    outputs:
-      version: ${{ steps.v.outputs.version }}
-      changelog: ${{ steps.v.outputs.changelog }}
-    steps:
-      - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
-      - name: 📦 Install cargo-edit
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
-        with:
-          crate: cargo-edit
-      - name: 📥 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: 🔖 Bump version
-        run: cargo set-version -p pyproject-fmt --bump "$RELEASE_TYPE"
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null && 'patch' || github.event.inputs.release }}
-      - name: 📦 Setup uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: "tasks/changelog.py"
-      - name: 📝 Generate changelog
-        id: v
-        run: uv run tasks/changelog.py pyproject-fmt "${{ github.event.number }}" "${{ github.event.pull_request.base.sha }}"
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: 🐍 Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.14"
-      - name: 🎨 Run pre-commit
-        uses: tox-dev/action-pre-commit-uv@246b66536e366bb885f52d61983bf32f7c95e8b1 # v1.0.3
-        continue-on-error: true
-      - name: 📝 Generate README.rst
-        run: python tasks/generate_readme.py pyproject-fmt
-      - name: 👀 Show changes
-        run: git diff HEAD -u
-      - name: 📤 Upload source
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: source
-          path: |
-            .
-            !.git
-          compression-level: 9
-          retention-days: 1
-          if-no-files-found: "error"
-
-  linux:
-    name: 🐧 ${{ matrix.platform.target }}
-    needs: [bump]
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 3.13t 3.14t pypy3.11" }
-          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.10 3.13t 3.14t" }
-          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.10 3.13t 3.14t" }
-          - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
-          # 3.15t needs explicit no-abi3 build (PEP 803 incomplete in 3.15.0a8)
-          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-    steps:
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-      - name: 🔨 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
-          manylinux: ${{ matrix.platform.manylinux || 'auto' }}
-          sccache: true
-      - name: 📤 Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
-          path: dist
-
-  windows:
-    name: 🪟 ${{ matrix.platform.target }}
-    needs: [bump]
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
-          # 3.15t Windows wheel skipped: python3-dll-a (pulled in by generate-import-lib) only
-          # has .def files up to 3.14t (https://github.com/PyO3/python3-dll-a/blob/main/src/lib.rs).
-          # Re-enable when https://github.com/PyO3/pyo3/issues/6012 finishes 3.15 ABI support.
-    steps:
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-      - name: 🐍 Setup Python 3.10
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.10"
-          architecture: ${{ matrix.platform.target == 'x86' && 'x86' || 'x64' }}
-      - name: 🔨 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target
-          sccache: true
-      - name: 📤 Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
-          path: dist
-
-  macos:
-    name: 🍎 ${{ matrix.platform.target }}
-    needs: [bump]
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { runner: macos-15, target: x86_64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
-          - { runner: macos-15, target: aarch64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
-          - { runner: macos-15, target: x86_64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-          - { runner: macos-15, target: aarch64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-    steps:
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-      - name: 🔨 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: -m pyproject-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter }} ${{ matrix.platform.extra || '' }} --target-dir target
-          sccache: true
-      - name: 📤 Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: wheels-macos-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
-          path: dist
-
-  sdist:
-    name: 📦 sdist
-    needs: [bump]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-      - name: 📦 Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          command: sdist
-          args: -m pyproject-fmt/Cargo.toml --out dist
-      - name: 📤 Upload sdist
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: wheels-sdist
-          path: dist
-
-  release:
-    name: 🚀 release
-    runs-on: ubuntu-24.04
-    environment:
-      name: release
-      url: https://pypi.org/project/pyproject-fmt/${{ needs.bump.outputs.version }}
-    permissions:
-      id-token: write
       contents: write
-    if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
-    needs: [bump, sdist, linux, macos, windows]
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: true
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-          path: .
-      - name: 👀 Show changes
-        run: git diff HEAD -u
-      - name: 💾 Commit release
-        run: |
-          git config --global user.name 'Bernat Gabor'
-          git config --global user.email 'gaborbernat@users.noreply.github.com'
-          git commit -am "Release pyproject-fmt ${NEEDS_BUMP_OUTPUTS_VERSION} [skip ci]"
-        env:
-          NEEDS_BUMP_OUTPUTS_VERSION: ${{needs.bump.outputs.version}}
-      - name: 📥 Download wheels
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: wheels-*
-          path: dist
-          merge-multiple: "true"
-      - name: 👀 Show wheels
-        run: ls -lth dist
-      - name: 🚀 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          skip-existing: true
-      - name: 📢 Create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          NEEDS_BUMP_OUTPUTS_VERSION: ${{needs.bump.outputs.version}}
-          NEEDS_BUMP_OUTPUTS_CHANGELOG: ${{ needs.bump.outputs.changelog }}
-        run: |
-          git pull --rebase origin main
-          git tag pyproject-fmt/${NEEDS_BUMP_OUTPUTS_VERSION}
-          git push
-          git push --tags
-          gh release create "pyproject-fmt/${NEEDS_BUMP_OUTPUTS_VERSION}" \
-              --title="pyproject-fmt/${NEEDS_BUMP_OUTPUTS_VERSION}" --verify-tag \
-            --notes "$(cat << 'EOM'
-          ${NEEDS_BUMP_OUTPUTS_CHANGELOG}
-          EOM
-          )"
-      - name: 🔄 Trigger pre-commit mirror sync
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: gh workflow run main.yaml --repo tox-dev/pyproject-fmt
-
-  all-pass:
-    name: ✅ pyproject-fmt-build
-    if: always()
-    needs: [changes, bump, linux, windows, macos, sdist]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Decide whether all jobs passed or were skipped
-        run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "Some jobs failed or were canceled"
-            exit 1
-          fi
-          echo "All jobs passed or were skipped"
+      id-token: write
+      pull-requests: read

--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: clippy
       - name: 📎 Run Clippy
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: rustfmt
       - name: 🎨 Check formatting
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: 🔨 Build
         run: cargo build -p pyproject-fmt --locked
 
@@ -99,17 +99,17 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: llvm-tools-preview
       - name: 📦 Install cargo-llvm-cov
-        uses: taiki-e/install-action@711e1c3275189d76dcc4d34ddea63bf96ac49090 # v2
+        uses: taiki-e/install-action@711e1c3275189d76dcc4d34ddea63bf96ac49090 # v2.76.0
         with:
           tool: cargo-llvm-cov
       - name: ✅ Run tests with coverage
         run: cargo llvm-cov -p pyproject-fmt --no-default-features --locked --codecov --output-path coverage.json --ignore-filename-regex 'main\.rs'
       - name: 📤 Upload coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.json
@@ -187,7 +187,7 @@ jobs:
       - name: 🔧 Install tox
         run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: 📝 Generate README.rst
         run: tox run -e readme
         working-directory: pyproject-fmt

--- a/.github/workflows/toml_fmt_common_test.yaml
+++ b/.github/workflows/toml_fmt_common_test.yaml
@@ -72,7 +72,7 @@ jobs:
           PYTEST_ADDOPTS: "-vv --durations=20"
       - name: 📤 Upload coverage
         if: startsWith(matrix.env, '3.')
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: toml-fmt-common/.tox/${{ matrix.env }}

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -10,7 +10,19 @@ on:
         options: ["no", patch, minor, major]
   push:
     branches: ["main"]
+    paths:
+      - "common/**"
+      - "toml-fmt-common/**"
+      - "tox-toml-fmt/**"
+      - ".github/workflows/tox_toml_fmt_build.yaml"
+      - ".github/workflows/_build.yaml"
   pull_request:
+    paths:
+      - "common/**"
+      - "toml-fmt-common/**"
+      - "tox-toml-fmt/**"
+      - ".github/workflows/tox_toml_fmt_build.yaml"
+      - ".github/workflows/_build.yaml"
   schedule:
     - cron: "0 8 * * *"
 
@@ -18,280 +30,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ github.event.inputs.release && github.event.inputs.release != 'no' && '-release' || '' }}
   cancel-in-progress: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null }}
 
-permissions:
-  contents: read
-
 jobs:
-  changes:
-    name: 🔍 changes
-    runs-on: ubuntu-latest
-    outputs:
-      run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.run == 'true' }}
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: 🔍 Check for changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
-        id: filter
-        with:
-          filters: |
-            run:
-              - 'common/**'
-              - 'toml-fmt-common/**'
-              - 'tox-toml-fmt/**'
-              - '.github/workflows/tox_toml_fmt_build.yaml'
-
-  bump:
-    name: 🔖 bump
-    needs: changes
-    if: needs.changes.outputs.run == 'true'
-    runs-on: ubuntu-24.04
+  build:
+    uses: ./.github/workflows/_build.yaml
+    with:
+      package-name: tox-toml-fmt
+      pre-commit-mirror: tox-dev/tox-toml-fmt
+    secrets: inherit
     permissions:
-      pull-requests: read
-    outputs:
-      version: ${{ steps.v.outputs.version }}
-      changelog: ${{ steps.v.outputs.changelog }}
-    steps:
-      - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
-      - name: 📦 Install cargo-edit
-        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3
-        with:
-          crate: cargo-edit
-      - name: 📥 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: 🔖 Bump version
-        run: cargo set-version -p tox-toml-fmt --bump "$RELEASE_TYPE"
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null && 'patch' || github.event.inputs.release }}
-      - name: 📦 Setup uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: "tasks/changelog.py"
-      - name: 📝 Generate changelog
-        id: v
-        run: uv run tasks/changelog.py tox-toml-fmt "${{ github.event.number }}" "${{ github.event.pull_request.base.sha }}"
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: 🐍 Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.14"
-      - name: 🎨 Run pre-commit
-        uses: tox-dev/action-pre-commit-uv@246b66536e366bb885f52d61983bf32f7c95e8b1 # v1.0.3
-        continue-on-error: true
-      - name: 📝 Generate README.rst
-        run: python tasks/generate_readme.py tox-toml-fmt
-      - name: 👀 Show changes
-        run: git diff HEAD -u
-      - name: 📤 Upload source
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: source
-          path: |
-            .
-            !.git
-          compression-level: 9
-          retention-days: 1
-          if-no-files-found: "error"
-
-  linux:
-    name: 🐧 ${{ matrix.platform.target }}
-    needs: [bump]
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.10 3.13t 3.14t pypy3.11" }
-          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.10 3.13t 3.14t" }
-          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.10 3.13t 3.14t" }
-          - { runner: ubuntu-24.04, target: riscv64gc-unknown-linux-gnu, manylinux: "2_31" }
-          # 3.15t needs explicit no-abi3 build (PEP 803 incomplete in 3.15.0a8)
-          - { runner: ubuntu-24.04, target: x86_64, manylinux: "2_28", interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-          - { runner: ubuntu-24.04, target: x86_64-unknown-linux-musl, manylinux: musllinux_1_2, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-          - { runner: ubuntu-24.04, target: aarch64, manylinux: "2_28", zig: true, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-    steps:
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-      - name: 🔨 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
-          manylinux: ${{ matrix.platform.manylinux || 'auto' }}
-          sccache: true
-      - name: 📤 Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: wheels-linux-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
-          path: dist
-
-  windows:
-    name: 🪟 ${{ matrix.platform.target }}
-    needs: [bump]
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { runner: windows-2025, target: x64, interpreter: "3.10 3.13t 3.14t" }
-          # 3.15t Windows wheel skipped: python3-dll-a (pulled in by generate-import-lib) only
-          # has .def files up to 3.14t (https://github.com/PyO3/python3-dll-a/blob/main/src/lib.rs).
-          # Re-enable when https://github.com/PyO3/pyo3/issues/6012 finishes 3.15 ABI support.
-    steps:
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-      - name: 🐍 Setup Python 3.10
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.10"
-          architecture: ${{ matrix.platform.target == 'x86' && 'x86' || 'x64' }}
-      - name: 🔨 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target
-          sccache: true
-      - name: 📤 Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
-          path: dist
-
-  macos:
-    name: 🍎 ${{ matrix.platform.target }}
-    needs: [bump]
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { runner: macos-15, target: x86_64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
-          - { runner: macos-15, target: aarch64, interpreter: "3.10 3.13t 3.14t pypy3.11" }
-          - { runner: macos-15, target: x86_64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-          - { runner: macos-15, target: aarch64, interpreter: "3.15t", extra: "--no-default-features --features extension-module", suffix: "-315t" }
-    steps:
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-      - name: 🔨 Build wheels
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          target: ${{ matrix.platform.target }}
-          args: -m tox-toml-fmt/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter }} ${{ matrix.platform.extra || '' }} --target-dir target
-          sccache: true
-      - name: 📤 Upload wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: wheels-macos-${{ matrix.platform.target }}${{ matrix.platform.suffix || '' }}
-          path: dist
-
-  sdist:
-    name: 📦 sdist
-    needs: [bump]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-      - name: 📦 Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          command: sdist
-          args: -m tox-toml-fmt/Cargo.toml --out dist
-      - name: 📤 Upload sdist
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: wheels-sdist
-          path: dist
-
-  release:
-    name: 🚀 release
-    runs-on: ubuntu-24.04
-    environment:
-      name: release
-      url: https://pypi.org/project/tox-toml-fmt/${{ needs.bump.outputs.version }}
-    permissions:
-      id-token: write
       contents: write
-    if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
-    needs: [bump, sdist, linux, macos, windows]
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: true
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-          path: .
-      - name: 👀 Show changes
-        run: git diff HEAD -u
-      - name: 💾 Commit release
-        run: |
-          git config --global user.name 'Bernat Gabor'
-          git config --global user.email 'gaborbernat@users.noreply.github.com'
-          git commit -am "Release tox-toml-fmt ${NEEDS_BUMP_OUTPUTS_VERSION} [skip ci]"
-        env:
-          NEEDS_BUMP_OUTPUTS_VERSION: ${{needs.bump.outputs.version}}
-      - name: 📥 Download wheels
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: wheels-*
-          path: dist
-          merge-multiple: "true"
-      - name: 👀 Show wheels
-        run: ls -lth dist
-      - name: 🚀 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          skip-existing: true
-      - name: 📢 Create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          NEEDS_BUMP_OUTPUTS_VERSION: ${{needs.bump.outputs.version}}
-          NEEDS_BUMP_OUTPUTS_CHANGELOG: ${{ needs.bump.outputs.changelog }}
-        run: |
-          git pull --rebase origin main
-          git tag tox-toml-fmt/${NEEDS_BUMP_OUTPUTS_VERSION}
-          git push
-          git push --tags
-          gh release create "tox-toml-fmt/${NEEDS_BUMP_OUTPUTS_VERSION}" \
-              --title="tox-toml-fmt/${NEEDS_BUMP_OUTPUTS_VERSION}" --verify-tag \
-            --notes "$(cat << 'EOM'
-          ${NEEDS_BUMP_OUTPUTS_CHANGELOG}
-          EOM
-          )"
-      - name: 🔄 Trigger pre-commit mirror sync
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        run: gh workflow run main.yaml --repo tox-dev/tox-toml-fmt
-
-  all-pass:
-    name: ✅ tox-toml-fmt-build
-    if: always()
-    needs: [changes, bump, linux, windows, macos, sdist]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Decide whether all jobs passed or were skipped
-        run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "Some jobs failed or were canceled"
-            exit 1
-          fi
-          echo "All jobs passed or were skipped"
+      id-token: write
+      pull-requests: read

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       package-name: tox-toml-fmt
       pre-commit-mirror: tox-dev/tox-toml-fmt
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: clippy
       - name: 📎 Run Clippy
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: rustfmt
       - name: 🎨 Check formatting
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: 🔨 Build
         run: cargo build -p tox-toml-fmt --locked
 
@@ -99,17 +99,17 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           components: llvm-tools-preview
       - name: 📦 Install cargo-llvm-cov
-        uses: taiki-e/install-action@711e1c3275189d76dcc4d34ddea63bf96ac49090 # v2
+        uses: taiki-e/install-action@711e1c3275189d76dcc4d34ddea63bf96ac49090 # v2.76.0
         with:
           tool: cargo-llvm-cov
       - name: ✅ Run tests with coverage
         run: cargo llvm-cov -p tox-toml-fmt --no-default-features --locked --codecov --output-path coverage.json --ignore-filename-regex 'main\.rs'
       - name: 📤 Upload coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.json
@@ -187,7 +187,7 @@ jobs:
       - name: 🔧 Install tox
         run: uv tool install --python-preference only-managed --python 3.14 tox --with tox-uv
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
       - name: 📝 Generate README.rst
         run: tox run -e readme
         working-directory: tox-toml-fmt

--- a/.github/workflows/update_dependencies.yaml
+++ b/.github/workflows/update_dependencies.yaml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
 
       - name: 🐍 Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
@@ -78,7 +78,7 @@ jobs:
           persist-credentials: false
 
       - name: 🦀 Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
 
       - name: ⬆️ Update git dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,21 +2,17 @@ ci:
   autoupdate_schedule: monthly
 
 repos:
-  # Priority 0: Formatters + read-only validators (all in parallel)
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "v2.21.1"
     hooks:
       - id: pyproject-fmt
-        priority: 0
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.15.12"
     hooks:
       - id: ruff-format
         args: ["--config", "pyproject.toml"]
-        priority: 0
       - id: ruff-check
         args: ["--fix", "--unsafe-fixes", "--exit-non-zero-on-fix", "--config", "pyproject.toml"]
-        priority: 1 # after ruff-format (both modify Python)
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: "v3.8.3"
     hooks:
@@ -24,29 +20,24 @@ repos:
         name: Prettier non-workflow files
         args: ["--print-width=120", "--prose-wrap=always"]
         exclude: ".github/workflows/"
-        priority: 0
       - id: prettier
         name: Prettier workflow files
         args: ["--print-width=240", "--prose-wrap=always"]
         exclude: "^(?!.github/workflows/)"
-        priority: 0
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.2
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]
-        priority: 0 # read-only
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:
       - id: codespell
         additional_dependencies: ["tomli>=2.4"]
-        priority: 0 # read-only
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.25
     hooks:
       - id: validate-pyproject
-        priority: 0 # read-only
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     rev: v1.24.1
     hooks:
@@ -54,14 +45,9 @@ repos:
   - repo: meta
     hooks:
       - id: check-hooks-apply
-        priority: 0 # read-only
       - id: check-useless-excludes
-        priority: 0 # read-only
-  # Priority 2: File fixers (cleanup after all formatters)
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
-        priority: 2
       - id: trailing-whitespace
-        priority: 2

--- a/tox-toml-fmt/Cargo.toml
+++ b/tox-toml-fmt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tox-toml-fmt"
 version = "1.9.3"
-description = "Format pyproject.toml files"
+description = "Format tox.toml files"
 repository = "https://github.com/tox-dev/tox-toml-fmt"
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
The `pyproject-fmt` and `tox-toml-fmt` build workflows were nearly identical — ~300 lines each with only package name substitutions between them. Every time a target, action version, or build step changed, it had to be updated in both files. This also made it easy for the two to silently diverge.

This extracts the shared build logic into a reusable `_build.yaml` workflow that both packages call with their specific inputs (`package-name`, `pre-commit-mirror`). Each caller keeps its own triggers and `paths:` filters so PRs touching only one package still skip the other's builds. ♻️ Net result: ~250 fewer lines to maintain and a single place to update build targets.

Two new platform targets ship with this change. 🪟 **Windows ARM64** wheels using GitHub's native `windows-11-arm` runner (same approach as pydantic-core). **aarch64 musl Linux** wheels via zig cross-compilation for Alpine on Apple Silicon — both pydantic-core and orjson already ship these.

Also cleans up pre-commit config: removes unsupported `priority` keys that caused warnings on every run, updates stale version comments on pinned GitHub Actions (zizmor `ref-version-mismatch`), and fixes `tox-toml-fmt/Cargo.toml` description which incorrectly said "Format pyproject.toml files".