### PR TITLE
✨ feat(common): add configurable table spacing options

### DIFF
--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -223,7 +223,16 @@ impl Tables {
         }
     }
 
-    pub fn reorder(&self, root_ast: &SyntaxNode, order: &[&str], multi_level_prefixes: &[&str]) {
+    pub fn reorder(
+        &self,
+        root_ast: &SyntaxNode,
+        order: &[&str],
+        multi_level_prefixes: &[&str],
+        root_table_spacing: &str,
+        sub_table_spacing: &str,
+    ) {
+        let root_breaks = root_table_spacing.chars().filter(|&c| c == '\n').count() + 1;
+        let sub_breaks = sub_table_spacing.chars().filter(|&c| c == '\n').count() + 1;
         let mut to_insert = Vec::<SyntaxElement>::new();
         let order = calculate_order(&self.header_to_pos, &self.table_set, order, multi_level_prefixes);
         let mut next = order.clone();
@@ -238,29 +247,24 @@ impl Tables {
             for (entry_idx, entries) in entries_list.iter().enumerate() {
                 let got = entries.borrow_mut();
                 if !got.is_empty() {
-                    let last = got.last().unwrap();
                     let mut add = got.clone();
 
-                    // Determine if we need spacing after this entry
                     let is_last_entry_of_this_table = entry_idx == num_entries - 1;
 
                     if is_last_entry_of_this_table {
-                        // This is the last entry for this table name
-                        if get_key(name, multi_level_prefixes) != get_key(next_name, multi_level_prefixes) {
-                            // Different group - add blank line spacing
-                            if last.kind() == LINE_BREAK {
-                                add.pop();
-                            }
-                            // Only add spacing if there's a next table (not at the end)
-                            if !next_name.is_empty() {
-                                add.extend(make_empty_newline());
-                            }
-                        } else if !next_name.is_empty() {
-                            // Same group - add exactly one LINE_BREAK
+                        if !next_name.is_empty() {
+                            let breaks =
+                                if get_key(name, multi_level_prefixes) != get_key(next_name, multi_level_prefixes) {
+                                    root_breaks
+                                } else {
+                                    sub_breaks
+                                };
                             while !add.is_empty() && add.last().unwrap().kind() == LINE_BREAK {
                                 add.pop();
                             }
-                            add.push(make_newline());
+                            for _ in 0..breaks {
+                                add.push(make_newline());
+                            }
                         }
                     } else {
                         // Not the last entry - add blank line before next entry of same table

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -14,7 +14,7 @@ fn parse(source: &str) -> tombi_syntax::SyntaxNode {
 fn tables_reorder_helper(start: &str, order: &[&str]) -> String {
     let root_ast = parse(start);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, order, &["tool"]);
+    tables.reorder(&root_ast, order, &["tool"], "\n", "");
     format_toml(&root_ast, 120)
 }
 
@@ -61,7 +61,7 @@ fn collapse_sub_tables_helper(start: &str, table_name: &str, has_sub_tables: boo
 fn issue_124_helper(start: &str, order: &[&str]) -> String {
     let root_ast = parse(start);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, order, &[]);
+    tables.reorder(&root_ast, order, &[], "\n", "");
     format_toml(&root_ast, 120)
 }
 
@@ -262,6 +262,34 @@ fn test_tables_reorder_case_different_tools_preserve_file_order() {
 }
 
 #[test]
+fn test_sub_table_spacing_blank_line() {
+    let start = indoc! {r#"
+        [tool.ruff]
+        line-length = 120
+
+        [tool.ruff.lint]
+        select = ["E"]
+
+        [tool.mypy]
+        strict = true
+    "#};
+    let root_ast = parse(start);
+    let tables = Tables::from_ast(&root_ast);
+    tables.reorder(&root_ast, &["tool"], &["tool"], "\n", "\n");
+    let res = format_toml(&root_ast, 120);
+    insta::assert_snapshot!(res, @r#"
+    [tool.ruff]
+    line-length = 120
+
+    [tool.ruff.lint]
+    select = [ "E" ]
+
+    [tool.mypy]
+    strict = true
+    "#);
+}
+
+#[test]
 fn test_get_table_name_table_header() {
     let toml = "[project]";
     let root_ast = parse(toml);
@@ -452,7 +480,7 @@ fn test_reorder_with_root_entries() {
 
     assert!(tables.header_to_pos.contains_key(""));
 
-    tables.reorder(&root_ast, &["", "project"], &[]);
+    tables.reorder(&root_ast, &["", "project"], &[], "\n", "");
     let res = format_toml(&root_ast, 120);
     assert!(res.contains("root_key"));
     assert!(res.contains("[project]"));
@@ -472,7 +500,7 @@ fn test_reorder_preserves_empty_lines_between_groups() {
     "#};
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["project", "tool"], &["tool"]);
+    tables.reorder(&root_ast, &["project", "tool"], &["tool"], "\n", "");
 
     let res = format_toml(&root_ast, 120);
     assert!(res.contains("\n\n"));
@@ -536,7 +564,7 @@ fn test_reorder_only_newline_table() {
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
 
-    tables.reorder(&root_ast, &["", "project"], &[]);
+    tables.reorder(&root_ast, &["", "project"], &[], "\n", "");
     let res = format_toml(&root_ast, 120);
     assert!(res.contains("[project]"));
 }
@@ -644,7 +672,7 @@ fn test_reorder_same_tool_group() {
     "#};
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["tool"], &["tool"]);
+    tables.reorder(&root_ast, &["tool"], &["tool"], "\n", "");
 
     let res = format_toml(&root_ast, 120);
     assert!(res.contains("[tool.black]"));
@@ -656,7 +684,7 @@ fn test_reorder_different_groups_no_trailing_newline() {
     let toml = "[tool.black]\nline-length = 120\n[project]\nname = \"foo\"";
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["project", "tool"], &["tool"]);
+    tables.reorder(&root_ast, &["project", "tool"], &["tool"], "\n", "");
 
     let res = format_toml(&root_ast, 120);
     assert!(res.contains("[project]"));
@@ -684,7 +712,7 @@ fn test_comments_before_table_header_stay_with_that_table() {
     "#};
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["build-system", "project"], &[]);
+    tables.reorder(&root_ast, &["build-system", "project"], &[], "\n", "");
 
     let res = format_toml(&root_ast, 120);
     // The comment should stay with [build-system], not [project]
@@ -704,7 +732,7 @@ fn test_multiple_comments_before_table_header() {
     "#};
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["build-system", "project"], &[]);
+    tables.reorder(&root_ast, &["build-system", "project"], &[], "\n", "");
 
     let res = format_toml(&root_ast, 120);
     // Both comments should stay with [build-system]
@@ -723,7 +751,7 @@ fn test_comment_with_blank_line_before_table_header() {
     "#};
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["build-system", "project"], &[]);
+    tables.reorder(&root_ast, &["build-system", "project"], &[], "\n", "");
 
     let res = format_toml(&root_ast, 120);
     // Comment should stay with [build-system] even with blank line before it
@@ -1615,7 +1643,7 @@ fn test_tables_reorder_with_empty_key() {
     "#};
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["tool"], &[]);
+    tables.reorder(&root_ast, &["tool"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [tool]
@@ -1638,7 +1666,7 @@ fn test_expand_sub_table_multiple_main_positions_no_expand() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
     expand_sub_table(&mut tables, "project", "scripts");
-    tables.reorder(&root_ast, &["project", "other"], &[]);
+    tables.reorder(&root_ast, &["project", "other"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [project]
@@ -1667,7 +1695,7 @@ fn test_collapse_sub_table_multiple_sub_positions_unchanged() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
     collapse_sub_table(&mut tables, "project", "scripts", 120);
-    tables.reorder(&root_ast, &["project", "project.scripts"], &[]);
+    tables.reorder(&root_ast, &["project", "project.scripts"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [project]
@@ -1686,7 +1714,7 @@ fn test_apply_table_formatting_expand_mode() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
     apply_table_formatting(&mut tables, |_name| false, &["project"], 120);
-    tables.reorder(&root_ast, &["project", "project.scripts"], &[]);
+    tables.reorder(&root_ast, &["project", "project.scripts"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [project]
@@ -1707,7 +1735,7 @@ fn test_expand_dotted_to_sub_tables_array_of_tables_unchanged() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
     expand_sub_tables(&mut tables, "tool");
-    tables.reorder(&root_ast, &["tool"], &[]);
+    tables.reorder(&root_ast, &["tool"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [[tool]]
@@ -1727,7 +1755,7 @@ fn test_tables_from_ast_with_table_children() {
     "#};
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["project"], &[]);
+    tables.reorder(&root_ast, &["project"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [project]
@@ -1745,7 +1773,7 @@ fn test_split_quoted_key_no_dot() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
     apply_table_formatting(&mut tables, |_| true, &["project"], 120);
-    tables.reorder(&root_ast, &["project"], &[]);
+    tables.reorder(&root_ast, &["project"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [project]
@@ -1765,7 +1793,7 @@ fn test_collapse_sub_table_with_quoted_key() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
     collapse_sub_table(&mut tables, "project", "scripts", 120);
-    tables.reorder(&root_ast, &["project", "project.scripts"], &[]);
+    tables.reorder(&root_ast, &["project", "project.scripts"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [project]
@@ -1786,7 +1814,7 @@ fn test_collapse_sub_table_with_literal_quoted_key() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
     collapse_sub_table(&mut tables, "project", "scripts", 120);
-    tables.reorder(&root_ast, &["project", "project.scripts"], &[]);
+    tables.reorder(&root_ast, &["project", "project.scripts"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [project]
@@ -1807,7 +1835,7 @@ fn test_collapse_sub_tables_skips_array_of_tables() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
     collapse_sub_tables(&mut tables, "project");
-    tables.reorder(&root_ast, &["project", "project.authors"], &[]);
+    tables.reorder(&root_ast, &["project", "project.authors"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [project]
@@ -1832,7 +1860,7 @@ fn test_reorder_array_of_tables_multiple_entries() {
     "#};
     let root_ast = parse(toml);
     let tables = Tables::from_ast(&root_ast);
-    tables.reorder(&root_ast, &["project", "project.authors"], &[]);
+    tables.reorder(&root_ast, &["project", "project.authors"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [project]
@@ -1914,7 +1942,7 @@ fn test_collapse_sub_table_trailing_comment_on_single_line_array() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
     collapse_sub_table(&mut tables, "tool.coverage", "run", 120);
-    tables.reorder(&root_ast, &["tool.coverage", "tool.coverage.run"], &[]);
+    tables.reorder(&root_ast, &["tool.coverage", "tool.coverage.run"], &[], "\n", "");
     let result = format_toml(&root_ast, 120);
     insta::assert_snapshot!(result, @r#"
     [tool.coverage]

--- a/pyproject-fmt/docs/configuration.rst
+++ b/pyproject-fmt/docs/configuration.rst
@@ -68,6 +68,8 @@ The shared config file uses the same keys as the ``[tool.pyproject-fmt]`` table,
     column_width = 120
     indent = 2
     table_format = "short"
+    sub_table_spacing = ""
+    separate_root_table = "\n"
     max_supported_python = "3.14"
 
 When both a shared config file and a ``[tool.pyproject-fmt]`` table exist, per-file settings from the
@@ -127,6 +129,23 @@ readability when tables have many keys or complex values:
 
     [project.scripts]
     mycli = "mypackage:main"
+
+Table spacing
+~~~~~~~~~~~~~
+
+The ``sub_table_spacing`` and ``separate_root_table`` options control the blank lines inserted between tables. Each
+option takes a string of ``\n`` characters where each ``\n`` adds one blank line:
+
+- ``sub_table_spacing`` (default ``""``) controls spacing between sub-tables within the same group. For example,
+  between ``[tool.ruff]`` and ``[tool.ruff.lint]``. Set to ``"\n"`` to add a blank line between sub-tables.
+- ``separate_root_table`` (default ``"\n"``) controls spacing between different root table groups. For example,
+  between ``[project]`` and ``[tool.ruff]``.
+
+.. code-block:: toml
+
+    [tool.pyproject-fmt]
+    sub_table_spacing = "\n"  # Add blank line between sub-tables
+    separate_root_table = "\n"  # One blank line between root table groups (default)
 
 Configuration priority
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject-fmt/docs/configuration.rst
+++ b/pyproject-fmt/docs/configuration.rst
@@ -30,6 +30,12 @@ The ``tool.pyproject-fmt`` table is used when present in the ``pyproject.toml`` 
     # Table format: "short" collapses sub-tables to dotted keys, "long" expands to [table.subtable] headers
     table_format = "short"
 
+    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line between sub-tables)
+    sub_table_spacing = ""
+
+    # Extra newlines between root table groups (e.g. "\n" for one blank line, "\n\n" for two)
+    separate_root_table = "\n"
+
     # List of tables to force expand regardless of table_format setting
     expand_tables = []
 

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -11,10 +11,10 @@ that all ``pyproject.toml`` files follow.
 - Smaller diffs when committing changes
 - Easier code reviews since formatting is never a question
 
-While a few key options exist (``column_width``, ``indent``, ``table_format``), the tool does not expose dozens of
-toggles. You get what the maintainers have chosen to be the right balance of readability, consistency, and usability.
-The ``column_width`` setting controls when arrays are split into multiple lines and when string values are wrapped using
-line continuations.
+While a few key options exist (``column_width``, ``indent``, ``table_format``, ``sub_table_spacing``,
+``separate_root_table``), the tool does not expose dozens of toggles. You get what the maintainers have chosen to be the
+right balance of readability, consistency, and usability. The ``column_width`` setting controls when arrays are split
+into multiple lines and when string values are wrapped using line continuations.
 
 General Formatting
 ------------------
@@ -168,6 +168,22 @@ Sub-tables can be formatted in two styles controlled by ``table_format``:
     [project.urls]
     homepage = "https://example.com"
     repository = "https://github.com/example/project"
+
+**Table spacing:**
+
+By default, different table groups (e.g. ``[project]`` and ``[tool.ruff]``) are separated by a blank line, while
+sub-tables within the same group (e.g. ``[tool.ruff]`` and ``[tool.ruff.lint]``) are kept compact with no blank line
+between them. You can control this with ``sub_table_spacing`` and ``separate_root_table``. Each option takes a string of
+``\n`` characters where each ``\n`` adds one blank line. For example, setting ``sub_table_spacing = "\n"`` adds a blank
+line between sub-tables:
+
+.. code-block:: toml
+
+    [tool.ruff]
+    line-length = 120
+
+    [tool.ruff.lint]
+    select = ["E", "W"]
 
 See :doc:`configuration` for how to control this behavior.
 

--- a/pyproject-fmt/rust/src/global.rs
+++ b/pyproject-fmt/rust/src/global.rs
@@ -1,7 +1,7 @@
 use common::table::Tables;
 use tombi_syntax::SyntaxNode;
 
-pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables) {
+pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables, root_table_spacing: &str, sub_table_spacing: &str) {
     tables.reorder(
         root_ast,
         &[
@@ -73,5 +73,7 @@ pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables) {
             "tool.vendoring",
         ],
         &["tool"], // Treat tool.* as distinct base keys (e.g., tool.black != tool.ruff)
+        root_table_spacing,
+        sub_table_spacing,
     );
 }

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -30,6 +30,8 @@ pub struct Settings {
     min_supported_python: (u8, u8),
     generate_python_version_classifiers: bool,
     table_format: String,
+    sub_table_spacing: String,
+    separate_root_table: String,
     expand_tables: Vec<String>,
     collapse_tables: Vec<String>,
     skip_wrap_for_keys: Vec<String>,
@@ -39,7 +41,7 @@ pub struct Settings {
 impl Settings {
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (*, column_width, indent, keep_full_version, max_supported_python, min_supported_python, generate_python_version_classifiers, table_format, expand_tables, collapse_tables, skip_wrap_for_keys))]
+    #[pyo3(signature = (*, column_width, indent, keep_full_version, max_supported_python, min_supported_python, generate_python_version_classifiers, table_format, sub_table_spacing, separate_root_table, expand_tables, collapse_tables, skip_wrap_for_keys))]
     fn new(
         column_width: usize,
         indent: usize,
@@ -48,6 +50,8 @@ impl Settings {
         min_supported_python: (u8, u8),
         generate_python_version_classifiers: bool,
         table_format: String,
+        sub_table_spacing: String,
+        separate_root_table: String,
         expand_tables: Vec<String>,
         collapse_tables: Vec<String>,
         skip_wrap_for_keys: Vec<String>,
@@ -60,6 +64,8 @@ impl Settings {
             min_supported_python,
             generate_python_version_classifiers,
             table_format,
+            sub_table_spacing,
+            separate_root_table,
             expand_tables,
             collapse_tables,
             skip_wrap_for_keys,
@@ -158,7 +164,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     uv::fix(&mut tables);
     pixi::fix(&mut tables);
     coverage::fix(&mut tables);
-    reorder_tables(&root_ast, &tables);
+    reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);
     common::string::wrap_all_long_strings(&root_ast, opt.column_width, &indent_string, &opt.skip_wrap_for_keys);
 
@@ -174,9 +180,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     common::array::align_array_comments(&formatted_ast);
     let formatted = formatted_ast.to_string();
 
-    // Remove blank lines that tombi adds between tables in the same group
-    // but only when table_format is "long" (compact formatting)
-    let result = if opt.table_format == "long" {
+    let result = if opt.table_format == "long" && opt.sub_table_spacing.is_empty() {
         remove_blank_lines_between_same_group_tables(&formatted, &prefix_refs)
     } else {
         formatted

--- a/pyproject-fmt/rust/src/tests/global_tests.rs
+++ b/pyproject-fmt/rust/src/tests/global_tests.rs
@@ -8,7 +8,7 @@ use crate::global::reorder_tables;
 fn reorder_table_helper(start: &str) -> String {
     let root_ast = parse(start);
     let tables = Tables::from_ast(&root_ast);
-    reorder_tables(&root_ast, &tables);
+    reorder_tables(&root_ast, &tables, "\n", "");
     ensure_all_arrays_multiline(&root_ast, 120);
     format_syntax(root_ast, 120)
 }

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -13,6 +13,8 @@ fn default_settings() -> Settings {
         min_supported_python: (3, 9),
         generate_python_version_classifiers: false,
         table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
         expand_tables: vec![],
         collapse_tables: vec![],
         skip_wrap_for_keys: vec![],
@@ -119,16 +121,8 @@ fn test_expand_tables_with_project() {
         urls.homepage = "https://example.com"
         "#};
     let settings = Settings {
-        column_width: 120,
-        indent: 2,
-        keep_full_version: false,
-        max_supported_python: (3, 9),
-        min_supported_python: (3, 9),
-        generate_python_version_classifiers: false,
-        table_format: String::from("short"),
         expand_tables: vec![String::from("project")],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"
@@ -154,16 +148,8 @@ fn test_collapse_project_authors() {
         email = "john@example.com"
         "#};
     let settings = Settings {
-        column_width: 120,
-        indent: 2,
-        keep_full_version: false,
-        max_supported_python: (3, 9),
-        min_supported_python: (3, 9),
-        generate_python_version_classifiers: false,
-        table_format: String::from("long"),
-        expand_tables: vec![],
         collapse_tables: vec![String::from("project.authors")],
-        skip_wrap_for_keys: vec![],
+        ..long_format_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"
@@ -184,16 +170,8 @@ fn test_collapse_project_maintainers() {
         email = "jane@example.com"
         "#};
     let settings = Settings {
-        column_width: 120,
-        indent: 2,
-        keep_full_version: false,
-        max_supported_python: (3, 9),
-        min_supported_python: (3, 9),
-        generate_python_version_classifiers: false,
-        table_format: String::from("long"),
-        expand_tables: vec![],
         collapse_tables: vec![String::from("project.maintainers")],
-        skip_wrap_for_keys: vec![],
+        ..long_format_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"
@@ -404,11 +382,8 @@ fn test_issue_146_expand_specific_subtable() {
         keep_full_version: true,
         max_supported_python: (3, 14),
         min_supported_python: (3, 14),
-        generate_python_version_classifiers: false,
-        table_format: String::from("short"),
         expand_tables: vec![String::from("project.optional-dependencies")],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert!(
@@ -430,16 +405,11 @@ fn test_css_specificity_more_specific_wins() {
         dev = ["pytest"]
         "#};
     let settings = Settings {
-        column_width: 120,
         indent: 4,
         keep_full_version: true,
-        max_supported_python: (3, 9),
-        min_supported_python: (3, 9),
-        generate_python_version_classifiers: false,
-        table_format: String::from("long"),
         expand_tables: vec![String::from("project.urls")],
         collapse_tables: vec![String::from("project")],
-        skip_wrap_for_keys: vec![],
+        ..long_format_settings()
     };
     let got = format_toml(start, &settings);
     assert!(
@@ -540,11 +510,8 @@ fn test_issue_146_deeply_nested_ruff_table() {
         keep_full_version: true,
         max_supported_python: (3, 14),
         min_supported_python: (3, 14),
-        generate_python_version_classifiers: false,
-        table_format: String::from("short"),
         expand_tables: vec![String::from("tool.ruff.lint.flake8-tidy-imports.banned-api")],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert!(
@@ -641,16 +608,8 @@ fn test_extract_table_names_from_array_tables() {
         name = "John"
         "#};
     let settings = Settings {
-        column_width: 120,
-        indent: 2,
-        keep_full_version: false,
-        max_supported_python: (3, 9),
-        min_supported_python: (3, 9),
-        generate_python_version_classifiers: false,
-        table_format: String::from("long"),
         expand_tables: vec![String::from("project.authors")],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
+        ..long_format_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"
@@ -734,6 +693,8 @@ fn test_settings_new() {
         (3, 9),
         true,
         String::from("short"),
+        String::from("\n"),
+        String::from("\n\n"),
         vec![String::from("project.urls")],
         vec![String::from("project.authors")],
         vec![],
@@ -745,6 +706,8 @@ fn test_settings_new() {
     assert_eq!(settings.min_supported_python, (3, 9));
     assert!(settings.generate_python_version_classifiers);
     assert_eq!(settings.table_format, "short");
+    assert_eq!(settings.sub_table_spacing, "\n");
+    assert_eq!(settings.separate_root_table, "\n\n");
     assert_eq!(settings.expand_tables, vec!["project.urls"]);
     assert_eq!(settings.collapse_tables, vec!["project.authors"]);
 }
@@ -761,6 +724,8 @@ fn test_table_format_config_from_settings() {
         (3, 9),
         false,
         String::from("short"),
+        String::new(),
+        String::from("\n"),
         vec![String::from("tool.ruff")],
         vec![String::from("project")],
         vec![],
@@ -792,18 +757,7 @@ fn test_idempotent_formatting() {
         name = "test"
         description = "This is a long description string that needs to exceed the default column width of one hundred and twenty characters to trigger wrapping."
     "#};
-    let settings = Settings {
-        column_width: 120,
-        indent: 2,
-        keep_full_version: false,
-        max_supported_python: (3, 9),
-        min_supported_python: (3, 9),
-        generate_python_version_classifiers: false,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-    };
+    let settings = default_settings();
     let first = format_toml(start, &settings);
     let second = format_toml(&first, &settings);
     let third = format_toml(&second, &settings);
@@ -870,6 +824,64 @@ fn test_table_key_without_prefix_match_long_format() {
     key = "value"
     [custom.nested]
     other = "data"
+    "#);
+}
+
+#[test]
+fn test_sub_table_spacing_blank_line() {
+    let start = indoc! {r#"
+        [tool.ruff]
+        line-length = 120
+
+        [tool.ruff.lint]
+        select = ["E", "W"]
+
+        [tool.mypy]
+        strict = true
+        "#};
+    let settings = Settings {
+        sub_table_spacing: String::from("\n"),
+        ..long_format_settings()
+    };
+    let got = format_toml(start, &settings);
+    assert_snapshot!(got, @r#"
+    [tool.ruff]
+    line-length = 120
+
+    [tool.ruff.lint]
+    select = [ "E", "W" ]
+
+    [tool.mypy]
+    strict = true
+    "#);
+}
+
+#[test]
+fn test_sub_table_spacing_with_project_tables() {
+    let start = indoc! {r#"
+        [project]
+        name = "test"
+
+        [project.urls]
+        homepage = "https://example.com"
+
+        [project.optional-dependencies]
+        dev = ["pytest"]
+        "#};
+    let settings = Settings {
+        sub_table_spacing: String::from("\n"),
+        ..long_format_settings()
+    };
+    let got = format_toml(start, &settings);
+    assert_snapshot!(got, @r#"
+    [project]
+    name = "test"
+
+    [project.optional-dependencies]
+    dev = [ "pytest" ]
+
+    [project.urls]
+    homepage = "https://example.com"
     "#);
 }
 

--- a/pyproject-fmt/src/pyproject_fmt/__main__.py
+++ b/pyproject-fmt/src/pyproject_fmt/__main__.py
@@ -19,6 +19,8 @@ class PyProjectFmtNamespace(FmtNamespace):
     max_supported_python: tuple[int, int]
     generate_python_version_classifiers: bool
     table_format: str
+    sub_table_spacing: str
+    separate_root_table: str
     expand_tables: list[str]
     collapse_tables: list[str]
     skip_wrap_for_keys: list[str]
@@ -57,6 +59,9 @@ class PyProjectFormatter(TOMLFormatter[PyProjectFmtNamespace]):
             help=msg,
         )
 
+        def _spacing_argument(value: str) -> str:
+            return value.replace("\\n", "\n") if isinstance(value, str) else value
+
         def _version_argument(got: str) -> tuple[int, int]:
             parts = got.split(".")
             if len(parts) != 2:  # noqa: PLR2004
@@ -86,6 +91,18 @@ class PyProjectFormatter(TOMLFormatter[PyProjectFmtNamespace]):
             choices=["short", "long"],
             default="short",
             help="table format: 'short' collapses sub-tables, 'long' expands to [table.subtable]",
+        )
+        parser.add_argument(
+            "--sub-table-spacing",
+            type=_spacing_argument,
+            default="",
+            help=r"extra newlines between sub-tables in the same group (e.g. '' for compact, '\n' for one blank line)",
+        )
+        parser.add_argument(
+            "--separate-root-table",
+            type=_spacing_argument,
+            default="\n",
+            help=r"extra newlines between root table groups (e.g. '\n' for one blank line, '\n\n' for two)",
         )
         parser.add_argument(
             "--expand-tables",
@@ -127,6 +144,8 @@ class PyProjectFormatter(TOMLFormatter[PyProjectFmtNamespace]):
             min_supported_python=(3, 10),  # default for when the user didn't specify via requires-python
             generate_python_version_classifiers=opt.generate_python_version_classifiers,
             table_format=opt.table_format,
+            sub_table_spacing=opt.sub_table_spacing,
+            separate_root_table=opt.separate_root_table,
             expand_tables=opt.expand_tables,
             collapse_tables=opt.collapse_tables,
             skip_wrap_for_keys=opt.skip_wrap_for_keys,

--- a/pyproject-fmt/src/pyproject_fmt/_lib.pyi
+++ b/pyproject-fmt/src/pyproject_fmt/_lib.pyi
@@ -9,6 +9,8 @@ class Settings:
         min_supported_python: tuple[int, int],
         generate_python_version_classifiers: bool,
         table_format: str,
+        sub_table_spacing: str,
+        separate_root_table: str,
         expand_tables: list[str],
         collapse_tables: list[str],
         skip_wrap_for_keys: list[str],
@@ -25,6 +27,10 @@ class Settings:
     def min_supported_python(self) -> tuple[int, int]: ...
     @property
     def table_format(self) -> str: ...
+    @property
+    def sub_table_spacing(self) -> str: ...
+    @property
+    def separate_root_table(self) -> str: ...
     @property
     def expand_tables(self) -> list[str]: ...
     @property

--- a/pyproject-fmt/tests/test_lib.py
+++ b/pyproject-fmt/tests/test_lib.py
@@ -97,9 +97,44 @@ def test_format_toml(start: str, expected: str) -> None:
         max_supported_python=(3, 8),
         generate_python_version_classifiers=True,
         table_format="short",
+        sub_table_spacing="",
+        separate_root_table="\n",
         expand_tables=[],
         collapse_tables=[],
         skip_wrap_for_keys=[],
     )
     res = format_toml(dedent(start), settings)
     assert res == dedent(expected)
+
+
+@pytest.mark.parametrize(
+    ("sub_table_spacing", "has_blank_line"),
+    [
+        pytest.param("\n", True, id="blank_line"),
+        pytest.param("", False, id="compact"),
+    ],
+)
+def test_sub_table_spacing(sub_table_spacing: str, *, has_blank_line: bool) -> None:
+    start = dedent("""\
+        [tool.ruff]
+        line-length = 120
+
+        [tool.ruff.lint]
+        select = ["E"]
+    """)
+    settings = Settings(
+        column_width=120,
+        indent=2,
+        keep_full_version=False,
+        min_supported_python=(3, 9),
+        max_supported_python=(3, 9),
+        generate_python_version_classifiers=False,
+        table_format="long",
+        sub_table_spacing=sub_table_spacing,
+        separate_root_table="\n",
+        expand_tables=[],
+        collapse_tables=[],
+        skip_wrap_for_keys=[],
+    )
+    res = format_toml(start, settings)
+    assert ("\n\n[tool.ruff.lint]" in res) == has_blank_line

--- a/tox-toml-fmt/docs/configuration.rst
+++ b/tox-toml-fmt/docs/configuration.rst
@@ -49,6 +49,8 @@ The shared config file uses the same keys as the ``[tox-toml-fmt]`` table, but w
 
     column_width = 120
     indent = 2
+    sub_table_spacing = ""
+    separate_root_table = "\n"
     pin_envs = ["fix", "type"]
 
 When both a shared config file and a ``[tox-toml-fmt]`` table exist, per-file settings from the ``[tox-toml-fmt]``

--- a/tox-toml-fmt/docs/configuration.rst
+++ b/tox-toml-fmt/docs/configuration.rst
@@ -17,6 +17,12 @@ The ``[tox-toml-fmt]`` table is used when present in the ``tox.toml`` file:
     # Number of spaces for indentation
     indent = 2
 
+    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line between sub-tables)
+    sub_table_spacing = ""
+
+    # Extra newlines between root table groups (e.g. "\n" for one blank line, "\n\n" for two)
+    separate_root_table = "\n"
+
     # Environments pinned to the start of env_list
     pin_envs = ["fix", "type"]
 

--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -11,8 +11,9 @@ that all ``tox.toml`` files follow.
 - Smaller diffs when committing changes
 - Easier code reviews since formatting is never a question
 
-While a few key options exist (``column_width``, ``indent``, ``table_format``), the tool does not expose dozens of
-toggles. You get what the maintainers have chosen to be the right balance of readability, consistency, and usability.
+While a few key options exist (``column_width``, ``indent``, ``table_format``, ``sub_table_spacing``,
+``separate_root_table``), the tool does not expose dozens of toggles. You get what the maintainers have chosen to be the
+right balance of readability, consistency, and usability.
 
 General Formatting
 ------------------
@@ -137,6 +138,14 @@ Sub-tables can be formatted in two styles controlled by ``table_format``:
     value = 1
 
 Individual tables can override the default using ``expand_tables`` and ``collapse_tables``.
+
+**Table spacing:**
+
+By default, different table groups are separated by a blank line, while sub-tables within the same group are kept
+compact. You can control this with ``sub_table_spacing`` and ``separate_root_table``. Each option takes a string of
+``\n`` characters where each ``\n`` adds one blank line. For example, setting ``sub_table_spacing = "\n"`` adds a blank
+line between sub-tables within the same environment.
+
 See :doc:`configuration` for how to control this behavior.
 
 **Environment tables are always expanded:**

--- a/tox-toml-fmt/rust/src/global.rs
+++ b/tox-toml-fmt/rust/src/global.rs
@@ -400,7 +400,7 @@ fn get_env_list_order(tables: &Tables) -> Vec<String> {
     env_order
 }
 
-pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables) {
+pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables, root_table_spacing: &str, sub_table_spacing: &str) {
     let env_list_order = get_env_list_order(tables);
     let mut order: Vec<&str> = vec!["", "env_run_base", "env_pkg_base", "env_base"];
 
@@ -419,7 +419,13 @@ pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables) {
 
     order.push("env");
 
-    tables.reorder(root_ast, &order, &["env_base", "env"]);
+    tables.reorder(
+        root_ast,
+        &order,
+        &["env_base", "env"],
+        root_table_spacing,
+        sub_table_spacing,
+    );
 }
 
 const TOX_INLINE_TABLE_SCHEMAS: &[InlineTableSchema] = &[

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -22,6 +22,8 @@ pub struct Settings {
     column_width: usize,
     indent: usize,
     table_format: String,
+    sub_table_spacing: String,
+    separate_root_table: String,
     expand_tables: Vec<String>,
     collapse_tables: Vec<String>,
     skip_wrap_for_keys: Vec<String>,
@@ -32,11 +34,13 @@ pub struct Settings {
 impl Settings {
     #[new]
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature = (*, column_width, indent, table_format, expand_tables, collapse_tables, skip_wrap_for_keys, pin_envs))]
+    #[pyo3(signature = (*, column_width, indent, table_format, sub_table_spacing, separate_root_table, expand_tables, collapse_tables, skip_wrap_for_keys, pin_envs))]
     fn new(
         column_width: usize,
         indent: usize,
         table_format: String,
+        sub_table_spacing: String,
+        separate_root_table: String,
         expand_tables: Vec<String>,
         collapse_tables: Vec<String>,
         skip_wrap_for_keys: Vec<String>,
@@ -46,6 +50,8 @@ impl Settings {
             column_width,
             indent,
             table_format,
+            sub_table_spacing,
+            separate_root_table,
             expand_tables,
             collapse_tables,
             skip_wrap_for_keys,
@@ -159,7 +165,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     sort_env_list(&tables, &opt.pin_envs);
     normalize_strings(&tables);
     reorder_inline_tables(&root_ast);
-    reorder_tables(&root_ast, &tables);
+    reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);
 
     let indent_string = " ".repeat(opt.indent);

--- a/tox-toml-fmt/rust/src/tests/doc_examples_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/doc_examples_tests.rs
@@ -9,6 +9,8 @@ fn format_toml_helper(start: &str, indent: usize) -> String {
         column_width: 120,
         indent,
         table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
         expand_tables: vec![],
         collapse_tables: vec![],
         skip_wrap_for_keys: vec![],

--- a/tox-toml-fmt/rust/src/tests/global_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/global_tests.rs
@@ -8,7 +8,7 @@ use common::table::Tables;
 fn reorder_table_helper(start: &str) -> String {
     let root_ast = parse(start);
     let tables = Tables::from_ast(&root_ast);
-    reorder_tables(&root_ast, &tables);
+    reorder_tables(&root_ast, &tables, "\n", "");
     let result = format_syntax(root_ast, 120);
     assert_valid_toml(&result);
     result
@@ -120,7 +120,7 @@ fn test_reorder_no_root_table() {
     "#};
     let root_ast = parse(start);
     let tables = Tables::from_ast(&root_ast);
-    reorder_tables(&root_ast, &tables);
+    reorder_tables(&root_ast, &tables, "\n", "");
     let got = format_syntax(root_ast, 120);
     assert_snapshot!(got, @r#"
     [env.test]
@@ -138,7 +138,7 @@ fn test_reorder_root_table_no_env_list_key() {
     "#};
     let root_ast = parse(start);
     let tables = Tables::from_ast(&root_ast);
-    reorder_tables(&root_ast, &tables);
+    reorder_tables(&root_ast, &tables, "\n", "");
     let got = format_syntax(root_ast, 120);
     assert_snapshot!(got, @r#"
     requires = [ "tox>=4" ]
@@ -161,7 +161,7 @@ fn test_reorder_env_list_not_array() {
     "#};
     let root_ast = parse(start);
     let tables = Tables::from_ast(&root_ast);
-    reorder_tables(&root_ast, &tables);
+    reorder_tables(&root_ast, &tables, "\n", "");
     let got = format_syntax(root_ast, 120);
     assert_snapshot!(got, @r#"
     env_list = "test"
@@ -187,7 +187,7 @@ fn test_reorder_empty_env_list() {
     "#};
     let root_ast = parse(start);
     let tables = Tables::from_ast(&root_ast);
-    reorder_tables(&root_ast, &tables);
+    reorder_tables(&root_ast, &tables, "\n", "");
     let got = format_syntax(root_ast, 120);
     assert_snapshot!(got, @r#"
     env_list = []
@@ -213,7 +213,7 @@ fn test_reorder_env_list_with_env_run_base() {
     "#};
     let root_ast = parse(start);
     let tables = Tables::from_ast(&root_ast);
-    reorder_tables(&root_ast, &tables);
+    reorder_tables(&root_ast, &tables, "\n", "");
     let got = format_syntax(root_ast, 120);
     assert_snapshot!(got, @r#"
     env_list = [ "test" ]

--- a/tox-toml-fmt/rust/src/tests/main_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/main_tests.rs
@@ -4,15 +4,24 @@ use insta::assert_snapshot;
 use super::assert_valid_toml;
 use crate::{format_toml, Settings};
 
-fn format_toml_helper(start: &str, indent: usize) -> String {
-    let settings = Settings {
+fn default_settings() -> Settings {
+    Settings {
         column_width: 80,
-        indent,
+        indent: 2,
         table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
         expand_tables: vec![],
         collapse_tables: vec![],
         skip_wrap_for_keys: vec![],
         pin_envs: vec![],
+    }
+}
+
+fn format_toml_helper(start: &str, indent: usize) -> String {
+    let settings = Settings {
+        indent,
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_valid_toml(&got);
@@ -69,11 +78,7 @@ fn test_column_width() {
     let settings = Settings {
         column_width: 50,
         indent: 4,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"
@@ -105,11 +110,7 @@ fn test_string_quote_normalization() {
     let settings = Settings {
         column_width: 80,
         indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"
@@ -130,11 +131,7 @@ fn test_string_with_double_quote_preserved() {
     let settings = Settings {
         column_width: 80,
         indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"
@@ -216,11 +213,7 @@ fn test_format_with_multiline_arrays() {
     let settings = Settings {
         column_width: 40,
         indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"
@@ -307,11 +300,7 @@ fn test_idempotent_formatting() {
     let settings = Settings {
         column_width: 80,
         indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let first = format_toml(start, &settings);
     let second = format_toml(&first, &settings);
@@ -328,11 +317,7 @@ fn test_format_with_large_indent() {
     let settings = Settings {
         column_width: 80,
         indent: 4,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"env_list = [ "test" ]"#);
@@ -346,11 +331,7 @@ fn test_format_with_narrow_column_width() {
     let settings = Settings {
         column_width: 30,
         indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_snapshot!(got, @r#"
@@ -364,14 +345,34 @@ fn test_format_with_narrow_column_width() {
 
 #[test]
 fn test_settings_new() {
-    let settings = Settings::new(120, 4, String::from("short"), vec![], vec![], vec![], vec![]);
+    let settings = Settings::new(
+        120,
+        4,
+        String::from("short"),
+        String::new(),
+        String::from("\n"),
+        vec![],
+        vec![],
+        vec![],
+        vec![],
+    );
     assert_eq!(settings.column_width, 120);
     assert_eq!(settings.indent, 4);
 }
 
 #[test]
 fn test_settings_default_values() {
-    let settings = Settings::new(80, 2, String::from("short"), vec![], vec![], vec![], vec![]);
+    let settings = Settings::new(
+        80,
+        2,
+        String::from("short"),
+        String::new(),
+        String::from("\n"),
+        vec![],
+        vec![],
+        vec![],
+        vec![],
+    );
     assert_eq!(settings.column_width, 80);
     assert_eq!(settings.indent, 2);
 }
@@ -382,6 +383,8 @@ fn test_settings_field_access() {
         column_width: 100,
         indent: 3,
         table_format: String::from("long"),
+        sub_table_spacing: String::from("\n"),
+        separate_root_table: String::from("\n\n"),
         expand_tables: vec![String::from("env.test")],
         collapse_tables: vec![String::from("env.lint")],
         skip_wrap_for_keys: vec![String::from("*.commands")],
@@ -390,6 +393,8 @@ fn test_settings_field_access() {
     assert_eq!(settings.column_width, 100);
     assert_eq!(settings.indent, 3);
     assert_eq!(settings.table_format, "long");
+    assert_eq!(settings.sub_table_spacing, "\n");
+    assert_eq!(settings.separate_root_table, "\n\n");
     assert_eq!(settings.expand_tables, vec!["env.test"]);
     assert_eq!(settings.collapse_tables, vec!["env.lint"]);
     assert_eq!(settings.skip_wrap_for_keys, vec!["*.commands"]);
@@ -399,7 +404,17 @@ fn test_settings_field_access() {
 #[test]
 fn test_format_toml_with_direct_settings() {
     let content = "env_list = ['a', 'b']";
-    let settings = Settings::new(80, 2, String::from("short"), vec![], vec![], vec![], vec![]);
+    let settings = Settings::new(
+        80,
+        2,
+        String::from("short"),
+        String::new(),
+        String::from("\n"),
+        vec![],
+        vec![],
+        vec![],
+        vec![],
+    );
     let result = format_toml(content, &settings);
     assert!(result.contains("env_list"));
     assert!(result.contains("\"a\""));
@@ -455,11 +470,7 @@ fn test_array_multiline_expansion() {
     let settings = Settings {
         column_width: 40,
         indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_valid_toml(&got);
@@ -486,11 +497,7 @@ fn test_long_string_wrapping() {
     let settings = Settings {
         column_width: 40,
         indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_valid_toml(&got);
@@ -518,11 +525,7 @@ fn test_table_collapse_short_format() {
     let settings = Settings {
         column_width: 80,
         indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_valid_toml(&got);
@@ -546,10 +549,7 @@ fn test_table_expand_long_format() {
         column_width: 80,
         indent: 2,
         table_format: String::from("long"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_valid_toml(&got);
@@ -573,12 +573,8 @@ fn test_skip_wrap_for_keys() {
         "#};
     let settings = Settings {
         column_width: 40,
-        indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
         skip_wrap_for_keys: vec![String::from("*.skip_me")],
-        pin_envs: vec![],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_valid_toml(&got);
@@ -797,13 +793,8 @@ fn test_sort_env_list_with_pin() {
         env_list = ["lint", "3.12", "type", "3.13", "fix"]
         "#};
     let settings = Settings {
-        column_width: 80,
-        indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
         pin_envs: vec![String::from("fix"), String::from("type")],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_valid_toml(&got);
@@ -918,13 +909,8 @@ fn test_sort_env_list_compound_pin() {
         env_list = ["py312-django", "lint", "py311-django", "fix"]
         "#};
     let settings = Settings {
-        column_width: 80,
-        indent: 2,
-        table_format: String::from("short"),
-        expand_tables: vec![],
-        collapse_tables: vec![],
-        skip_wrap_for_keys: vec![],
         pin_envs: vec![String::from("fix")],
+        ..default_settings()
     };
     let got = format_toml(start, &settings);
     assert_valid_toml(&got);
@@ -1577,5 +1563,39 @@ fn test_constraints_editable_and_paths_not_normalized() {
     assert_snapshot!(got, @r#"
     [env.test]
     constraints = [ "-e ./local_pkg[dev]", "{tox_root}/constraints.txt" ]
+    "#);
+}
+
+#[test]
+fn test_sub_table_spacing_blank_line() {
+    let start = indoc! {r#"
+        env_list = ["test", "lint"]
+
+        [env_run_base]
+        description = "base"
+
+        [env.test]
+        description = "test"
+
+        [env.lint]
+        description = "lint"
+        "#};
+    let settings = Settings {
+        sub_table_spacing: String::from("\n"),
+        ..default_settings()
+    };
+    let got = format_toml(start, &settings);
+    assert_valid_toml(&got);
+    assert_snapshot!(got, @r#"
+    env_list = [ "lint", "test" ]
+
+    [env_run_base]
+    description = "base"
+
+    [env.lint]
+    description = "lint"
+
+    [env.test]
+    description = "test"
     "#);
 }

--- a/tox-toml-fmt/src/tox_toml_fmt/__main__.py
+++ b/tox-toml-fmt/src/tox_toml_fmt/__main__.py
@@ -17,6 +17,8 @@ class PyProjectFmtNamespace(FmtNamespace):
     """Formatting arguments."""
 
     table_format: str
+    sub_table_spacing: str
+    separate_root_table: str
     expand_tables: list[str]
     collapse_tables: list[str]
     skip_wrap_for_keys: list[str]
@@ -47,6 +49,9 @@ class ToxTOMLFormatter(TOMLFormatter[PyProjectFmtNamespace]):
         :param parser: parser to operate on.
         """
 
+        def _spacing_argument(value: str) -> str:
+            return value.replace("\\n", "\n") if isinstance(value, str) else value
+
         def _list_argument(value: str | list[str]) -> list[str]:
             if isinstance(value, list):
                 return value
@@ -57,6 +62,18 @@ class ToxTOMLFormatter(TOMLFormatter[PyProjectFmtNamespace]):
             choices=["short", "long"],
             default="short",
             help="table format: 'short' collapses sub-tables, 'long' expands to [table.subtable]",
+        )
+        parser.add_argument(
+            "--sub-table-spacing",
+            type=_spacing_argument,
+            default="",
+            help=r"extra newlines between sub-tables in the same group (e.g. '' for compact, '\n' for one blank line)",
+        )
+        parser.add_argument(
+            "--separate-root-table",
+            type=_spacing_argument,
+            default="\n",
+            help=r"extra newlines between root table groups (e.g. '\n' for one blank line, '\n\n' for two)",
         )
         parser.add_argument(
             "--expand-tables",
@@ -101,6 +118,8 @@ class ToxTOMLFormatter(TOMLFormatter[PyProjectFmtNamespace]):
             column_width=opt.column_width,
             indent=opt.indent,
             table_format=opt.table_format,
+            sub_table_spacing=opt.sub_table_spacing,
+            separate_root_table=opt.separate_root_table,
             expand_tables=opt.expand_tables,
             collapse_tables=opt.collapse_tables,
             skip_wrap_for_keys=opt.skip_wrap_for_keys,

--- a/tox-toml-fmt/src/tox_toml_fmt/_lib.pyi
+++ b/tox-toml-fmt/src/tox_toml_fmt/_lib.pyi
@@ -5,6 +5,8 @@ class Settings:
         column_width: int,
         indent: int,
         table_format: str,
+        sub_table_spacing: str,
+        separate_root_table: str,
         expand_tables: list[str],
         collapse_tables: list[str],
         skip_wrap_for_keys: list[str],
@@ -16,6 +18,10 @@ class Settings:
     def indent(self) -> int: ...
     @property
     def table_format(self) -> str: ...
+    @property
+    def sub_table_spacing(self) -> str: ...
+    @property
+    def separate_root_table(self) -> str: ...
     @property
     def expand_tables(self) -> list[str]: ...
     @property

--- a/tox-toml-fmt/tests/test_lib.py
+++ b/tox-toml-fmt/tests/test_lib.py
@@ -46,6 +46,8 @@ def test_format_toml(start: str, expected: str) -> None:
         column_width=120,
         indent=4,
         table_format="short",
+        sub_table_spacing="",
+        separate_root_table="\n",
         expand_tables=[],
         collapse_tables=[],
         skip_wrap_for_keys=[],
@@ -53,3 +55,29 @@ def test_format_toml(start: str, expected: str) -> None:
     )
     res = format_toml(dedent(start), settings)
     assert res == dedent(expected)
+
+
+def test_sub_table_spacing_separates_sub_tables() -> None:
+    start = dedent("""\
+        env_list = ["test"]
+
+        [env_run_base]
+        description = "base"
+
+        [env.test]
+        description = "test"
+    """)
+    settings = Settings(
+        column_width=120,
+        indent=4,
+        table_format="short",
+        sub_table_spacing="\n",
+        separate_root_table="\n",
+        expand_tables=[],
+        collapse_tables=[],
+        skip_wrap_for_keys=[],
+        pin_envs=[],
+    )
+    res = format_toml(start, settings)
+    assert "\n\n[env_run_base]" in res
+    assert "\n\n[env.test]" in res


### PR DESCRIPTION
The formatter collapses blank lines between tables within the same group (e.g., between `[tool.ruff]` and `[tool.ruff.lint]`), and there was no way to override this. For configs with many sub-tables this produces dense, hard-to-scan output. 📖

Two new CLI options give users control over the spacing between tables. `--sub-table-spacing` (default `""`) controls the extra newlines inserted between sub-tables in the same group, while `--separate-root-table` (default `"\n"`) controls spacing between different root table groups. The value is a string of `\n` characters where each `\n` adds one blank line. The defaults preserve existing behavior, so this is fully backwards compatible.

The spacing logic in `Tables::reorder()` is now parameterized instead of hardcoded, and both `pyproject-fmt` and `tox-toml-fmt` expose the options through their CLI and TOML config.

Closes #316