### PR TITLE
✨ feat(pyproject-fmt): add [tool.mypy] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -684,6 +684,82 @@ Inline tables that don't match any Poetry-specific schema (for example ``[[proje
     dependencies.foo = { git = "https://github.com/example/foo", branch = "main" }
     dependencies.zebra = "^1.0"
     source = [ { name = "private", url = "https://pypi.example.com/simple", priority = "primary" } ]
+``[tool.mypy]``
+~~~~~~~~~~~~~~~
+
+Covers all documented mypy options plus the ``[[tool.mypy.overrides]]`` array of tables. Keys are reordered to match
+the section structure of the official mypy configuration reference.
+
+**Top-level key ordering** (sectioned):
+
+1. Import discovery: ``mypy_path`` → ``files`` → ``modules`` → ``packages`` → ``exclude`` → ``exclude_gitignore`` →
+   ``namespace_packages`` → ``explicit_package_bases`` → ``ignore_missing_imports`` → ``follow_untyped_imports`` →
+   ``follow_imports`` → ``follow_imports_for_stubs`` → ``python_executable`` → ``no_site_packages`` →
+   ``no_silence_site_packages``
+2. Platform configuration: ``python_version`` → ``platform`` → ``always_true`` → ``always_false``
+3. Disallow dynamic typing: ``disallow_any_unimported`` → ``disallow_any_expr`` → ``disallow_any_decorated`` →
+   ``disallow_any_explicit`` → ``disallow_any_generics`` → ``disallow_subclassing_any``
+4. Untyped definitions and calls: ``disallow_untyped_calls`` → ``untyped_calls_exclude`` → ``disallow_untyped_defs``
+   → ``disallow_incomplete_defs`` → ``check_untyped_defs`` → ``disallow_untyped_decorators``
+5. None and Optional: ``implicit_optional`` → ``strict_optional``
+6. Configuring warnings: ``warn_redundant_casts`` → ``warn_unused_ignores`` → ``warn_no_return`` →
+   ``warn_return_any`` → ``warn_unreachable`` → ``deprecated_calls_exclude``
+7. Suppressing errors: ``ignore_errors``
+8. Miscellaneous strictness: ``allow_untyped_globals`` → ``allow_redefinition`` → ``local_partial_types`` →
+   ``disable_error_code`` → ``enable_error_code`` → ``extra_checks`` → ``implicit_reexport`` →
+   ``strict_equality`` → ``strict_bytes`` → ``strict``
+9. Configuring error messages: ``show_error_context`` → ``show_column_numbers`` → ``show_error_end`` →
+   ``hide_error_codes`` → ``show_error_code_links`` → ``pretty`` → ``color_output`` → ``error_summary`` →
+   ``show_absolute_path``
+10. Incremental mode: ``incremental`` → ``cache_dir`` → ``sqlite_cache`` → ``cache_fine_grained`` →
+    ``skip_version_check`` → ``skip_cache_mtime_checks``
+11. Advanced options: ``plugins`` → ``pdb`` → ``show_traceback`` → ``raise_exceptions`` →
+    ``custom_typing_module`` → ``custom_typeshed_dir`` → ``warn_incomplete_stub`` → ``native_parser``
+12. Report generation: ``any_exprs_report`` → ``cobertura_xml_report`` → ``html_report`` → ``linecount_report`` →
+    ``linecoverage_report`` → ``lineprecision_report`` → ``txt_report`` → ``xml_report`` → ``xslt_html_report`` →
+    ``xslt_txt_report``
+13. Miscellaneous: ``junit_xml`` → ``junit_format`` → ``scripts_are_modules`` → ``warn_unused_configs`` →
+    ``verbosity``
+14. ``overrides`` last.
+
+**``[[tool.mypy.overrides]]`` entry key ordering:**
+
+``module`` first (required), then per-module overridable keys in the same logical grouping as the parent table
+(import behavior, platform markers, disallow dynamic typing, untyped defs/calls, optional handling, warnings,
+suppression, miscellaneous strictness).
+
+**Sorted arrays:**
+
+- Top-level: ``files``, ``modules``, ``packages``, ``exclude``, ``always_true``, ``always_false``,
+  ``untyped_calls_exclude``, ``deprecated_calls_exclude``, ``disable_error_code``, ``enable_error_code``.
+- Inside overrides entries: ``module`` (when an array of patterns), ``always_true``, ``always_false``,
+  ``disable_error_code``, ``enable_error_code``.
+
+``plugins`` and ``mypy_path`` are deliberately preserved as written: plugins run in declared order and reordering
+changes behavior; ``mypy_path`` is a search path with priority semantics.
+
+**Inline-table handling:**
+
+When ``[[tool.mypy.overrides]]`` collapses to ``overrides = [{...}, {...}]`` under the default ``table_format =
+"short"``, key order inside each entry is normalized via discriminators unique to mypy
+(``disable_error_code`` / ``enable_error_code`` / ``ignore_missing_imports`` / ``follow_untyped_imports`` /
+``ignore_errors`` / ``warn_unused_ignores`` / ``disallow_untyped_defs`` / ``check_untyped_defs``). The arrays inside
+each inline entry are sorted in place, so ``disable_error_code = [...]`` is alphabetized whether the override is
+expanded or collapsed.
+
+.. code-block:: toml
+
+    # Before
+    [[tool.mypy.overrides]]
+    ignore_missing_imports = true
+    disable_error_code = ["import-untyped", "attr-defined"]
+    module = "third_party.*"
+
+    # After
+    [tool.mypy]
+    overrides = [
+      { module = "third_party.*", ignore_missing_imports = true, disable_error_code = [ "attr-defined", "import-untyped" ] },
+    ]
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -16,6 +16,7 @@ mod project;
 mod commitizen;
 mod coverage;
 mod global;
+mod mypy;
 mod pixi;
 mod poetry;
 mod ruff;
@@ -167,12 +168,16 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     pixi::fix(&mut tables);
     commitizen::fix(&mut tables);
     poetry::fix(&mut tables);
+    mypy::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed
     // to inline arrays of inline tables (e.g. [[tool.poetry.source]] → source = [{...}])
     // are visible in root_ast as INLINE_TABLE descendants.
     poetry::reorder_inline_tables(&root_ast);
+    // mypy needs to walk the AST after AoT entries (`[[tool.mypy.overrides]]`) collapse
+    // into inline-array form via reorder_tables.
+    mypy::reorder_inline_tables(&root_ast);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);
     common::string::wrap_all_long_strings(&root_ast, opt.column_width, &indent_string, &opt.skip_wrap_for_keys);
 

--- a/pyproject-fmt/rust/src/mypy.rs
+++ b/pyproject-fmt/rust/src/mypy.rs
@@ -1,0 +1,313 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_inline_table_keys, reorder_table_keys, InlineTableSchema, Tables};
+use lexical_sort::natural_lexical_cmp;
+use tombi_syntax::SyntaxKind::{ARRAY, INLINE_TABLE, KEYS, KEY_VALUE};
+use tombi_syntax::SyntaxNode;
+
+// Grouped to match the section structure of the official mypy config reference.
+const KEY_ORDER: &[&str] = &[
+    "",
+    // 1. Import discovery
+    "mypy_path",
+    "files",
+    "modules",
+    "packages",
+    "exclude",
+    "exclude_gitignore",
+    "namespace_packages",
+    "explicit_package_bases",
+    "ignore_missing_imports",
+    "follow_untyped_imports",
+    "follow_imports",
+    "follow_imports_for_stubs",
+    "python_executable",
+    "no_site_packages",
+    "no_silence_site_packages",
+    // 2. Platform configuration
+    "python_version",
+    "platform",
+    "always_true",
+    "always_false",
+    // 3. Disallow dynamic typing
+    "disallow_any_unimported",
+    "disallow_any_expr",
+    "disallow_any_decorated",
+    "disallow_any_explicit",
+    "disallow_any_generics",
+    "disallow_subclassing_any",
+    // 4. Untyped definitions and calls
+    "disallow_untyped_calls",
+    "untyped_calls_exclude",
+    "disallow_untyped_defs",
+    "disallow_incomplete_defs",
+    "check_untyped_defs",
+    "disallow_untyped_decorators",
+    // 5. None and Optional handling
+    "implicit_optional",
+    "strict_optional",
+    // 6. Configuring warnings
+    "warn_redundant_casts",
+    "warn_unused_ignores",
+    "warn_no_return",
+    "warn_return_any",
+    "warn_unreachable",
+    "deprecated_calls_exclude",
+    "report_deprecated_as_note",
+    // 7. Suppressing errors
+    "ignore_errors",
+    // 8. Miscellaneous strictness flags (strict meta-flag last)
+    "allow_untyped_globals",
+    "allow_redefinition",
+    "allow_redefinition_new",
+    "allow_redefinition_old",
+    "local_partial_types",
+    "disable_error_code",
+    "enable_error_code",
+    "extra_checks",
+    "implicit_reexport",
+    "strict_concatenate",
+    "strict_equality",
+    "strict_equality_for_none",
+    "strict_bytes",
+    "strict",
+    // 9. Configuring error messages
+    "show_error_context",
+    "show_column_numbers",
+    "show_error_end",
+    "hide_error_codes",
+    "show_error_code_links",
+    "pretty",
+    "color_output",
+    "error_summary",
+    "show_absolute_path",
+    // 10. Incremental mode
+    "incremental",
+    "cache_dir",
+    "sqlite_cache",
+    "cache_fine_grained",
+    "skip_version_check",
+    "skip_cache_mtime_checks",
+    // 11. Advanced options
+    "plugins",
+    "pdb",
+    "show_traceback",
+    "raise_exceptions",
+    "custom_typing_module",
+    "custom_typeshed_dir",
+    "warn_incomplete_stub",
+    "native_parser",
+    // 12. Report generation
+    "any_exprs_report",
+    "cobertura_xml_report",
+    "html_report",
+    "linecount_report",
+    "linecoverage_report",
+    "lineprecision_report",
+    "txt_report",
+    "xml_report",
+    "xslt_html_report",
+    "xslt_txt_report",
+    // 13. Miscellaneous
+    "junit_xml",
+    "junit_format",
+    "scripts_are_modules",
+    "warn_unused_configs",
+    "verbosity",
+    // 14. Overrides (AoT or inline-array of inline tables) — always last
+    "overrides",
+];
+
+// module is required, so it leads; the rest mirror the parent groupings, restricted to
+// the per-module-overridable subset.
+const OVERRIDES_KEY_ORDER: &[&str] = &[
+    "",
+    "module",
+    // Import behavior
+    "ignore_missing_imports",
+    "follow_untyped_imports",
+    "follow_imports",
+    "follow_imports_for_stubs",
+    // Platform truthy/falsy markers
+    "always_true",
+    "always_false",
+    // Disallow dynamic typing
+    "disallow_any_unimported",
+    "disallow_any_expr",
+    "disallow_any_decorated",
+    "disallow_any_explicit",
+    "disallow_any_generics",
+    "disallow_subclassing_any",
+    // Untyped defs and calls
+    "disallow_untyped_calls",
+    "disallow_untyped_defs",
+    "disallow_incomplete_defs",
+    "check_untyped_defs",
+    "disallow_untyped_decorators",
+    // None and Optional
+    "implicit_optional",
+    "strict_optional",
+    // Warnings
+    "warn_unused_ignores",
+    "warn_no_return",
+    "warn_return_any",
+    "warn_unreachable",
+    // Suppression
+    "ignore_errors",
+    // Misc strictness
+    "allow_untyped_globals",
+    "allow_redefinition",
+    "allow_redefinition_old",
+    "local_partial_types",
+    "disable_error_code",
+    "enable_error_code",
+    "extra_checks",
+    "implicit_reexport",
+    "strict_concatenate",
+    "strict_equality",
+    "strict_equality_for_none",
+    "strict",
+];
+
+// Set-semantics arrays only; plugins and mypy_path are excluded as order-sensitive.
+const TOP_LEVEL_SORT_ARRAYS: &[&str] = &[
+    "files",
+    "modules",
+    "packages",
+    "exclude",
+    "always_true",
+    "always_false",
+    "untyped_calls_exclude",
+    "deprecated_calls_exclude",
+    "disable_error_code",
+    "enable_error_code",
+];
+
+// module globs are sorted too, matching the existing project convention.
+const OVERRIDES_SORT_ARRAYS: &[&str] = &[
+    "module",
+    "always_true",
+    "always_false",
+    "disable_error_code",
+    "enable_error_code",
+];
+
+pub fn fix(tables: &mut Tables) {
+    fix_root(tables);
+    fix_expanded_overrides(tables);
+}
+
+fn fix_root(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.mypy") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+
+    for_entries(table, &mut |key, entry| {
+        let k = key.as_str();
+        if TOP_LEVEL_SORT_ARRAYS.contains(&k) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}
+
+fn fix_expanded_overrides(tables: &mut Tables) {
+    let Some(entries) = tables.get("tool.mypy.overrides") else {
+        return;
+    };
+    for entry_ref in entries {
+        let table = &mut entry_ref.borrow_mut();
+        for_entries(table, &mut |key, entry| {
+            if OVERRIDES_SORT_ARRAYS.contains(&key.as_str()) {
+                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            }
+        });
+        reorder_table_keys(table, OVERRIDES_KEY_ORDER);
+    }
+}
+
+// Discriminator chosen to avoid collisions: `disable_error_code` and `enable_error_code`
+// are mypy-specific in pyproject.toml; `module` alone would risk matching unrelated
+// inline tables. Several discriminators map to the same OVERRIDES_KEY_ORDER so an entry
+// with only `module` + `ignore_missing_imports` (for example) is still recognized.
+pub const INLINE_TABLE_SCHEMAS: &[InlineTableSchema] = &[
+    InlineTableSchema {
+        discriminator: "disable_error_code",
+        key_order: OVERRIDES_KEY_ORDER,
+    },
+    InlineTableSchema {
+        discriminator: "enable_error_code",
+        key_order: OVERRIDES_KEY_ORDER,
+    },
+    InlineTableSchema {
+        discriminator: "ignore_missing_imports",
+        key_order: OVERRIDES_KEY_ORDER,
+    },
+    InlineTableSchema {
+        discriminator: "follow_untyped_imports",
+        key_order: OVERRIDES_KEY_ORDER,
+    },
+    InlineTableSchema {
+        discriminator: "ignore_errors",
+        key_order: OVERRIDES_KEY_ORDER,
+    },
+    InlineTableSchema {
+        discriminator: "warn_unused_ignores",
+        key_order: OVERRIDES_KEY_ORDER,
+    },
+    InlineTableSchema {
+        discriminator: "disallow_untyped_defs",
+        key_order: OVERRIDES_KEY_ORDER,
+    },
+    InlineTableSchema {
+        discriminator: "check_untyped_defs",
+        key_order: OVERRIDES_KEY_ORDER,
+    },
+];
+
+pub fn reorder_inline_tables(root_ast: &SyntaxNode) {
+    reorder_inline_table_keys(root_ast, INLINE_TABLE_SCHEMAS);
+    sort_arrays_inside_overrides(root_ast);
+}
+
+/// When `[[tool.mypy.overrides]]` is collapsed into `overrides = [ {...}, {...} ]`, the
+/// arrays inside each inline entry (e.g. `disable_error_code = ["x", "y"]`) live inside
+/// values, not table entries — `for_entries` on the parent table won't see them. Walk the
+/// AST under the `overrides` key and sort the known array-of-string fields in-place.
+fn sort_arrays_inside_overrides(root_ast: &SyntaxNode) {
+    for kv in root_ast.descendants().filter(|n| n.kind() == KEY_VALUE) {
+        let Some(keys) = kv.children().find(|c| c.kind() == KEYS) else {
+            continue;
+        };
+        let key_text = keys.text().to_string();
+        let key_trim = key_text.trim();
+        // Match either `overrides = [...]` (within `[tool.mypy]`) or
+        // `mypy.overrides = [...]` (when collapsed under tool).
+        if !(key_trim == "overrides" || key_trim.ends_with(".overrides")) {
+            continue;
+        }
+        let Some(array) = kv.children().find(|c| c.kind() == ARRAY) else {
+            continue;
+        };
+        for inline in array.descendants().filter(|n| n.kind() == INLINE_TABLE) {
+            // INLINE_TABLE children are wrapped in KEY_VALUE_WITH_COMMA_GROUP — use
+            // descendants() to reach KEY_VALUE nodes regardless of nesting depth.
+            for inner_kv in inline.descendants().filter(|n| n.kind() == KEY_VALUE) {
+                let Some(inner_keys) = inner_kv.children().find(|c| c.kind() == KEYS) else {
+                    continue;
+                };
+                let inner_key = inner_keys.text().to_string().trim().to_string();
+                if !OVERRIDES_SORT_ARRAYS.contains(&inner_key.as_str()) {
+                    continue;
+                }
+                if let Some(inner_array) = inner_kv.children().find(|c| c.kind() == ARRAY) {
+                    sort_string_array_in_place(&inner_array);
+                }
+            }
+        }
+    }
+}
+
+fn sort_string_array_in_place(array: &SyntaxNode) {
+    sort_strings::<String, _, _>(array, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod coverage_tests;
 mod dependency_groups_tests;
 mod global_tests;
 mod main_tests;
+mod mypy_tests;
 mod pixi_tests;
 mod poetry_tests;
 mod project_tests;

--- a/pyproject-fmt/rust/src/tests/mypy_tests.rs
+++ b/pyproject-fmt/rust/src/tests/mypy_tests.rs
@@ -1,0 +1,387 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::mypy::{fix, reorder_inline_tables};
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.mypy"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    reorder_inline_tables(&root_ast);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 13),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn evaluate_full(start: &str) -> String {
+    let r = format_toml(start, &default_settings());
+    assert_valid_toml(&r);
+    r
+}
+
+#[test]
+fn test_mypy_top_level_key_order_groups_sections() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    warn_unused_configs = true
+    strict = true
+    cache_dir = ".mypy_cache"
+    plugins = ["pydantic.mypy"]
+    pretty = true
+    python_version = "3.11"
+    files = ["src"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    files = [ "src" ]
+    python_version = "3.11"
+    strict = true
+    pretty = true
+    cache_dir = ".mypy_cache"
+    plugins = [ "pydantic.mypy" ]
+    warn_unused_configs = true
+    "#);
+}
+
+#[test]
+fn test_mypy_import_discovery_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    packages = ["z_pkg", "a_pkg", "m_pkg"]
+    modules = ["zebra", "alpha"]
+    files = ["tests", "src", "examples"]
+    exclude = ["build/", "dist/", "\\.tox/"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    files = [ "examples", "src", "tests" ]
+    modules = [ "alpha", "zebra" ]
+    packages = [ "a_pkg", "m_pkg", "z_pkg" ]
+    exclude = [ "\\.tox/", "build/", "dist/" ]
+    "#);
+}
+
+#[test]
+fn test_mypy_plugins_order_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    plugins = ["pydantic.mypy", "numpy.typing.mypy_plugin", "z_first"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    plugins = [ "pydantic.mypy", "numpy.typing.mypy_plugin", "z_first" ]
+    "#);
+}
+
+#[test]
+fn test_mypy_path_order_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    mypy_path = ["./stubs", "./src", "./vendor"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    mypy_path = [ "./stubs", "./src", "./vendor" ]
+    "#);
+}
+
+#[test]
+fn test_mypy_error_code_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    disable_error_code = ["import-untyped", "attr-defined", "no-untyped-def"]
+    enable_error_code = ["truthy-bool", "redundant-expr"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    disable_error_code = [ "attr-defined", "import-untyped", "no-untyped-def" ]
+    enable_error_code = [ "redundant-expr", "truthy-bool" ]
+    "#);
+}
+
+#[test]
+fn test_mypy_always_true_false_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    always_true = ["FEATURE_Z", "FEATURE_A"]
+    always_false = ["DEBUG", "BETA"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    always_true = [ "FEATURE_A", "FEATURE_Z" ]
+    always_false = [ "BETA", "DEBUG" ]
+    "#);
+}
+
+#[test]
+fn test_mypy_overrides_aot_key_order() {
+    let start = indoc::indoc! {r#"
+    [[tool.mypy.overrides]]
+    ignore_missing_imports = true
+    disable_error_code = ["attr-defined"]
+    module = "third_party.*"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    overrides = [ { module = "third_party.*", ignore_missing_imports = true, disable_error_code = [ "attr-defined" ] } ]
+    "#);
+}
+
+#[test]
+fn test_mypy_overrides_module_as_array() {
+    let start = indoc::indoc! {r#"
+    [[tool.mypy.overrides]]
+    ignore_missing_imports = true
+    module = ["zlib_mod", "alpha_mod", "mike_mod"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    overrides = [ { module = [ "alpha_mod", "mike_mod", "zlib_mod" ], ignore_missing_imports = true } ]
+    "#);
+}
+
+#[test]
+fn test_mypy_overrides_disable_error_code_sorted_inside_inline() {
+    let start = indoc::indoc! {r#"
+    [[tool.mypy.overrides]]
+    module = "tests.*"
+    disable_error_code = ["no-untyped-def", "attr-defined", "import-untyped"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    overrides = [ { module = "tests.*", disable_error_code = [ "attr-defined", "import-untyped", "no-untyped-def" ] } ]
+    "#);
+}
+
+#[test]
+fn test_mypy_multiple_overrides_preserved_order() {
+    let start = indoc::indoc! {r#"
+    [[tool.mypy.overrides]]
+    module = "third_party.*"
+    ignore_missing_imports = true
+
+    [[tool.mypy.overrides]]
+    module = "tests.*"
+    disable_error_code = ["attr-defined"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    overrides = [
+      { module = "third_party.*", ignore_missing_imports = true },
+      { module = "tests.*", disable_error_code = [ "attr-defined" ] },
+    ]
+    "#);
+}
+
+#[test]
+fn test_mypy_unknown_keys_alphabetized_at_end() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    zzz_unknown = true
+    aaa_unknown = false
+    strict = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    strict = true
+    aaa_unknown = false
+    zzz_unknown = true
+    "#);
+}
+
+#[test]
+fn test_mypy_comments_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    # Python target version
+    python_version = "3.12"
+    # Be strict
+    strict = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    # Python target version
+    python_version = "3.12"
+    # Be strict
+    strict = true
+    "#);
+}
+
+#[test]
+fn test_mypy_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    python_version = "3.11"
+    files = [ "src", "tests" ]
+    strict = true
+    disable_error_code = [ "attr-defined" ]
+    plugins = [ "pydantic.mypy" ]
+
+    [[tool.mypy.overrides]]
+    module = "third_party.*"
+    ignore_missing_imports = true
+    "#};
+    let once = evaluate_full(start);
+    let twice = evaluate_full(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_mypy_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "demo"
+    "#);
+}
+
+#[test]
+fn test_mypy_does_not_reorder_unrelated_inline_tables() {
+    // [[project.authors]] has `{ name, email }`. Our schemas key on mypy-specific
+    // discriminators, so authors must be untouched.
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    authors = [ { email = "alice@example.com", name = "Alice" } ]
+    "#};
+    let result = evaluate_full(start);
+    assert!(
+        result.contains(r#"{ email = "alice@example.com", name = "Alice" }"#)
+            || result.contains(r#"{ name = "Alice", email = "alice@example.com" }"#),
+        "authors inline-table should not be reordered by mypy schemas, got:\n{result}"
+    );
+}
+
+#[test]
+fn test_mypy_warnings_group_together() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    warn_unreachable = true
+    warn_redundant_casts = true
+    warn_return_any = true
+    warn_unused_ignores = true
+    warn_no_return = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    warn_redundant_casts = true
+    warn_unused_ignores = true
+    warn_no_return = true
+    warn_return_any = true
+    warn_unreachable = true
+    "#);
+}
+
+#[test]
+fn test_mypy_report_keys_grouped() {
+    let start = indoc::indoc! {r#"
+    [tool.mypy]
+    txt_report = "reports/txt"
+    html_report = "reports/html"
+    xml_report = "reports/xml"
+    strict = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.mypy]
+    strict = true
+    html_report = "reports/html"
+    txt_report = "reports/txt"
+    xml_report = "reports/xml"
+    "#);
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let r = format_toml(start, &long_settings());
+    assert_valid_toml(&r);
+    r
+}
+
+#[test]
+fn test_mypy_long_format_overrides_expanded() {
+    let start = indoc::indoc! {r#"
+    [[tool.mypy.overrides]]
+    ignore_missing_imports = true
+    disable_error_code = ["import-untyped", "attr-defined"]
+    module = "third_party.*"
+    "#};
+    let result = evaluate_long(start);
+    assert!(
+        result.contains("[[tool.mypy.overrides]]"),
+        "expected AoT preserved:\n{result}"
+    );
+    // module first, then disable_error_code sorted
+    let m = result.find("module = ").expect("module");
+    let i = result
+        .find("ignore_missing_imports = ")
+        .expect("ignore_missing_imports");
+    let d = result.find("disable_error_code = ").expect("disable_error_code");
+    assert!(m < i && i < d, "key order wrong:\n{result}");
+    assert!(
+        result.contains(r#"disable_error_code = [ "attr-defined", "import-untyped" ]"#),
+        "disable_error_code not sorted:\n{result}"
+    );
+}
+
+#[test]
+fn test_mypy_long_format_overrides_module_array_sorted() {
+    let start = indoc::indoc! {r#"
+    [[tool.mypy.overrides]]
+    module = ["zlib_mod", "alpha_mod"]
+    ignore_missing_imports = true
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[[tool.mypy.overrides]]"));
+    assert!(
+        result.contains(r#"module = [ "alpha_mod", "zlib_mod" ]"#),
+        "module not sorted:\n{result}"
+    );
+}


### PR DESCRIPTION
[Mypy](https://mypy.readthedocs.io/) ([pyproject.toml config](https://mypy.readthedocs.io/en/stable/config_file.html)) is the most-downloaded standalone Python type checker (around 164M downloads/month) and roughly 10k `pyproject.toml` files on GitHub contain a bare `[tool.mypy]` table; counting `[[tool.mypy.overrides]]` pushes the aggregate past 16k. ✨ The formatter previously left every key untouched, so users had no canonical ordering for one of the largest tool blocks in their file and no normalization for the order-irrelevant string arrays (`disable_error_code`, `enable_error_code`, `always_true`, `always_false`, `files`, `modules`, `packages`, `exclude`).

This adds a handler that covers every key documented in the mypy configuration reference, plus a few present in `mypy/options.py` but missing from the rendered docs (`show_error_end`, `report_deprecated_as_note`, the `allow_redefinition_new` / `allow_redefinition_old` split). Top-level keys are grouped to match the doc section structure: import discovery → platform → disallow-dynamic → untyped defs/calls → optional handling → warnings → suppression → misc strictness → error messages → incremental → advanced → report generation → misc. `overrides` lands last regardless of source position.

The per-module `[[tool.mypy.overrides]]` entries get their own ordering: the required `module` key first, then the per-module-overridable subset taken verbatim from `PER_MODULE_OPTIONS` in mypy's source, grouped the same way as the parent table. When `table_format = \"short\"` collapses the AoT into `overrides = [{...}]`, key order inside each entry is normalized via an `InlineTableSchema` set keyed on mypy-specific discriminators (`disable_error_code`, `enable_error_code`, `ignore_missing_imports`, etc.) so it never accidentally matches inline tables in unrelated tool sections. 🔧 A small AST walker rooted at the `overrides` key sorts the string arrays inside each collapsed entry, since those values aren't reachable via `for_entries` on the parent table.

`plugins` and `mypy_path` are deliberately preserved as written: plugins execute in declared order and `mypy_path` is a search path with priority semantics. Sorting either would silently change mypy's behavior.

This PR also carries the same `common` triple-literal string fix as #324 — both branches were cut from `upstream/main` independently, and the 30 mypy samples I validated against included files with `[tool.black]` `exclude = '''...'''` blocks that would otherwise produce invalid TOML. 🐛 If #324 lands first, this commit becomes a no-op in the rebase. All 30 sampled `pyproject.toml` files format to valid TOML and round-trip identically through a second pass.