### PR TITLE
👷 ci(common): add version bump and release flow

### DIFF
--- a/.github/workflows/toml_fmt_common_build.yaml
+++ b/.github/workflows/toml_fmt_common_build.yaml
@@ -74,8 +74,7 @@ jobs:
       - name: 📝 Generate changelog
         id: v
         run: |
-          VERSION=$(uv run --with tomli python -c "import tomli; print(tomli.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version=$(uv version)" >> "$GITHUB_OUTPUT"
           uv run ../tasks/changelog.py toml-fmt-common "${{ github.event.number }}" "${{ github.event.pull_request.base.sha }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -105,7 +104,7 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
           persist-credentials: true
       - name: 📦 Setup uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0 # zizmor: ignore[cache-poisoning]
       - name: 🔖 Bump version
         working-directory: toml-fmt-common
         run: uv version --bump "$RELEASE_TYPE"

--- a/.github/workflows/toml_fmt_common_build.yaml
+++ b/.github/workflows/toml_fmt_common_build.yaml
@@ -3,11 +3,11 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        description: "🚀 Release?"
+        description: "🚀 Release (semver bump)?"
         required: true
         default: "no"
         type: choice
-        options: ["no", "yes"]
+        options: ["no", patch, minor, major]
   push:
     branches: ["main"]
   pull_request:
@@ -15,7 +15,7 @@ on:
     - cron: "0 8 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ github.event.inputs.release && github.event.inputs.release != 'no' && '-release' || '' }}
   cancel-in-progress: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null }}
 
 permissions:
@@ -45,9 +45,13 @@ jobs:
               - '.github/workflows/toml_fmt_common_build.yaml'
 
   build:
+    name: 🔨 build
     needs: changes
     if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      changelog: ${{ steps.v.outputs.changelog }}
     defaults:
       run:
         working-directory: toml-fmt-common
@@ -62,6 +66,19 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
+      - name: 🔖 Bump version
+        if: github.event.inputs.release != 'no' && github.event.inputs.release != null
+        run: uv version --bump "$RELEASE_TYPE"
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release }}
+      - name: 📝 Generate changelog
+        id: v
+        run: |
+          VERSION=$(uv run --with tomli python -c "import tomli; print(tomli.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          uv run ../tasks/changelog.py toml-fmt-common "${{ github.event.number }}" "${{ github.event.pull_request.base.sha }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🔨 Build package
         run: uv build --python 3.14 --python-preference only-managed --sdist --wheel . --out-dir dist
       - name: 📤 Store the distribution packages
@@ -71,15 +88,36 @@ jobs:
           path: toml-fmt-common/dist/*
 
   release:
+    name: 🚀 release
     needs: [build]
     runs-on: ubuntu-latest
     environment:
       name: release
-      url: https://pypi.org/project/toml-fmt-common/${{ github.ref_name }}
+      url: https://pypi.org/project/toml-fmt-common/${{ needs.build.outputs.version }}
     permissions:
       id-token: write
-    if: github.event.inputs.release == 'yes' && github.ref == 'refs/heads/main'
+      contents: write
+    if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
     steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: true
+      - name: 📦 Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: 🔖 Bump version
+        working-directory: toml-fmt-common
+        run: uv version --bump "$RELEASE_TYPE"
+        env:
+          RELEASE_TYPE: ${{ github.event.inputs.release }}
+      - name: 💾 Commit release
+        run: |
+          git config --global user.name 'Bernat Gabor'
+          git config --global user.email 'gaborbernat@users.noreply.github.com'
+          git commit -am "Release toml-fmt-common ${VERSION} [skip ci]"
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
       - name: 📥 Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -89,6 +127,19 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           attestations: true
+      - name: 📢 Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          VERSION: ${{ needs.build.outputs.version }}
+          CHANGELOG: ${{ needs.build.outputs.changelog }}
+        run: |
+          git pull --rebase origin main
+          git tag "toml-fmt-common/${VERSION}"
+          git push
+          git push --tags
+          gh release create "toml-fmt-common/${VERSION}" \
+              --title="toml-fmt-common/${VERSION}" --verify-tag \
+            --notes "${CHANGELOG}"
 
   all-pass:
     name: ✅ toml-fmt-common-build

--- a/tasks/changelog.py
+++ b/tasks/changelog.py
@@ -92,7 +92,7 @@ def run() -> None:
 
 def parse_cli() -> Options:
     parser = ArgumentParser()
-    parser.add_argument("project", choices=["pyproject-fmt", "tox-toml-fmt"])
+    parser.add_argument("project", choices=["pyproject-fmt", "tox-toml-fmt", "toml-fmt-common"])
     parser.add_argument("pr", type=lambda s: int(s) if s else None, nargs="?", default=None)
     parser.add_argument("base", type=str, nargs="?", default="")
     parser.add_argument("--regenerate", action="store_true", help="Regenerate entire changelog from all releases")
@@ -102,8 +102,11 @@ def parse_cli() -> Options:
 
 
 def get_version(base: Path) -> str:
-    with (base / "Cargo.toml").open("rb") as cargo_toml_file_handler:
-        return load(cargo_toml_file_handler)["package"]["version"]
+    if (cargo := base / "Cargo.toml").exists():
+        with cargo.open("rb") as fh:
+            return load(fh)["package"]["version"]
+    with (base / "pyproject.toml").open("rb") as fh:
+        return load(fh)["project"]["version"]
 
 
 def regenerate_changelog(
@@ -204,7 +207,8 @@ def entries(
 
 def commit_affects_project(commit: object, project: str) -> bool:
     changed_files = list(commit.stats.files.keys())
-    return any(file_path.startswith(("common/", f"{project}/")) for file_path in changed_files)
+    prefixes = ("common/", f"{project}/")
+    return any(file_path.startswith(prefixes) for file_path in changed_files)
 
 
 if __name__ == "__main__":

--- a/toml-fmt-common/CHANGELOG.md
+++ b/toml-fmt-common/CHANGELOG.md
@@ -1,0 +1,46 @@
+<a id="1.3.2"></a>
+
+## 1.3.2 - 2026-03-20
+
+- 🐛 fix(toml-fmt-common): include license file in sdist by [@gaborbernat](https://github.com/gaborbernat) in
+  [#313](https://github.com/tox-dev/toml-fmt/pull/313)
+
+<a id="1.3.1"></a>
+
+## 1.3.1 - 2026-03-02
+
+- 🐛 fix(toml-fmt-common): skip write check in --check and --stdout modes by
+  [@gaborbernat](https://github.com/gaborbernat) in [#278](https://github.com/tox-dev/toml-fmt/pull/278)
+
+<a id="1.3.0"></a>
+
+## 1.3.0 - 2026-03-01
+
+- 🐛 fix(common): include tests in sdist by [@gaborbernat](https://github.com/gaborbernat) in
+  [#261](https://github.com/tox-dev/toml-fmt/pull/261)
+
+<a id="1.2.0"></a>
+
+## 1.2.0 - 2026-01-30
+
+- ✨ feat(common): add shared config file support by [@gaborbernat](https://github.com/gaborbernat) in
+  [#258](https://github.com/tox-dev/toml-fmt/pull/258)
+
+<a id="1.1.0"></a>
+
+## 1.1.0 - 2025-10-08
+
+- ✨ feat(workspace): internalize toml-fmt-common as workspace member by
+  [@gaborbernat](https://github.com/gaborbernat) in [#170](https://github.com/tox-dev/toml-fmt/pull/170)
+
+<a id="1.0.1"></a>
+
+## 1.0.1 - 2024-10-20
+
+- Initial release (patch fix)
+
+<a id="1.0.0"></a>
+
+## 1.0.0 - 2024-10-20
+
+- Initial release

--- a/toml-fmt-common/CHANGELOG.md
+++ b/toml-fmt-common/CHANGELOG.md
@@ -30,8 +30,8 @@
 
 ## 1.1.0 - 2025-10-08
 
-- ✨ feat(workspace): internalize toml-fmt-common as workspace member by
-  [@gaborbernat](https://github.com/gaborbernat) in [#170](https://github.com/tox-dev/toml-fmt/pull/170)
+- ✨ feat(workspace): internalize toml-fmt-common as workspace member by [@gaborbernat](https://github.com/gaborbernat)
+  in [#170](https://github.com/tox-dev/toml-fmt/pull/170)
 
 <a id="1.0.1"></a>
 

--- a/toml-fmt-common/src/toml_fmt_common/__init__.py
+++ b/toml-fmt-common/src/toml_fmt_common/__init__.py
@@ -295,7 +295,7 @@ def build_cli(of: TOMLFormatter[T]) -> tuple[ArgumentParser, Mapping[str, Callab
         "--skip-wrap-for-keys",
         type=list_argument,
         default=[],
-        help="comma-separated list of key patterns to skip string wrapping (supports wildcards like *.parse)",
+        help="comma-separated list of key patterns to skip string wrapping (supports wildcards like '*.parse')",
     )
     of.add_format_flags(format_group)
     type_conversion: Mapping[str, Callable[[Any], Any]] = {


### PR DESCRIPTION
The toml-fmt-common release workflow published without bumping the version, causing `400 File already exists` on PyPI. Unlike pyproject-fmt and tox-toml-fmt which use `_build.yaml` with `cargo set-version`, toml-fmt-common had no version bump step at all.

Added semver bump via `uv version --bump`, changelog generation, commit, tag, and GitHub release creation to match the pattern used by the formatter packages. The release input changed from `yes/no` to `no/patch/minor/major` so the caller picks the bump type.