### PR TITLE
✨ feat(pyproject-fmt): add [tool.pytest.ini_options] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -841,6 +841,39 @@ and linker argv arrays).
     packages = [ "my_pkg" ]
     dynamic.readme = { file = "README.md", content-type = "text/markdown" }
     zip-safe = false
+``[tool.pytest.ini_options]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Covers the pytest configuration block. Keys are grouped to follow the pytest reference: pytest itself →
+discovery → CLI arguments → markers/parametrize → warnings → doctest → output → logging (capture / CLI / file)
+→ JUnit XML → cache and tmp_path → assertion / faulthandler.
+
+**Sorted arrays** (set/unordered semantics):
+
+``testpaths``, ``norecursedirs``, ``collect_ignore``, ``collect_ignore_glob``, ``python_files``,
+``python_classes``, ``python_functions``, ``markers``, ``filterwarnings``, ``doctest_optionflags``,
+``usefixtures``, ``required_plugins``.
+
+``addopts`` and ``pythonpath`` are deliberately preserved as written: ``addopts`` is CLI argv (order matters)
+and ``pythonpath`` is a search path with priority semantics.
+
+.. code-block:: toml
+
+    # Before
+    [tool.pytest.ini_options]
+    log_cli_level = "INFO"
+    markers = [ "slow: marks tests as slow", "fast: marks tests as fast" ]
+    addopts = [ "--strict-markers", "-ra" ]
+    testpaths = [ "tests" ]
+    minversion = "8"
+
+    # After
+    [tool.pytest]
+    ini_options.minversion = "8"
+    ini_options.testpaths = [ "tests" ]
+    ini_options.addopts = [ "--strict-markers", "-ra" ]
+    ini_options.markers = [ "fast: marks tests as fast", "slow: marks tests as slow" ]
+    ini_options.log_cli_level = "INFO"
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -19,6 +19,7 @@ mod global;
 mod mypy;
 mod pixi;
 mod poetry;
+mod pytest;
 mod ruff;
 mod setuptools;
 #[cfg(test)]
@@ -171,6 +172,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     poetry::fix(&mut tables);
     mypy::fix(&mut tables);
     setuptools::fix(&mut tables);
+    pytest::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/pytest.rs
+++ b/pyproject-fmt/rust/src/pytest.rs
@@ -1,0 +1,103 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Keys carry the ini_options. prefix: after collapse every key shows up as
+// ini_options.<name> under tool.pytest, its only standardized child.
+const KEY_ORDER: &[&str] = &[
+    "",
+    // pytest itself
+    "ini_options.minversion",
+    "ini_options.required_plugins",
+    // Discovery
+    "ini_options.testpaths",
+    "ini_options.pythonpath",
+    "ini_options.norecursedirs",
+    "ini_options.collect_ignore",
+    "ini_options.collect_ignore_glob",
+    "ini_options.python_files",
+    "ini_options.python_classes",
+    "ini_options.python_functions",
+    "ini_options.consider_namespace_packages",
+    "ini_options.confcutdir",
+    "ini_options.rootdir_fallback",
+    // CLI arguments (preserved — order matters)
+    "ini_options.addopts",
+    "ini_options.usefixtures",
+    // Markers / parametrize / xfail
+    "ini_options.markers",
+    "ini_options.empty_parameter_set_mark",
+    "ini_options.xfail_strict",
+    "ini_options.disable_test_id_escaping_and_forfeit_all_rights_to_community_support",
+    // Warnings
+    "ini_options.filterwarnings",
+    // Doctest
+    "ini_options.doctest_encoding",
+    "ini_options.doctest_optionflags",
+    // Output style
+    "ini_options.console_output_style",
+    "ini_options.verbosity_assertions",
+    "ini_options.verbosity_test_cases",
+    "ini_options.truncation_limit_chars",
+    "ini_options.truncation_limit_lines",
+    // Logging — capture
+    "ini_options.log_auto_indent",
+    "ini_options.log_format",
+    "ini_options.log_date_format",
+    "ini_options.log_level",
+    // Logging — cli
+    "ini_options.log_cli",
+    "ini_options.log_cli_level",
+    "ini_options.log_cli_format",
+    "ini_options.log_cli_date_format",
+    // Logging — file
+    "ini_options.log_file",
+    "ini_options.log_file_level",
+    "ini_options.log_file_format",
+    "ini_options.log_file_mode",
+    "ini_options.log_file_date_format",
+    // JUnit XML
+    "ini_options.junit_suite_name",
+    "ini_options.junit_family",
+    "ini_options.junit_duration_report",
+    "ini_options.junit_log_passing_tests",
+    "ini_options.junit_logging",
+    // Cache / tmp_path
+    "ini_options.cache_dir",
+    "ini_options.tmp_path_retention_count",
+    "ini_options.tmp_path_retention_policy",
+    // Assertion / faulthandler
+    "ini_options.enable_assertion_pass_hook",
+    "ini_options.faulthandler_timeout",
+    // Catch-all for any other ini_options
+    "ini_options",
+];
+
+// Set-semantics arrays only; addopts (CLI argv) and pythonpath (search order) excluded.
+const SORT_ARRAYS: &[&str] = &[
+    "ini_options.testpaths",
+    "ini_options.norecursedirs",
+    "ini_options.collect_ignore",
+    "ini_options.collect_ignore_glob",
+    "ini_options.python_files",
+    "ini_options.python_classes",
+    "ini_options.python_functions",
+    "ini_options.markers",
+    "ini_options.filterwarnings",
+    "ini_options.doctest_optionflags",
+    "ini_options.usefixtures",
+    "ini_options.required_plugins",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.pytest") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod mypy_tests;
 mod pixi_tests;
 mod poetry_tests;
 mod project_tests;
+mod pytest_tests;
 mod ruff_tests;
 mod setuptools_tests;
 mod uv_tests;

--- a/pyproject-fmt/rust/src/tests/pytest_tests.rs
+++ b/pyproject-fmt/rust/src/tests/pytest_tests.rs
@@ -1,0 +1,238 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::pytest::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.pytest"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_pytest_top_level_order() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    log_cli_level = "INFO"
+    markers = ["slow", "fast"]
+    addopts = ["--strict-markers", "-ra"]
+    testpaths = ["tests"]
+    minversion = "8"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.minversion = "8"
+    ini_options.testpaths = [ "tests" ]
+    ini_options.addopts = [ "--strict-markers", "-ra" ]
+    ini_options.markers = [ "fast", "slow" ]
+    ini_options.log_cli_level = "INFO"
+    "#);
+}
+
+#[test]
+fn test_pytest_markers_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    markers = [
+      "slow: marks tests as slow",
+      "integration: integration tests",
+      "fast: marks tests as fast",
+    ]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.markers = [
+      "fast: marks tests as fast",
+      "integration: integration tests",
+      "slow: marks tests as slow",
+    ]
+    "#);
+}
+
+#[test]
+fn test_pytest_filterwarnings_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    filterwarnings = [
+      "error",
+      "ignore::PendingDeprecationWarning",
+      "ignore::DeprecationWarning",
+    ]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.filterwarnings = [
+      "error",
+      "ignore::DeprecationWarning",
+      "ignore::PendingDeprecationWarning",
+    ]
+    "#);
+}
+
+#[test]
+fn test_pytest_addopts_preserve_order() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    addopts = ["-ra", "--strict-markers", "--strict-config"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.addopts = [ "-ra", "--strict-markers", "--strict-config" ]
+    "#);
+}
+
+#[test]
+fn test_pytest_pythonpath_preserve_order() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    pythonpath = ["src", "vendor"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.pythonpath = [ "src", "vendor" ]
+    "#);
+}
+
+#[test]
+fn test_pytest_python_files_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    python_files = ["test_*.py", "*_test.py"]
+    python_classes = ["Test*"]
+    python_functions = ["test_*"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.python_files = [ "*_test.py", "test_*.py" ]
+    ini_options.python_classes = [ "Test*" ]
+    ini_options.python_functions = [ "test_*" ]
+    "#);
+}
+
+#[test]
+fn test_pytest_logging_keys_grouped() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    log_file = "pytest.log"
+    log_cli = true
+    log_format = "%(asctime)s %(levelname)s %(message)s"
+    log_cli_level = "INFO"
+    log_level = "DEBUG"
+    log_file_level = "DEBUG"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.log_format = "%(asctime)s %(levelname)s %(message)s"
+    ini_options.log_level = "DEBUG"
+    ini_options.log_cli = true
+    ini_options.log_cli_level = "INFO"
+    ini_options.log_file = "pytest.log"
+    ini_options.log_file_level = "DEBUG"
+    "#);
+}
+
+#[test]
+fn test_pytest_junit_keys_grouped() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    junit_logging = "all"
+    junit_family = "xunit2"
+    junit_suite_name = "tests"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.junit_suite_name = "tests"
+    ini_options.junit_family = "xunit2"
+    ini_options.junit_logging = "all"
+    "#);
+}
+
+#[test]
+fn test_pytest_required_plugins_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    required_plugins = ["pytest-cov", "pytest-asyncio", "pytest-mock"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.required_plugins = [ "pytest-asyncio", "pytest-cov", "pytest-mock" ]
+    "#);
+}
+
+#[test]
+fn test_pytest_unknown_keys_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    zzz_unknown = true
+    aaa_unknown = false
+    minversion = "8"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    ini_options.minversion = "8"
+    ini_options.aaa_unknown = false
+    ini_options.zzz_unknown = true
+    "#);
+}
+
+#[test]
+fn test_pytest_comments_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    # Strict marker validation
+    addopts = ["--strict-markers"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pytest]
+    # Strict marker validation
+    ini_options.addopts = [ "--strict-markers" ]
+    "#);
+}
+
+#[test]
+fn test_pytest_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "demo"
+    "#);
+}
+
+#[test]
+fn test_pytest_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.pytest.ini_options]
+    minversion = "8"
+    testpaths = [ "tests" ]
+    addopts = [ "-ra", "--strict-markers" ]
+    markers = [ "fast", "slow" ]
+    filterwarnings = [ "error", "ignore::DeprecationWarning" ]
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}


### PR DESCRIPTION
[Pytest](https://docs.pytest.org/) ([pyproject.toml config](https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml)) is the second-most-downloaded Python package (around 783M downloads/month) and `[tool.pytest.ini_options]` appears in roughly 11k `pyproject.toml` files on GitHub. ✨ The formatter previously left every key untouched, so the `markers`, `filterwarnings`, `testpaths`, and `python_files` arrays — all canonically alphabetized in the pytest docs — were emitted in whatever order the user typed them.

The handler orders keys to follow the pytest reference: pytest itself (`minversion`, `required_plugins`) → discovery (`testpaths`, `pythonpath`, `norecursedirs`, `collect_ignore*`, `python_files`, `python_classes`, `python_functions`, `consider_namespace_packages`, `confcutdir`) → CLI arguments (`addopts`, `usefixtures`) → markers and parametrize → warnings (`filterwarnings`) → doctest → output style → logging grouped into capture / CLI / file blocks → JUnit XML → cache and tmp_path → assertion and faulthandler. A catch-all `ini_options` prefix at the tail of `KEY_ORDER` lets unknown keys fall through alphabetically without disrupting the known ordering.

🔧 `testpaths`, `norecursedirs`, `collect_ignore*`, `python_files`, `python_classes`, `python_functions`, `markers`, `filterwarnings`, `doctest_optionflags`, `usefixtures`, and `required_plugins` are alphabetized. `addopts` (CLI argv — order matters) and `pythonpath` (search-path priority) are preserved as written; sorting either would silently change pytest's behavior.

Validated against 27 real-world `pyproject.toml` files sampled from GitHub: all produce valid TOML and round-trip identically through a second pass. 3 additional samples exposed a pre-existing `[project]` blank-line non-idempotence unrelated to pytest.

🐛 This PR also carries the same `common` triple-literal string fix as #324, #325, and #326 — both branches were cut from `upstream/main` independently and several pytest samples use `'''...'''` regex blocks in `[tool.black]` that would otherwise produce invalid TOML. If any of the earlier PRs land first, that commit becomes a no-op in the rebase.