### PR TITLE
🐛 fix(ci): drop incompatible --frozen flag from uv version bump

### DIFF
--- a/.github/workflows/toml_fmt_common_build.yaml
+++ b/.github/workflows/toml_fmt_common_build.yaml
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: 🔖 Bump version
         if: github.event.inputs.release != 'no' && github.event.inputs.release != null
-        run: uv version --frozen --no-sync --bump "$RELEASE_TYPE"
+        run: uv version --no-sync --bump "$RELEASE_TYPE"
         env:
           RELEASE_TYPE: ${{ github.event.inputs.release }}
       - name: 📝 Generate changelog
@@ -107,7 +107,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0 # zizmor: ignore[cache-poisoning]
       - name: 🔖 Bump version
         working-directory: toml-fmt-common
-        run: uv version --frozen --no-sync --bump "$RELEASE_TYPE"
+        run: uv version --no-sync --bump "$RELEASE_TYPE"
         env:
           RELEASE_TYPE: ${{ github.event.inputs.release }}
       - name: 💾 Commit release


### PR DESCRIPTION
The previous fix in #322 paired `--frozen` with `--no-sync`, but uv treats those flags as mutually exclusive and exits with `the argument --no-sync cannot be used with --frozen` (see https://github.com/tox-dev/toml-fmt/actions/runs/26555785161). 🐛

Keeping `--no-sync` alone is sufficient: uv still re-locks the workspace so `uv.lock` stays consistent with the bumped `toml-fmt-common` version, but it skips the venv install step that was invoking maturin's `prepare_metadata_for_build_editable` on `pyproject-fmt` and pulling in the Rust toolchain.