### PR TITLE
✨ feat(pyproject-fmt): add [tool.poetry] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -599,6 +599,91 @@ source (``version``, ``version_scheme``, ``version_provider``, ``version_files``
 changelog → hooks (``pre_bump_hooks``, ``post_bump_hooks``) → ``customize``.
 
 **Sorted arrays:** ``version_files``, ``allowed_prefixes``, ``extras``, ``extra_files``.
+``[tool.poetry]``
+~~~~~~~~~~~~~~~~~
+
+Covers both Poetry 1.x (legacy metadata under ``[tool.poetry]``) and Poetry 2.x (metadata moved to standard
+``[project]``; Poetry-specific keys still under ``[tool.poetry]``).
+
+**Top-level key ordering:**
+
+1. Identity: ``name`` → ``version`` → ``description`` → ``package-mode``
+2. License & authorship: ``license`` → ``authors`` → ``maintainers``
+3. Documentation: ``readme`` → ``homepage`` → ``repository`` → ``documentation``
+4. Discovery: ``keywords`` → ``classifiers``
+5. Packaging contents: ``packages`` → ``include`` → ``exclude`` → ``build``
+6. Dependencies (sub-tables): ``dependencies`` → ``dev-dependencies`` → ``group`` → ``extras``
+7. Entry points / distribution: ``scripts`` → ``plugins`` → ``urls`` → ``source``
+8. Poetry runtime constraints: ``requires-poetry`` → ``requires-plugins`` → ``build-constraints``
+
+**Sub-table key ordering:**
+
+``[tool.poetry.dependencies]`` / ``[tool.poetry.dev-dependencies]`` / per-group dependencies
+    ``python`` first (interpreter constraint), all other package names alphabetized.
+
+``[tool.poetry.group.<name>]``
+    ``optional`` → ``include-groups`` → ``dependencies``.
+
+``[tool.poetry.extras]``, ``[tool.poetry.scripts]``, ``[tool.poetry.urls]``, ``[tool.poetry.plugins.*]``, ``[tool.poetry.requires-plugins]``, ``[tool.poetry.build-constraints]``
+    Keys alphabetized.
+
+``[tool.poetry.build]``
+    ``script`` → ``generate-setup-file``.
+
+``[[tool.poetry.source]]``
+    Each entry's keys ordered ``name`` → ``url`` → ``priority`` → ``links`` → ``indexed``, with the deprecated
+    ``default`` and ``secondary`` keys placed last. Array order itself is preserved (priority ordering is
+    semantically significant).
+
+**Sorted arrays:**
+
+- ``keywords``, ``classifiers``: deduplicated (case-insensitive) and sorted alphabetically.
+- ``exclude``: sorted alphabetically.
+- ``[tool.poetry.extras]`` values (each ``extras.<name>``): sorted alphabetically.
+- ``[tool.poetry.group.<name>.include-groups]``: sorted alphabetically.
+- Per-dependency ``extras`` arrays (in ``dependencies``, ``dev-dependencies``, per-group dependencies,
+  ``requires-plugins``, ``build-constraints``): sorted alphabetically.
+
+Arrays whose order carries semantic meaning are preserved as written: ``authors``, ``maintainers``, ``packages``,
+``include``, ``readme`` (when an array), multi-constraint dependency arrays, and ``[[tool.poetry.source]]`` entries.
+
+**Inline-table key ordering:**
+
+When a Poetry-specific inline table is detected (via discriminator keys unique to Poetry's schema), its keys are
+reordered:
+
+- Sources (``{ priority = ... }``, ``{ secondary = ... }``, ``{ links = ... }``, ``{ indexed = ... }``):
+  ``name`` → ``url`` → ``priority`` → ``links`` → ``indexed`` → ``default`` → ``secondary``.
+- Git dependencies (``{ git = ... }``):
+  ``git`` → ``branch`` → ``tag`` → ``rev`` → ``subdirectory`` → ``python`` → ``platform`` → ``markers`` →
+  ``allow-prereleases`` → ``allows-prereleases`` → ``optional`` → ``extras`` → ``develop``.
+- Path dependencies (``{ path = ... }``):
+  ``path`` → ``develop`` → ``subdirectory`` → ``python`` → ``platform`` → ``markers`` → ``optional`` → ``extras``.
+- File dependencies (``{ file = ... }``):
+  ``file`` → ``subdirectory`` → ``python`` → ``platform`` → ``markers`` → ``optional`` → ``extras``.
+
+Inline tables that don't match any Poetry-specific schema (for example ``[[project.authors]]`` inline form
+``{ name = "...", email = "..." }``) are left untouched.
+
+.. code-block:: toml
+
+    # Before
+    [[tool.poetry.source]]
+    priority = "primary"
+    url = "https://pypi.example.com/simple"
+    name = "private"
+
+    [tool.poetry.dependencies]
+    zebra = "^1.0"
+    python = "^3.11"
+    foo = { branch = "main", git = "https://github.com/example/foo" }
+
+    # After
+    [tool.poetry]
+    dependencies.python = "^3.11"
+    dependencies.foo = { git = "https://github.com/example/foo", branch = "main" }
+    dependencies.zebra = "^1.0"
+    source = [ { name = "private", url = "https://pypi.example.com/simple", priority = "primary" } ]
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -17,6 +17,7 @@ mod commitizen;
 mod coverage;
 mod global;
 mod pixi;
+mod poetry;
 mod ruff;
 #[cfg(test)]
 mod tests;
@@ -165,8 +166,13 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     uv::fix(&mut tables);
     pixi::fix(&mut tables);
     commitizen::fix(&mut tables);
+    poetry::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
+    // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed
+    // to inline arrays of inline tables (e.g. [[tool.poetry.source]] → source = [{...}])
+    // are visible in root_ast as INLINE_TABLE descendants.
+    poetry::reorder_inline_tables(&root_ast);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);
     common::string::wrap_all_long_strings(&root_ast, opt.column_width, &indent_string, &opt.skip_wrap_for_keys);
 

--- a/pyproject-fmt/rust/src/poetry.rs
+++ b/pyproject-fmt/rust/src/poetry.rs
@@ -1,0 +1,386 @@
+use common::array::{dedupe_strings, sort_strings};
+use common::table::{for_entries, reorder_inline_table_keys, reorder_table_keys, InlineTableSchema, Tables};
+use lexical_sort::natural_lexical_cmp;
+use tombi_syntax::SyntaxNode;
+
+// Sub-table prefixes are appended dynamically because some (group.<name>.*) need
+// per-instance entries to control inner key order.
+const TOP_LEVEL_ORDER: &[&str] = &[
+    "",
+    // Identity
+    "name",
+    "version",
+    "description",
+    "package-mode",
+    // License & authorship
+    "license",
+    "authors",
+    "maintainers",
+    // Documentation
+    "readme",
+    "homepage",
+    "repository",
+    "documentation",
+    // Discovery
+    "keywords",
+    "classifiers",
+    // Packaging contents
+    "packages",
+    "include",
+    "exclude",
+];
+
+// Order for [[tool.poetry.source]] entries (AoT, kept as separate tables). Deprecated
+// keys (default, secondary) are placed last so we don't promote them above current keys.
+const SOURCE_KEY_ORDER: &[&str] = &[
+    "",
+    "name",
+    "url",
+    "priority",
+    "links",
+    "indexed",
+    "default",
+    "secondary",
+];
+
+// Order for [tool.poetry.build] when expanded as its own table.
+const BUILD_KEY_ORDER: &[&str] = &["", "script", "generate-setup-file"];
+
+// Order for [tool.poetry.group.<name>] when expanded.
+const GROUP_KEY_ORDER: &[&str] = &["", "optional", "include-groups", "dependencies"];
+
+// Within [tool.poetry.dependencies] (and the per-group equivalents), "python" is the
+// interpreter constraint and conventionally comes first; everything else is sorted.
+const DEPENDENCIES_KEY_ORDER: &[&str] = &["", "python"];
+
+pub fn fix(tables: &mut Tables) {
+    fix_root(tables);
+    fix_expanded_sub_tables(tables);
+    fix_source(tables);
+}
+
+// Inline-table key order for things that get collapsed to inline form. Discriminators are
+// chosen to be Poetry-specific (priority/links/indexed/secondary only appear on sources;
+// git/path/file only on dependencies), to avoid colliding with inline tables in other
+// `[tool.*]` sections that happen to share generic keys like `name` or `url`.
+const SOURCE_INLINE_KEYS: &[&str] = &["name", "url", "priority", "links", "indexed", "default", "secondary"];
+
+const GIT_DEP_INLINE_KEYS: &[&str] = &[
+    "git",
+    "branch",
+    "tag",
+    "rev",
+    "subdirectory",
+    "python",
+    "platform",
+    "markers",
+    "allow-prereleases",
+    "allows-prereleases",
+    "optional",
+    "extras",
+    "develop",
+];
+
+const PATH_DEP_INLINE_KEYS: &[&str] = &[
+    "path",
+    "develop",
+    "subdirectory",
+    "python",
+    "platform",
+    "markers",
+    "optional",
+    "extras",
+];
+
+const FILE_DEP_INLINE_KEYS: &[&str] = &[
+    "file",
+    "subdirectory",
+    "python",
+    "platform",
+    "markers",
+    "optional",
+    "extras",
+];
+
+pub const INLINE_TABLE_SCHEMAS: &[InlineTableSchema] = &[
+    InlineTableSchema {
+        discriminator: "priority",
+        key_order: SOURCE_INLINE_KEYS,
+    },
+    InlineTableSchema {
+        discriminator: "links",
+        key_order: SOURCE_INLINE_KEYS,
+    },
+    InlineTableSchema {
+        discriminator: "indexed",
+        key_order: SOURCE_INLINE_KEYS,
+    },
+    InlineTableSchema {
+        discriminator: "secondary",
+        key_order: SOURCE_INLINE_KEYS,
+    },
+    InlineTableSchema {
+        discriminator: "git",
+        key_order: GIT_DEP_INLINE_KEYS,
+    },
+    InlineTableSchema {
+        discriminator: "path",
+        key_order: PATH_DEP_INLINE_KEYS,
+    },
+    InlineTableSchema {
+        discriminator: "file",
+        key_order: FILE_DEP_INLINE_KEYS,
+    },
+];
+
+pub fn reorder_inline_tables(root_ast: &SyntaxNode) {
+    reorder_inline_table_keys(root_ast, INLINE_TABLE_SCHEMAS);
+}
+
+fn fix_root(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.poetry") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+
+    for_entries(table, &mut |key, entry| {
+        let k = key.as_str();
+        match k {
+            "keywords" | "classifiers" => {
+                dedupe_strings(entry, |s| s.to_lowercase());
+                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            }
+            "exclude" => {
+                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            }
+            _ => {
+                if is_sort_value_array(k) {
+                    sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| {
+                        natural_lexical_cmp(lhs, rhs)
+                    });
+                }
+            }
+        }
+    });
+
+    let order = build_root_key_order(table);
+    let order_refs: Vec<&str> = order.iter().map(String::as_str).collect();
+    reorder_table_keys(table, &order_refs);
+}
+
+/// Extras lists, include-groups, and per-dependency extras are name sets, so they sort.
+fn is_sort_value_array(key: &str) -> bool {
+    if let Some(rest) = key.strip_prefix("extras.") {
+        return !rest.contains('.');
+    }
+    if let Some(rest) = key.strip_prefix("group.") {
+        if let Some((_group, tail)) = split_first_segment(rest) {
+            if tail == "include-groups" {
+                return true;
+            }
+            if let Some(inner) = tail.strip_prefix("dependencies.") {
+                return is_dep_extras(inner);
+            }
+        }
+        return false;
+    }
+    for dep_table in [
+        "dependencies",
+        "dev-dependencies",
+        "requires-plugins",
+        "build-constraints",
+    ] {
+        if let Some(rest) = key.strip_prefix(dep_table) {
+            if let Some(inner) = rest.strip_prefix('.') {
+                return is_dep_extras(inner);
+            }
+        }
+    }
+    false
+}
+
+/// Matches `<pkg>.extras` where `<pkg>` has no further dots.
+fn is_dep_extras(s: &str) -> bool {
+    let Some((_pkg, tail)) = split_first_segment(s) else {
+        return false;
+    };
+    tail == "extras"
+}
+
+fn split_first_segment(s: &str) -> Option<(&str, &str)> {
+    s.find('.').map(|i| (&s[..i], &s[i + 1..]))
+}
+
+fn build_root_key_order(table: &[tombi_syntax::SyntaxElement]) -> Vec<String> {
+    let mut order: Vec<String> = TOP_LEVEL_ORDER.iter().map(|s| (*s).to_string()).collect();
+
+    // `build` may appear as a scalar (build = "build.py"), an inline-table key, or via
+    // dotted sub-keys (build.script, build.generate-setup-file). The "build" prefix
+    // entry catches all those.
+    order.push(String::from("build.script"));
+    order.push(String::from("build.generate-setup-file"));
+    order.push(String::from("build"));
+
+    // Dependencies: python first, then alphabetized.
+    order.push(String::from("dependencies.python"));
+    order.push(String::from("dependencies"));
+    order.push(String::from("dev-dependencies"));
+
+    // Per-group ordering: optional, include-groups, dependencies (python first inside).
+    let group_names = collect_dotted_segment(table, "group");
+    for group in &group_names {
+        order.push(format!("group.{group}.optional"));
+        order.push(format!("group.{group}.include-groups"));
+        order.push(format!("group.{group}.dependencies.python"));
+        order.push(format!("group.{group}.dependencies"));
+    }
+    order.push(String::from("group"));
+
+    order.push(String::from("extras"));
+    order.push(String::from("scripts"));
+    order.push(String::from("plugins"));
+    order.push(String::from("urls"));
+    order.push(String::from("source"));
+    order.push(String::from("requires-poetry"));
+    order.push(String::from("requires-plugins"));
+    order.push(String::from("build-constraints"));
+
+    order
+}
+
+/// Distinct first segments following a dotted prefix (prefix "group" → ["dev", "test"]).
+fn collect_dotted_segment(table: &[tombi_syntax::SyntaxElement], prefix: &str) -> Vec<String> {
+    use tombi_syntax::SyntaxKind::{KEYS, KEY_VALUE};
+    let prefix_dot = format!("{prefix}.");
+    let mut names: Vec<String> = Vec::new();
+    for element in table.iter().filter(|e| e.kind() == KEY_VALUE) {
+        let Some(kv) = element.as_node() else { continue };
+        let Some(keys_node) = kv.children().find(|c| c.kind() == KEYS) else {
+            continue;
+        };
+        let raw = keys_node.text().to_string().trim().to_string();
+        if let Some(rest) = raw.strip_prefix(&prefix_dot) {
+            let next = rest.split('.').next().unwrap_or(rest);
+            let name = unquote(next).to_string();
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+    }
+    names
+}
+
+fn unquote(s: &str) -> &str {
+    s.strip_prefix('"')
+        .and_then(|x| x.strip_suffix('"'))
+        .or_else(|| s.strip_prefix('\'').and_then(|x| x.strip_suffix('\'')))
+        .unwrap_or(s)
+}
+
+fn fix_expanded_sub_tables(tables: &mut Tables) {
+    // When the user runs with `table_format = "long"` (no collapse), sub-tables remain
+    // as their own headers. Apply per-table normalization in that case.
+    fix_expanded_dependencies(tables, "tool.poetry.dependencies");
+    fix_expanded_dependencies(tables, "tool.poetry.dev-dependencies");
+    fix_expanded_dependencies(tables, "tool.poetry.requires-plugins");
+    fix_expanded_dependencies(tables, "tool.poetry.build-constraints");
+    fix_expanded_extras(tables);
+    fix_expanded_alpha(tables, "tool.poetry.scripts");
+    fix_expanded_alpha(tables, "tool.poetry.urls");
+    fix_expanded_plugins(tables);
+    fix_expanded_groups(tables);
+    fix_expanded_build(tables);
+}
+
+fn fix_expanded_dependencies(tables: &mut Tables, table_key: &str) {
+    let Some(elements) = tables.get(table_key) else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    // Entries here are package names (`fastapi`, `requests`, …) mapped to either a version
+    // string or an inline-table dep spec. The InlineTableSchema set handles the inline-
+    // table key order; here we just promote `python` to the top via DEPENDENCIES_KEY_ORDER.
+    reorder_table_keys(table, DEPENDENCIES_KEY_ORDER);
+}
+
+fn fix_expanded_extras(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.poetry.extras") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |_key, entry| {
+        sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+    });
+    reorder_table_keys(table, &[""]);
+}
+
+fn fix_expanded_alpha(tables: &mut Tables, table_key: &str) {
+    let Some(elements) = tables.get(table_key) else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    reorder_table_keys(table, &[""]);
+}
+
+fn fix_expanded_plugins(tables: &mut Tables) {
+    if let Some(elements) = tables.get("tool.poetry.plugins") {
+        let table = &mut elements.first().unwrap().borrow_mut();
+        reorder_table_keys(table, &[""]);
+    }
+    for group in collect_header_segments(tables, "tool.poetry.plugins.") {
+        let key = format!("tool.poetry.plugins.{group}");
+        if let Some(elements) = tables.get(&key) {
+            let table = &mut elements.first().unwrap().borrow_mut();
+            reorder_table_keys(table, &[""]);
+        }
+    }
+}
+
+fn fix_expanded_groups(tables: &mut Tables) {
+    for group in collect_header_segments(tables, "tool.poetry.group.") {
+        let key = format!("tool.poetry.group.{group}");
+        if let Some(elements) = tables.get(&key) {
+            let table = &mut elements.first().unwrap().borrow_mut();
+            for_entries(table, &mut |key, entry| {
+                if key.as_str() == "include-groups" {
+                    sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| {
+                        natural_lexical_cmp(lhs, rhs)
+                    });
+                }
+            });
+            reorder_table_keys(table, GROUP_KEY_ORDER);
+        }
+        fix_expanded_dependencies(tables, &format!("tool.poetry.group.{group}.dependencies"));
+    }
+}
+
+fn fix_expanded_build(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.poetry.build") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    reorder_table_keys(table, BUILD_KEY_ORDER);
+}
+
+fn fix_source(tables: &mut Tables) {
+    let Some(source_entries) = tables.get("tool.poetry.source") else {
+        return;
+    };
+    for entry_ref in source_entries {
+        let table = &mut entry_ref.borrow_mut();
+        reorder_table_keys(table, SOURCE_KEY_ORDER);
+    }
+}
+
+/// Immediate next segment of every header under `prefix` (group. headers → ["dev", "test"]).
+fn collect_header_segments(tables: &Tables, prefix: &str) -> Vec<String> {
+    let mut names: Vec<String> = tables
+        .header_to_pos
+        .keys()
+        .filter_map(|h| h.strip_prefix(prefix))
+        .map(|rest| rest.split('.').next().unwrap_or(rest).to_string())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod dependency_groups_tests;
 mod global_tests;
 mod main_tests;
 mod pixi_tests;
+mod poetry_tests;
 mod project_tests;
 mod ruff_tests;
 mod uv_tests;

--- a/pyproject-fmt/rust/src/tests/poetry_tests.rs
+++ b/pyproject-fmt/rust/src/tests/poetry_tests.rs
@@ -1,0 +1,773 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::poetry::{fix, reorder_inline_tables};
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.poetry"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    // Inline-table reordering operates AST-wide, so run it after the root children have
+    // been restored from the table_set (mirrors what format_toml does in main.rs).
+    reorder_inline_tables(&root_ast);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_poetry_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn evaluate_full(start: &str) -> String {
+    let result = format_toml(start, &default_poetry_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+fn long_format_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_poetry_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_format_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_poetry_top_level_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry]
+    requires-poetry = ">=2.0"
+    classifiers = ["License :: OSI Approved :: MIT License"]
+    keywords = ["toml", "format"]
+    homepage = "https://example.com"
+    documentation = "https://docs.example.com"
+    repository = "https://github.com/example/example"
+    readme = "README.md"
+    license = "MIT"
+    description = "Example package"
+    version = "1.0.0"
+    name = "example"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    name = "example"
+    version = "1.0.0"
+    description = "Example package"
+    license = "MIT"
+    readme = "README.md"
+    homepage = "https://example.com"
+    repository = "https://github.com/example/example"
+    documentation = "https://docs.example.com"
+    keywords = [ "format", "toml" ]
+    classifiers = [ "License :: OSI Approved :: MIT License" ]
+    requires-poetry = ">=2.0"
+    "#);
+}
+
+#[test]
+fn test_poetry_keywords_sorted_and_deduped() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry]
+    keywords = ["zebra", "alpha", "Alpha", "mike", "alpha"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    keywords = [ "alpha", "mike", "zebra" ]
+    "#);
+}
+
+#[test]
+fn test_poetry_classifiers_sorted_and_deduped() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry]
+    classifiers = [
+      "Programming Language :: Python :: 3.12",
+      "License :: OSI Approved :: MIT License",
+      "Programming Language :: Python :: 3.11",
+      "Programming Language :: Python :: 3.11",
+    ]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    classifiers = [
+      "License :: OSI Approved :: MIT License",
+      "Programming Language :: Python :: 3.11",
+      "Programming Language :: Python :: 3.12"
+    ]
+    "#);
+}
+
+#[test]
+fn test_poetry_exclude_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry]
+    exclude = ["tests/*", "docs/*", "build/*"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    exclude = [ "build/*", "docs/*", "tests/*" ]
+    "#);
+}
+
+#[test]
+fn test_poetry_authors_preserve_order() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry]
+    authors = ["Bob <bob@example.com>", "Alice <alice@example.com>"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    authors = [ "Bob <bob@example.com>", "Alice <alice@example.com>" ]
+    "#);
+}
+
+#[test]
+fn test_poetry_dependencies_python_first_then_alpha() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.dependencies]
+    zebra = "^1.0"
+    alpha = "^2.0"
+    python = "^3.11"
+    mike = "^1.5"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    dependencies.python = "^3.11"
+    dependencies.alpha = "^2.0"
+    dependencies.mike = "^1.5"
+    dependencies.zebra = "^1.0"
+    "#);
+}
+
+#[test]
+fn test_poetry_dev_dependencies_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.dev-dependencies]
+    pytest = "^8.0"
+    black = "^25.0"
+    mypy = "^1.10"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    dev-dependencies.black = "^25.0"
+    dev-dependencies.mypy = "^1.10"
+    dev-dependencies.pytest = "^8.0"
+    "#);
+}
+
+#[test]
+fn test_poetry_extras_keys_and_values_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.extras]
+    web = ["uvicorn", "starlette", "fastapi"]
+    cli = ["typer", "rich"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    extras.cli = [ "rich", "typer" ]
+    extras.web = [ "fastapi", "starlette", "uvicorn" ]
+    "#);
+}
+
+#[test]
+fn test_poetry_group_key_order_and_include_groups_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.group.dev]
+    include-groups = ["lint", "test", "docs"]
+    optional = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    group.dev.optional = true
+    group.dev.include-groups = [ "docs", "lint", "test" ]
+    "#);
+}
+
+#[test]
+fn test_poetry_group_dependencies_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.group.test.dependencies]
+    pytest-cov = "^5.0"
+    pytest = "^8.0"
+    coverage = "^7.5"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    group.test.dependencies.coverage = "^7.5"
+    group.test.dependencies.pytest = "^8.0"
+    group.test.dependencies.pytest-cov = "^5.0"
+    "#);
+}
+
+#[test]
+fn test_poetry_scripts_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.scripts]
+    my-cli = "my_pkg.cli:main"
+    my-server = "my_pkg.server:run"
+    my-admin = "my_pkg.admin:run"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    scripts.my-admin = "my_pkg.admin:run"
+    scripts.my-cli = "my_pkg.cli:main"
+    scripts.my-server = "my_pkg.server:run"
+    "#);
+}
+
+#[test]
+fn test_poetry_urls_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.urls]
+    "Source" = "https://github.com/example/example"
+    "Bug Tracker" = "https://github.com/example/example/issues"
+    "Funding" = "https://github.com/sponsors/example"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    urls."Bug Tracker" = "https://github.com/example/example/issues"
+    urls."Funding" = "https://github.com/sponsors/example"
+    urls."Source" = "https://github.com/example/example"
+    "#);
+}
+
+#[test]
+fn test_poetry_plugins_inner_keys_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.plugins."poetry.application.plugin"]
+    zebra = "z_pkg:Z"
+    alpha = "a_pkg:A"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    plugins."poetry.application.plugin".alpha = "a_pkg:A"
+    plugins."poetry.application.plugin".zebra = "z_pkg:Z"
+    "#);
+}
+
+#[test]
+fn test_poetry_source_aot_key_order_preserves_array_order() {
+    let start = indoc::indoc! {r#"
+    [[tool.poetry.source]]
+    priority = "primary"
+    url = "https://pypi.example.com/simple"
+    name = "private"
+
+    [[tool.poetry.source]]
+    url = "https://pypi.org/simple"
+    name = "PyPI"
+    priority = "supplemental"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    source = [
+      { name = "private", url = "https://pypi.example.com/simple", priority = "primary" },
+      { name = "PyPI", url = "https://pypi.org/simple", priority = "supplemental" },
+    ]
+    "#);
+}
+
+#[test]
+fn test_poetry_source_deprecated_keys_kept_last() {
+    let start = indoc::indoc! {r#"
+    [[tool.poetry.source]]
+    secondary = true
+    name = "legacy"
+    url = "https://legacy.example.com/simple"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    source = [ { name = "legacy", url = "https://legacy.example.com/simple", secondary = true } ]
+    "#);
+}
+
+#[test]
+fn test_poetry_build_inline_table_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.build]
+    generate-setup-file = true
+    script = "build.py"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    build.script = "build.py"
+    build.generate-setup-file = true
+    "#);
+}
+
+#[test]
+fn test_poetry_requires_plugins_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.requires-plugins]
+    poetry-plugin-export = ">=1.8"
+    poetry-dynamic-versioning = ">=1.0"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    requires-plugins.poetry-dynamic-versioning = ">=1.0"
+    requires-plugins.poetry-plugin-export = ">=1.8"
+    "#);
+}
+
+#[test]
+fn test_poetry_build_constraints_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.build-constraints]
+    zeta = { setuptools = "<78" }
+    alpha = { setuptools = "<79" }
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    build-constraints.alpha = { setuptools = "<79" }
+    build-constraints.zeta = { setuptools = "<78" }
+    "#);
+}
+
+#[test]
+fn test_poetry_dependency_subtable_extras_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.dependencies.fastapi]
+    extras = ["all", "standard"]
+    version = "^0.110"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    dependencies.fastapi.extras = [ "all", "standard" ]
+    dependencies.fastapi.version = "^0.110"
+    "#);
+}
+
+#[test]
+fn test_poetry_dependency_subtable_unsorted_extras_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.dependencies.fastapi]
+    version = "^0.110"
+    extras = ["standard", "all"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    dependencies.fastapi.extras = [ "all", "standard" ]
+    dependencies.fastapi.version = "^0.110"
+    "#);
+}
+
+#[test]
+fn test_poetry_comments_preserved_around_reordered_keys() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry]
+    # Package name
+    name = "example"
+    # License
+    license = "MIT"
+    # Version
+    version = "1.0.0"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    # Package name
+    name = "example"
+    # Version
+    version = "1.0.0"
+    # License
+    license = "MIT"
+    "#);
+}
+
+#[test]
+fn test_poetry_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry]
+    name = "example"
+    version = "1.0.0"
+    description = "Example package"
+    license = "MIT"
+    authors = [ "Alice <alice@example.com>" ]
+    keywords = [ "format", "toml" ]
+    classifiers = [ "License :: OSI Approved :: MIT License" ]
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_poetry_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "example"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "example"
+    "#);
+}
+
+#[test]
+fn test_poetry_source_inline_key_order() {
+    let start = indoc::indoc! {r#"
+    [[tool.poetry.source]]
+    priority = "primary"
+    url = "https://pypi.example.com/simple"
+    name = "private"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    source = [ { name = "private", url = "https://pypi.example.com/simple", priority = "primary" } ]
+    "#);
+}
+
+#[test]
+fn test_poetry_source_deprecated_secondary_inline_key_order() {
+    let start = indoc::indoc! {r#"
+    [[tool.poetry.source]]
+    secondary = true
+    name = "legacy"
+    url = "https://legacy.example.com/simple"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    source = [ { name = "legacy", url = "https://legacy.example.com/simple", secondary = true } ]
+    "#);
+}
+
+#[test]
+fn test_poetry_git_dependency_inline_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.dependencies]
+    foo = { branch = "main", git = "https://github.com/example/foo", subdirectory = "pkg" }
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    dependencies.foo = { git = "https://github.com/example/foo", branch = "main", subdirectory = "pkg" }
+    "#);
+}
+
+#[test]
+fn test_poetry_path_dependency_inline_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.dependencies]
+    foo = { develop = true, path = "../foo", extras = ["all"] }
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    dependencies.foo = { path = "../foo", develop = true, extras = [ "all" ] }
+    "#);
+}
+
+#[test]
+fn test_poetry_file_dependency_inline_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.dependencies]
+    foo = { python = ">=3.10", file = "./wheels/foo-1.0.whl" }
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.poetry]
+    dependencies.foo = { file = "./wheels/foo-1.0.whl", python = ">=3.10" }
+    "#);
+}
+
+#[test]
+fn test_poetry_full_pipeline_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry]
+    name = "example"
+    version = "1.0.0"
+    description = "Example package"
+    keywords = ["b", "a"]
+
+    [[tool.poetry.source]]
+    priority = "primary"
+    name = "private"
+    url = "https://pypi.example.com/simple"
+
+    [tool.poetry.dependencies]
+    requests = { extras = ["socks"], version = "^2.31" }
+    foo = { git = "https://github.com/example/foo", branch = "main" }
+    "#};
+    let once = evaluate_full(start);
+    let twice = evaluate_full(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_poetry_does_not_reorder_unrelated_inline_tables() {
+    // [project.authors] uses `{ name, email }` inline tables. Our schemas key on
+    // poetry-specific discriminators (priority, git, path, file, etc.), so authors
+    // should be left untouched.
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    authors = [ { email = "alice@example.com", name = "Alice" } ]
+    "#};
+    let result = evaluate_full(start);
+    assert!(
+        result.contains(r#"{ email = "alice@example.com", name = "Alice" }"#)
+            || result.contains(r#"{ name = "Alice", email = "alice@example.com" }"#),
+        "authors inline-table should not be reordered by Poetry schemas, got:\n{result}"
+    );
+}
+
+#[test]
+fn test_poetry_long_format_dependencies_expanded() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.dependencies]
+    zebra = "^1.0"
+    python = "^3.11"
+    alpha = "^2.0"
+    "#};
+    let result = evaluate_long(start);
+    // python first, then alphabetized
+    assert!(
+        result.contains("[tool.poetry.dependencies]"),
+        "expected expanded form, got:\n{result}"
+    );
+    let py_pos = result.find("python = ").expect("python present");
+    let alpha_pos = result.find("alpha = ").expect("alpha present");
+    let zebra_pos = result.find("zebra = ").expect("zebra present");
+    assert!(py_pos < alpha_pos && alpha_pos < zebra_pos, "ordering wrong:\n{result}");
+}
+
+#[test]
+fn test_poetry_long_format_extras_expanded() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.extras]
+    web = ["uvicorn", "fastapi", "starlette"]
+    cli = ["typer", "rich"]
+    "#};
+    let result = evaluate_long(start);
+    assert!(
+        result.contains("[tool.poetry.extras]"),
+        "expected expanded form, got:\n{result}"
+    );
+    // Inner arrays alphabetized
+    assert!(
+        result.contains(r#"cli = [ "rich", "typer" ]"#),
+        "cli sort failed:\n{result}"
+    );
+    assert!(
+        result.contains(r#"web = [ "fastapi", "starlette", "uvicorn" ]"#),
+        "web sort failed:\n{result}"
+    );
+}
+
+#[test]
+fn test_poetry_long_format_scripts_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.scripts]
+    z-cli = "z:main"
+    a-cli = "a:main"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.poetry.scripts]"));
+    let a_pos = result.find("a-cli = ").expect("a-cli");
+    let z_pos = result.find("z-cli = ").expect("z-cli");
+    assert!(a_pos < z_pos, "scripts not alphabetized:\n{result}");
+}
+
+#[test]
+fn test_poetry_long_format_urls_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.urls]
+    "Source" = "https://example.com"
+    "Bug Tracker" = "https://example.com/issues"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.poetry.urls]"));
+    let bug = result.find("Bug Tracker").expect("Bug Tracker");
+    let src = result.find("Source").expect("Source");
+    assert!(bug < src, "urls not alphabetized:\n{result}");
+}
+
+#[test]
+fn test_poetry_long_format_plugins_unquoted_inner() {
+    // Unquoted plugin group names (no dots) — fix_expanded_plugins handles these.
+    let start = indoc::indoc! {r#"
+    [tool.poetry.plugins.console_scripts]
+    zebra = "z:Z"
+    alpha = "a:A"
+    "#};
+    let result = evaluate_long(start);
+    let a_pos = result.find("alpha = ").expect("alpha");
+    let z_pos = result.find("zebra = ").expect("zebra");
+    assert!(a_pos < z_pos, "plugins inner keys not sorted:\n{result}");
+}
+
+#[test]
+fn test_poetry_long_format_group_inner_order() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.group.dev]
+    include-groups = ["test", "lint", "docs"]
+    optional = true
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.poetry.group.dev]"));
+    let opt_pos = result.find("optional = ").expect("optional");
+    let inc_pos = result.find("include-groups = ").expect("include-groups");
+    assert!(opt_pos < inc_pos, "group key order wrong:\n{result}");
+    // include-groups sorted
+    assert!(
+        result.contains(r#"include-groups = [ "docs", "lint", "test" ]"#),
+        "include-groups not sorted:\n{result}"
+    );
+}
+
+#[test]
+fn test_poetry_long_format_group_dependencies_expanded() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.group.test.dependencies]
+    zebra = "^1.0"
+    python = "^3.11"
+    alpha = "^2.0"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.poetry.group.test.dependencies]"));
+    let py_pos = result.find("python = ").expect("python");
+    let alpha_pos = result.find("alpha = ").expect("alpha");
+    let zebra_pos = result.find("zebra = ").expect("zebra");
+    assert!(py_pos < alpha_pos && alpha_pos < zebra_pos);
+}
+
+#[test]
+fn test_poetry_long_format_source_aot_preserved() {
+    let start = indoc::indoc! {r#"
+    [[tool.poetry.source]]
+    priority = "primary"
+    url = "https://pypi.example.com/simple"
+    name = "private"
+    "#};
+    let result = evaluate_long(start);
+    assert!(
+        result.contains("[[tool.poetry.source]]"),
+        "expected AoT preserved, got:\n{result}"
+    );
+    // name → url → priority
+    let n = result.find("name = ").expect("name");
+    let u = result.find("url = ").expect("url");
+    let p = result.find("priority = ").expect("priority");
+    assert!(n < u && u < p, "source key order wrong:\n{result}");
+}
+
+#[test]
+fn test_poetry_long_format_build_inline_table() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.build]
+    generate-setup-file = true
+    script = "build.py"
+    "#};
+    let result = evaluate_long(start);
+    let s = result.find("script = ").expect("script");
+    let g = result.find("generate-setup-file = ").expect("generate-setup-file");
+    assert!(s < g, "build key order wrong:\n{result}");
+}
+
+#[test]
+fn test_poetry_long_format_dev_dependencies_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.dev-dependencies]
+    pytest = "^8.0"
+    black = "^25.0"
+    mypy = "^1.10"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.poetry.dev-dependencies]"));
+    let b = result.find("black = ").expect("black");
+    let m = result.find("mypy = ").expect("mypy");
+    let p = result.find("pytest = ").expect("pytest");
+    assert!(b < m && m < p);
+}
+
+#[test]
+fn test_poetry_long_format_requires_plugins_expanded() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.requires-plugins]
+    z-plug = ">=1"
+    a-plug = ">=1"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.poetry.requires-plugins]"));
+    let a = result.find("a-plug = ").expect("a-plug");
+    let z = result.find("z-plug = ").expect("z-plug");
+    assert!(a < z);
+}
+
+#[test]
+fn test_poetry_long_format_build_constraints_expanded() {
+    let start = indoc::indoc! {r#"
+    [tool.poetry.build-constraints]
+    zeta = { setuptools = "<78" }
+    alpha = { setuptools = "<79" }
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.poetry.build-constraints]"));
+    let a = result.find("alpha = ").expect("alpha");
+    let z = result.find("zeta = ").expect("zeta");
+    assert!(a < z);
+}
+
+#[test]
+fn test_poetry_long_format_plugins_top_alphabetized() {
+    // When there are multiple plugin groups, the parent plugins table's keys are
+    // ordered via fix_expanded_plugins.
+    let start = indoc::indoc! {r#"
+    [tool.poetry.plugins]
+    zeta = "z:Z"
+    alpha = "a:A"
+    "#};
+    let result = evaluate_long(start);
+    let a = result.find("alpha = ").expect("alpha");
+    let z = result.find("zeta = ").expect("zeta");
+    assert!(a < z, "top-level plugins not alphabetized:\n{result}");
+}


### PR DESCRIPTION
[Poetry](https://python-poetry.org/) ([pyproject.toml config](https://python-poetry.org/docs/pyproject/)) is the single biggest unhandled section in real `pyproject.toml` files: the bare `[tool.poetry]` table appears in roughly 12k files on GitHub and the sub-table family (`dependencies`, `group.*`, `source`, `scripts`, `extras`, `plugins`, `urls`) brings the aggregate past 40k occurrences. ✨ Until now the formatter passed Poetry through untouched, so users got canonical ordering for `[project]` and `[tool.ruff]` while the largest remaining block in their file stayed as-written.

This adds a handler that covers the full Poetry 1.x and 2.x schemas. Top-level metadata is ordered identity → license → docs → discovery → packaging → deps → entry points → runtime constraints. Per-dependency tables put `python` first then alphabetize package names. Per-group ordering is `optional` → `include-groups` → `dependencies`. Arrays with set semantics (`keywords`, `classifiers`, `exclude`, `extras` values, `include-groups`, per-dep `extras`) are sorted and deduplicated. The deprecated `default`/`secondary` source keys are kept last so they don't get promoted above the current `priority` field. Ordering runs against the collapsed parent table using dotted keys, so it works under both `table_format = \"short\"` and `\"long\"`.

For inline tables that survive collapse — `[[tool.poetry.source]]` becomes `source = [{...}]`, and dependency specs are already inline — a Poetry-specific `InlineTableSchema` set reorders keys inside each entry. Discriminators were chosen to be Poetry-only (`priority`/`links`/`indexed`/`secondary` for sources; `git`/`path`/`file` for deps) so the schemas never accidentally match `[[project.authors]]` entries with `{ name, email }`. 🔧 `reorder_inline_tables` had to land after `reorder_tables` in the main pipeline rather than before, because the AoT-to-inline-array conversion happens during `reorder_tables`; running first leaves nothing for the inline-table pass to find and the first format pass is non-idempotent.

Validating against 30 real-world `pyproject.toml` files sampled from GitHub surfaced an unrelated correctness bug in `common`: triple-literal `'''...'''` strings carrying backslashes (regex globs in `[tool.black]` `exclude` blocks were the canonical case) were being re-emitted as triple-basic `\"\"\"...\"\"\"` without escaping the backslashes, producing syntactically invalid TOML. 🐛 The first commit in this PR extends the literal-form check with a `can_use_multiline_literal_string` predicate that permits newlines but forbids the closing delimiter, and preserves the literal form whenever the source was already literal and the text is still representable that way. All 30 samples now format to valid TOML and round-trip identically through a second pass.