### PR TITLE
🐛 fix(toml-fmt-common): include license file in sdist

### DIFF
--- a/toml-fmt-common/LICENSE.txt
+++ b/toml-fmt-common/LICENSE.txt
@@ -1,0 +1,18 @@
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/toml-fmt-common/pyproject.toml
+++ b/toml-fmt-common/pyproject.toml
@@ -8,6 +8,7 @@ version = "1.3.2"
 description = "Common logic to the TOML formatter."
 readme = "README.md"
 license = "MIT"
+license-files = [ "LICENSE.txt" ]
 maintainers = [
   { name = "Bernát Gábor", email = "gaborjbernat@gmail.com" },
 ]


### PR DESCRIPTION
The `toml-fmt-common` sdist has been missing `LICENSE.txt` since version 1.3.0, when the package was internalized as a workspace member in #170. 📦 The license file stayed at the monorepo root but was never added to the sub-package directory, so `uv-build` stopped including it in distributions.

The fix adds a copy of `LICENSE.txt` to `toml-fmt-common/` and declares `license-files` in `pyproject.toml`. This matches the pattern used by `pyproject-fmt` and `tox-toml-fmt`, which each have their own copy. A symlink was considered but rejected because git on Windows checks out symlinks as plain text files without Developer Mode enabled.

Fixes #309