### PR TITLE
🐛 fix(ci): expand changelog variable in release notes

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -252,10 +252,7 @@ jobs:
           git push --tags
           gh release create "${PACKAGE}/${VERSION}" \
               --title="${PACKAGE}/${VERSION}" --verify-tag \
-            --notes "$(cat << 'EOM'
-          ${CHANGELOG}
-          EOM
-          )"
+            --notes "${CHANGELOG}"
       - name: 🔄 Trigger pre-commit mirror sync
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
The zizmor security audit (commit d3902de) correctly moved `${{ needs.bump.outputs.changelog }}` from inline GitHub Actions expressions into env vars to prevent expression injection in `run:` blocks. However, the heredoc that passed the changelog to `gh release create --notes` used a quoted delimiter (`<< 'EOM'`), which disables bash variable expansion inside the body. The result: every release since April 13 shipped with the literal string `${NEEDS_BUMP_OUTPUTS_CHANGELOG}` as its release notes. 🐛

The fix replaces the heredoc with a direct double-quoted variable reference (`"${CHANGELOG}"`), which expands correctly and preserves newlines in multi-line changelogs. The four affected releases (tox-toml-fmt 1.9.2, 1.9.3, pyproject-fmt 2.21.1, 2.21.2) have already been backfilled manually.

Fixes #315