### PR TITLE
🐛 fix(ci): skip uv workspace sync when bumping common version

### DIFF
--- a/.github/workflows/toml_fmt_common_build.yaml
+++ b/.github/workflows/toml_fmt_common_build.yaml
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: 🔖 Bump version
         if: github.event.inputs.release != 'no' && github.event.inputs.release != null
-        run: uv version --bump "$RELEASE_TYPE"
+        run: uv version --frozen --no-sync --bump "$RELEASE_TYPE"
         env:
           RELEASE_TYPE: ${{ github.event.inputs.release }}
       - name: 📝 Generate changelog
@@ -107,7 +107,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0 # zizmor: ignore[cache-poisoning]
       - name: 🔖 Bump version
         working-directory: toml-fmt-common
-        run: uv version --bump "$RELEASE_TYPE"
+        run: uv version --frozen --no-sync --bump "$RELEASE_TYPE"
         env:
           RELEASE_TYPE: ${{ github.event.inputs.release }}
       - name: 💾 Commit release


### PR DESCRIPTION
Dispatching the new `📦 toml-fmt-common` release workflow failed during `uv version --bump` because uv detected the surrounding workspace, set up the root virtual environment, and tried to install every workspace member editably. 🦀 That dragged in `pyproject-fmt`, whose maturin backend calls `prepare_metadata_for_build_editable` and requires a working Rust toolchain — the rustup component download timed out and the bump step exited 1 before the wheel build ever ran (see https://github.com/tox-dev/toml-fmt/actions/runs/26555175353).

The bump only needs to rewrite `toml-fmt-common/pyproject.toml`; the re-lock and venv sync are wasted work for a pure-Python member of a mixed workspace. Adding `--frozen --no-sync` to both bump invocations keeps uv from touching `uv.lock` or the workspace venv, matching the way `cargo set-version` operates for the Rust packages elsewhere in the repo.