### PR TITLE
✨ feat(pyproject-fmt): add [tool.setuptools] + [tool.setuptools_scm] handlers

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -760,6 +760,87 @@ expanded or collapsed.
     overrides = [
       { module = "third_party.*", ignore_missing_imports = true, disable_error_code = [ "attr-defined", "import-untyped" ] },
     ]
+``[tool.setuptools]`` and ``[tool.setuptools_scm]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Covers the setuptools build backend and the version-from-SCM plugin.
+
+**``[tool.setuptools]`` top-level key ordering** (grouped):
+
+1. Packaging discovery: ``py-modules`` → ``packages.find.*`` / ``packages.find-namespace.*`` → ``packages`` →
+   ``package-dir``
+2. Package data: ``include-package-data`` → ``package-data`` → ``exclude-package-data``
+3. Dynamic metadata: ``dynamic``
+4. Extensions / build customization: ``ext-modules`` → ``cmdclass``
+5. Distribution metadata: ``platforms`` → ``provides`` → ``obsoletes`` → ``license-files``
+6. Data files: ``data-files``
+7. Deprecated / obsolete (pushed last): ``script-files`` → ``namespace-packages`` → ``zip-safe`` →
+   ``eager-resources`` → ``dependency-links``
+
+**``[tool.setuptools.packages.find]`` / ``[tool.setuptools.packages.find-namespace]`` inner ordering:**
+
+``where`` → ``include`` → ``exclude`` → ``namespaces``.
+
+**``[tool.setuptools.package-data]`` / ``[tool.setuptools.exclude-package-data]`` / ``[tool.setuptools.data-files]``
+ordering:**
+
+The catch-all ``"*"`` pattern always goes first, then the other package patterns alphabetically. Each value (an
+array of glob patterns) is sorted alphabetically.
+
+**``[tool.setuptools.dynamic]`` ordering:**
+
+Field names alphabetized. Inline-table directives (e.g. ``version = { attr = "pkg.__version__" }`` or
+``readme = { file = "README.md", content-type = "text/markdown" }``) get their keys ordered ``attr`` → ``file`` →
+``content-type``.
+
+**Sorted arrays:**
+
+- ``py-modules``, ``platforms``, ``provides``, ``obsoletes``, ``script-files``, ``namespace-packages``,
+  ``eager-resources``: alphabetized.
+- ``packages.find.include`` / ``packages.find.exclude`` / ``packages.find-namespace.*``: alphabetized.
+- Values inside ``package-data`` / ``exclude-package-data`` / ``data-files`` tables: alphabetized.
+
+Arrays whose order is meaningful are preserved as written: ``packages`` (literal list — first match wins),
+``license-files`` (PEP 639 concatenation order), and everything under ``[[tool.setuptools.ext-modules]]`` (compiler
+and linker argv arrays).
+
+**``[tool.setuptools_scm]`` key ordering** (grouped):
+
+1. Version output: ``version_file`` → ``version_file_template``
+2. Version computation: ``version_scheme`` → ``local_scheme`` → ``version_cls`` → ``normalize``
+3. Root discovery: ``root`` → ``relative_to`` → ``fallback_root`` → ``parent`` → ``search_parent_directories`` →
+   ``dist_name``
+4. Tag / parse: ``tag_regex`` → ``parse`` → ``parentdir_prefix_version`` → ``fallback_version``
+5. Nested SCM-specific tables: ``scm.git.pre_parse`` → ``scm.git.describe_command``
+6. Deprecated (pushed last): ``git_describe_command`` (use ``scm.git.describe_command``) → ``write_to`` (use
+   ``version_file``) → ``write_to_template`` (use ``version_file_template``) → ``version_class`` (use
+   ``version_cls``) → ``template``
+
+.. code-block:: toml
+
+    # Before
+    [tool.setuptools]
+    zip-safe = false
+    py-modules = ["foo", "bar"]
+    packages = ["my_pkg"]
+
+    [tool.setuptools.packages.find]
+    namespaces = true
+    where = ["src"]
+    include = ["my_pkg*"]
+
+    [tool.setuptools.dynamic]
+    readme = { content-type = "text/markdown", file = "README.md" }
+
+    # After
+    [tool.setuptools]
+    py-modules = [ "bar", "foo" ]
+    packages.find.where = [ "src" ]
+    packages.find.include = [ "my_pkg*" ]
+    packages.find.namespaces = true
+    packages = [ "my_pkg" ]
+    dynamic.readme = { file = "README.md", content-type = "text/markdown" }
+    zip-safe = false
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -20,6 +20,7 @@ mod mypy;
 mod pixi;
 mod poetry;
 mod ruff;
+mod setuptools;
 #[cfg(test)]
 mod tests;
 mod uv;
@@ -169,6 +170,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     commitizen::fix(&mut tables);
     poetry::fix(&mut tables);
     mypy::fix(&mut tables);
+    setuptools::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed
@@ -178,6 +180,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     // mypy needs to walk the AST after AoT entries (`[[tool.mypy.overrides]]`) collapse
     // into inline-array form via reorder_tables.
     mypy::reorder_inline_tables(&root_ast);
+    setuptools::reorder_inline_tables(&root_ast);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);
     common::string::wrap_all_long_strings(&root_ast, opt.column_width, &indent_string, &opt.skip_wrap_for_keys);
 

--- a/pyproject-fmt/rust/src/setuptools.rs
+++ b/pyproject-fmt/rust/src/setuptools.rs
@@ -1,0 +1,217 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_inline_table_keys, reorder_table_keys, InlineTableSchema, Tables};
+use lexical_sort::natural_lexical_cmp;
+use tombi_syntax::SyntaxNode;
+
+// Sub-tables collapse to dotted keys (packages.find.where, package-data."*", etc.); the
+// "packages" prefix catches them all, with finer entries added for inner ordering.
+const KEY_ORDER: &[&str] = &[
+    "",
+    // --- Packaging discovery ---
+    "py-modules",
+    "packages.find.where",
+    "packages.find.include",
+    "packages.find.exclude",
+    "packages.find.namespaces",
+    "packages.find-namespace.where",
+    "packages.find-namespace.include",
+    "packages.find-namespace.exclude",
+    "packages.find-namespace.namespaces",
+    "packages",
+    "package-dir",
+    // --- Package data ---
+    "include-package-data",
+    "package-data",
+    "exclude-package-data",
+    // --- Dynamic metadata ---
+    "dynamic",
+    // --- Extensions / build customization ---
+    "ext-modules",
+    "cmdclass",
+    // --- Distribution metadata ---
+    "platforms",
+    "provides",
+    "obsoletes",
+    "license-files",
+    // --- Discouraged / legacy data files ---
+    "data-files",
+    // --- Deprecated / obsolete (pushed last) ---
+    "script-files",
+    "namespace-packages",
+    "zip-safe",
+    "eager-resources",
+    "dependency-links",
+];
+
+// Safe-to-sort arrays only; packages, license-files, and ext-module paths/argv are left
+// out — order affects build, link, or PEP-639 concatenation.
+const TOP_LEVEL_SORT_ARRAYS: &[&str] = &[
+    "py-modules",
+    "platforms",
+    "provides",
+    "obsoletes",
+    "script-files",
+    "namespace-packages",
+    "eager-resources",
+    "packages.find.include",
+    "packages.find.exclude",
+    "packages.find-namespace.include",
+    "packages.find-namespace.exclude",
+];
+
+const SCM_KEY_ORDER: &[&str] = &[
+    "",
+    // --- Version output ---
+    "version_file",
+    "version_file_template",
+    // --- Version computation / scheme ---
+    "version_scheme",
+    "local_scheme",
+    "version_cls",
+    "normalize",
+    // --- Root / discovery ---
+    "root",
+    "relative_to",
+    "fallback_root",
+    "parent",
+    "search_parent_directories",
+    "dist_name",
+    // --- Tag / parse ---
+    "tag_regex",
+    "parse",
+    "parentdir_prefix_version",
+    "fallback_version",
+    // --- Nested SCM-specific tables (collapse to dotted keys) ---
+    "scm.git.pre_parse",
+    "scm.git.describe_command",
+    "scm",
+    // --- Deprecated (push last) ---
+    "git_describe_command",
+    "write_to",
+    "write_to_template",
+    "version_class",
+    "template",
+];
+
+pub fn fix(tables: &mut Tables) {
+    fix_setuptools(tables);
+    fix_setuptools_scm(tables);
+    fix_expanded_packages_find(tables);
+    fix_expanded_dynamic_table(tables);
+    fix_expanded_data_tables(tables, "tool.setuptools.package-data");
+    fix_expanded_data_tables(tables, "tool.setuptools.exclude-package-data");
+    fix_expanded_data_tables(tables, "tool.setuptools.data-files");
+    fix_expanded_alpha_table(tables, "tool.setuptools.cmdclass");
+}
+
+fn fix_setuptools(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.setuptools") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        let k = key.as_str();
+        if TOP_LEVEL_SORT_ARRAYS.contains(&k) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        } else if is_inner_package_data_array(k) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}
+
+fn is_inner_package_data_array(key: &str) -> bool {
+    for prefix in ["package-data.", "exclude-package-data.", "data-files."] {
+        if let Some(rest) = key.strip_prefix(prefix) {
+            if !rest.is_empty() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn fix_setuptools_scm(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.setuptools_scm") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    reorder_table_keys(table, SCM_KEY_ORDER);
+}
+
+fn fix_expanded_packages_find(tables: &mut Tables) {
+    for key in [
+        "tool.setuptools.packages.find",
+        "tool.setuptools.packages.find-namespace",
+    ] {
+        let Some(elements) = tables.get(key) else {
+            continue;
+        };
+        let table = &mut elements.first().unwrap().borrow_mut();
+        for_entries(table, &mut |inner, entry| {
+            if matches!(inner.as_str(), "include" | "exclude") {
+                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            }
+        });
+        reorder_table_keys(table, &["", "where", "include", "exclude", "namespaces"]);
+    }
+}
+
+fn fix_expanded_dynamic_table(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.setuptools.dynamic") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    // [""] sorts every key alphabetically.
+    reorder_table_keys(table, &[""]);
+}
+
+fn fix_expanded_data_tables(tables: &mut Tables, table_key: &str) {
+    let Some(elements) = tables.get(table_key) else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |_key, entry| {
+        sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+    });
+    // `*` catch-all first, then alphabetical.
+    let mut order: Vec<String> = vec![String::new(), String::from("*")];
+    let mut others: Vec<String> = Vec::new();
+    for_entries(table, &mut |key, _| {
+        let k = key.as_str();
+        if k != "*" && !others.contains(&k.to_string()) {
+            others.push(k.to_string());
+        }
+    });
+    others.sort();
+    order.extend(others);
+    let refs: Vec<&str> = order.iter().map(String::as_str).collect();
+    reorder_table_keys(table, &refs);
+}
+
+fn fix_expanded_alpha_table(tables: &mut Tables, table_key: &str) {
+    let Some(elements) = tables.get(table_key) else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    reorder_table_keys(table, &[""]);
+}
+
+// Discriminators attr/content-type are unique to dynamic directives; file is too generic
+// to discriminate on, so it is omitted from the discriminator set.
+const DYNAMIC_DIRECTIVE_ORDER: &[&str] = &["attr", "file", "content-type"];
+
+pub const INLINE_TABLE_SCHEMAS: &[InlineTableSchema] = &[
+    InlineTableSchema {
+        discriminator: "attr",
+        key_order: DYNAMIC_DIRECTIVE_ORDER,
+    },
+    InlineTableSchema {
+        discriminator: "content-type",
+        key_order: DYNAMIC_DIRECTIVE_ORDER,
+    },
+];
+
+pub fn reorder_inline_tables(root_ast: &SyntaxNode) {
+    reorder_inline_table_keys(root_ast, INLINE_TABLE_SCHEMAS);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod pixi_tests;
 mod poetry_tests;
 mod project_tests;
 mod ruff_tests;
+mod setuptools_tests;
 mod uv_tests;
 
 pub fn collect_entries(tables: &common::table::Tables) -> Vec<SyntaxElement> {

--- a/pyproject-fmt/rust/src/tests/setuptools_tests.rs
+++ b/pyproject-fmt/rust/src/tests/setuptools_tests.rs
@@ -1,0 +1,376 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::setuptools::{fix, reorder_inline_tables};
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.setuptools", "tool.setuptools_scm"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    reorder_inline_tables(&root_ast);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 13),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn evaluate_full(start: &str) -> String {
+    let r = format_toml(start, &default_settings());
+    assert_valid_toml(&r);
+    r
+}
+
+#[test]
+fn test_setuptools_top_level_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools]
+    zip-safe = false
+    license-files = ["LICENSE"]
+    platforms = ["any"]
+    include-package-data = true
+    packages = ["my_pkg"]
+    py-modules = ["foo", "bar"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    py-modules = [ "bar", "foo" ]
+    packages = [ "my_pkg" ]
+    include-package-data = true
+    platforms = [ "any" ]
+    license-files = [ "LICENSE" ]
+    zip-safe = false
+    "#);
+}
+
+#[test]
+fn test_setuptools_sortable_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools]
+    py-modules = ["zebra", "alpha"]
+    platforms = ["windows", "linux", "darwin"]
+    provides = ["zeta", "alpha"]
+    obsoletes = ["legacy_z", "legacy_a"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    py-modules = [ "alpha", "zebra" ]
+    platforms = [ "darwin", "linux", "windows" ]
+    provides = [ "alpha", "zeta" ]
+    obsoletes = [ "legacy_a", "legacy_z" ]
+    "#);
+}
+
+#[test]
+fn test_setuptools_packages_preserve_order() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools]
+    packages = ["main_pkg", "alpha_pkg", "zebra_pkg"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    packages = [ "main_pkg", "alpha_pkg", "zebra_pkg" ]
+    "#);
+}
+
+#[test]
+fn test_setuptools_packages_find_inner_order() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools.packages.find]
+    namespaces = true
+    exclude = ["tests*", "docs*"]
+    include = ["my_pkg*"]
+    where = ["src"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    packages.find.where = [ "src" ]
+    packages.find.include = [ "my_pkg*" ]
+    packages.find.exclude = [ "docs*", "tests*" ]
+    packages.find.namespaces = true
+    "#);
+}
+
+#[test]
+fn test_setuptools_package_data_star_first_then_alpha() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools.package-data]
+    "zebra_pkg" = ["*.txt", "*.md"]
+    "alpha_pkg" = ["*.json"]
+    "*" = ["*.cfg"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    package-data."*" = [ "*.cfg" ]
+    package-data."alpha_pkg" = [ "*.json" ]
+    package-data."zebra_pkg" = [ "*.md", "*.txt" ]
+    "#);
+}
+
+#[test]
+fn test_setuptools_exclude_package_data_inner_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools.exclude-package-data]
+    "*" = ["zebra.txt", "alpha.txt"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    exclude-package-data."*" = [ "alpha.txt", "zebra.txt" ]
+    "#);
+}
+
+#[test]
+fn test_setuptools_dynamic_field_order_alpha() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools.dynamic]
+    version = { attr = "my_pkg.__version__" }
+    readme = { file = "README.md" }
+    dependencies = { file = "requirements.txt" }
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    dynamic.dependencies = { file = "requirements.txt" }
+    dynamic.readme = { file = "README.md" }
+    dynamic.version = { attr = "my_pkg.__version__" }
+    "#);
+}
+
+#[test]
+fn test_setuptools_dynamic_readme_inline_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools.dynamic]
+    readme = { content-type = "text/markdown", file = "README.md" }
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    dynamic.readme = { file = "README.md", content-type = "text/markdown" }
+    "#);
+}
+
+#[test]
+fn test_setuptools_scm_top_level_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools_scm]
+    fallback_version = "0.0.0"
+    root = ".."
+    local_scheme = "no-local-version"
+    version_scheme = "release-branch-semver"
+    version_file = "src/my_pkg/_version.py"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools_scm]
+    version_file = "src/my_pkg/_version.py"
+    version_scheme = "release-branch-semver"
+    local_scheme = "no-local-version"
+    root = ".."
+    fallback_version = "0.0.0"
+    "#);
+}
+
+#[test]
+fn test_setuptools_scm_deprecated_keys_last() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools_scm]
+    write_to = "src/_version.py"
+    version_scheme = "guess-next-dev"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools_scm]
+    version_scheme = "guess-next-dev"
+    write_to = "src/_version.py"
+    "#);
+}
+
+#[test]
+fn test_setuptools_scm_git_sub_table() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools_scm.scm.git]
+    describe_command = "git describe --dirty --tags --long --match *.*.*"
+    pre_parse = "warn_on_shallow"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools_scm]
+    scm.git.pre_parse = "warn_on_shallow"
+    scm.git.describe_command = "git describe --dirty --tags --long --match *.*.*"
+    "#);
+}
+
+#[test]
+fn test_setuptools_unknown_keys_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools]
+    zzz_unknown = true
+    aaa_unknown = false
+    py-modules = ["foo"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    py-modules = [ "foo" ]
+    aaa_unknown = false
+    zzz_unknown = true
+    "#);
+}
+
+#[test]
+fn test_setuptools_comments_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools]
+    # Top-level module list
+    py-modules = ["foo"]
+    # Include everything
+    include-package-data = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.setuptools]
+    # Top-level module list
+    py-modules = [ "foo" ]
+    # Include everything
+    include-package-data = true
+    "#);
+}
+
+#[test]
+fn test_setuptools_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools]
+    py-modules = [ "alpha", "beta" ]
+    include-package-data = true
+
+    [tool.setuptools.packages.find]
+    where = [ "src" ]
+    include = [ "pkg_*" ]
+
+    [tool.setuptools.dynamic]
+    version = { attr = "pkg.__version__" }
+    readme = { file = "README.md", content-type = "text/markdown" }
+
+    [tool.setuptools_scm]
+    version_file = "src/pkg/_version.py"
+    "#};
+    let once = evaluate_full(start);
+    let twice = evaluate_full(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_setuptools_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "demo"
+    "#);
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let r = format_toml(start, &long_settings());
+    assert_valid_toml(&r);
+    r
+}
+
+#[test]
+fn test_setuptools_long_format_packages_find() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools.packages.find]
+    namespaces = true
+    exclude = ["tests*"]
+    include = ["my_pkg*"]
+    where = ["src"]
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.setuptools.packages.find]"));
+    let w = result.find("where = ").expect("where");
+    let i = result.find("include = ").expect("include");
+    let e = result.find("exclude = ").expect("exclude");
+    let n = result.find("namespaces = ").expect("namespaces");
+    assert!(w < i && i < e && e < n, "key order wrong:\n{result}");
+}
+
+#[test]
+fn test_setuptools_long_format_dynamic_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools.dynamic]
+    version = { attr = "pkg.__version__" }
+    dependencies = { file = "requirements.txt" }
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.setuptools.dynamic]"));
+    let d = result.find("dependencies = ").expect("dependencies");
+    let v = result.find("version = ").expect("version");
+    assert!(d < v, "dynamic fields not alphabetized:\n{result}");
+}
+
+#[test]
+fn test_setuptools_long_format_package_data_star_first() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools.package-data]
+    "zebra" = ["*.txt"]
+    "alpha" = ["*.json"]
+    "*" = ["*.cfg"]
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.setuptools.package-data]"));
+    let star = result.find("\"*\" = ").expect("star");
+    let alpha = result.find("alpha = ").expect("alpha");
+    let zebra = result.find("zebra = ").expect("zebra");
+    assert!(star < alpha && alpha < zebra, "package-data key order wrong:\n{result}");
+}
+
+#[test]
+fn test_setuptools_long_format_cmdclass_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.setuptools.cmdclass]
+    zeta_cmd = "z:Z"
+    alpha_cmd = "a:A"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.setuptools.cmdclass]"));
+    let a = result.find("alpha_cmd = ").expect("alpha_cmd");
+    let z = result.find("zeta_cmd = ").expect("zeta_cmd");
+    assert!(a < z, "cmdclass not alphabetized:\n{result}");
+}


### PR DESCRIPTION
[Setuptools](https://setuptools.pypa.io/) ([pyproject.toml config](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)) is the most-installed Python build backend (around 1.3B downloads/month) and its `[tool.setuptools]` block appears in roughly 12k `pyproject.toml` files on GitHub; [`[tool.setuptools_scm]`](https://setuptools-scm.readthedocs.io/) ([pyproject.toml config](https://setuptools-scm.readthedocs.io/en/latest/config/)) adds another 4k. ✨ Together they're the biggest remaining gap in build-backend coverage now that ruff, uv, and pixi are in. The formatter previously left every key untouched, so a typical setuptools project got canonical ordering for `[project]` and `[build-system]` but nothing for the discovery / data / dynamic / extension keys that make up the actual build configuration.

The `setuptools` handler groups top-level keys to follow the doc structure: packaging discovery (`py-modules`, `packages`, `package-dir`, `packages.find.*`) → package data (`include-package-data`, `package-data`, `exclude-package-data`) → dynamic metadata → extensions and `cmdclass` → distribution metadata (`platforms`, `provides`, `obsoletes`, `license-files`) → discouraged `data-files` → deprecated keys (`script-files`, `namespace-packages`, `zip-safe`, `eager-resources`, `dependency-links`) pushed last. `[tool.setuptools.packages.find]` and `find-namespace` get the canonical `where` → `include` → `exclude` → `namespaces` inner order. `package-data` / `exclude-package-data` / `data-files` tables put the catch-all `\"*\"` key first then alphabetize the rest, with each glob array sorted in place.

🔧 Array sortability follows build semantics. `py-modules`, `platforms`, `provides`, `obsoletes`, and the discouraged single-list keys are alphabetized. `packages` (literal list — first match wins), `license-files` (PEP 639 concatenation order), and everything under `[[ext-modules]]` (compiler/linker argv arrays) are preserved as written. Sorting any of those would silently change the produced wheel.

The `setuptools_scm` handler covers every key from the `Configuration` dataclass in `vcs-versioning/src/vcs_versioning/_config.py`, grouped: version output → computation → root discovery → tag/parse → nested `scm.git.*` → deprecated aliases (`git_describe_command`, `write_to`, `write_to_template`, `version_class`, `template`) pushed last.

For dynamic-directive inline tables (`version = { attr = \"...\" }`, `readme = { file = \"...\", content-type = \"...\" }`) keys are reordered via an `InlineTableSchema` set keyed on `attr` and `content-type` — both are unique enough in pyproject.toml to avoid colliding with inline tables in other sections.

Validated against 29 real-world `pyproject.toml` files sampled from GitHub: all produce valid TOML and round-trip identically through a second pass. One 30th sample exposed a pre-existing non-idempotence in `[project]` blank-line handling that is unrelated to setuptools.

🐛 This PR also carries the same `common` triple-literal string fix as #324 and #325 — both `pyproject-fmt`-specific branches were cut from `upstream/main` independently and several setuptools samples use `'''...'''` regex blocks in `[tool.black]` that would otherwise produce invalid TOML. If #324 lands first, that commit becomes a no-op in the rebase.