### PR TITLE
✨ feat(pyproject-fmt): add [tool.black] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -874,6 +874,20 @@ and ``pythonpath`` is a search path with priority semantics.
     ini_options.addopts = [ "--strict-markers", "-ra" ]
     ini_options.markers = [ "fast: marks tests as fast", "slow: marks tests as slow" ]
     ini_options.log_cli_level = "INFO"
+``[tool.black]``
+~~~~~~~~~~~~~~~~
+
+Black's configuration is small but ubiquitous. Keys are ordered: ``required-version`` → ``target-version`` →
+``line-length`` → ``include`` / ``extend-exclude`` / ``force-exclude`` / ``exclude`` → behavior flags
+(``skip-string-normalization``, ``skip-magic-trailing-comma``, ``preview``, ``unstable``,
+``enable-unstable-feature``, ``fast``, ``workers``) → output (``color``, ``verbose``, ``quiet``).
+
+**Sorted arrays:**
+
+- ``target-version``: alphabetized so ``py39`` precedes ``py310`` etc.
+- ``enable-unstable-feature``: alphabetized.
+
+The ``include`` / ``exclude`` family are regex strings, not arrays, so they're left as-is.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/black.rs
+++ b/pyproject-fmt/rust/src/black.rs
@@ -1,0 +1,39 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Group: meta → length → targets → include/exclude → behavior flags → output.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "required-version",
+    "target-version",
+    "line-length",
+    "include",
+    "extend-exclude",
+    "force-exclude",
+    "exclude",
+    "skip-string-normalization",
+    "skip-magic-trailing-comma",
+    "preview",
+    "unstable",
+    "enable-unstable-feature",
+    "fast",
+    "workers",
+    "color",
+    "verbose",
+    "quiet",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.black") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| match key.as_str() {
+        "target-version" | "enable-unstable-feature" => {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+        _ => {}
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -14,6 +14,7 @@ mod dependency_groups;
 mod project;
 
 mod commitizen;
+mod black;
 mod coverage;
 mod global;
 mod mypy;
@@ -173,6 +174,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     mypy::fix(&mut tables);
     setuptools::fix(&mut tables);
     pytest::fix(&mut tables);
+    black::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/black_tests.rs
+++ b/pyproject-fmt/rust/src/tests/black_tests.rs
@@ -1,0 +1,131 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::black::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.black"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_black_top_level_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.black]
+    workers = 4
+    preview = true
+    skip-magic-trailing-comma = false
+    skip-string-normalization = false
+    extend-exclude = "/tests/"
+    target-version = ["py311", "py310"]
+    line-length = 88
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.black]
+    target-version = [ "py310", "py311" ]
+    line-length = 88
+    extend-exclude = "/tests/"
+    skip-string-normalization = false
+    skip-magic-trailing-comma = false
+    preview = true
+    workers = 4
+    "#);
+}
+
+#[test]
+fn test_black_target_version_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.black]
+    target-version = ["py313", "py39", "py312", "py310", "py311"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.black]
+    target-version = [ "py39", "py310", "py311", "py312", "py313" ]
+    "#);
+}
+
+#[test]
+fn test_black_required_version_first() {
+    let start = indoc::indoc! {r#"
+    [tool.black]
+    line-length = 88
+    required-version = "24.10"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.black]
+    required-version = "24.10"
+    line-length = 88
+    "#);
+}
+
+#[test]
+fn test_black_unknown_keys_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.black]
+    zzz_unknown = true
+    aaa_unknown = false
+    line-length = 88
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.black]
+    line-length = 88
+    aaa_unknown = false
+    zzz_unknown = true
+    "#);
+}
+
+#[test]
+fn test_black_comments_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.black]
+    # Target older Pythons
+    target-version = ["py39"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.black]
+    # Target older Pythons
+    target-version = [ "py39" ]
+    "#);
+}
+
+#[test]
+fn test_black_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.black]
+    target-version = [ "py310", "py311" ]
+    line-length = 88
+    extend-exclude = "/tests/"
+    preview = true
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_black_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "demo"
+    "#);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -2,6 +2,7 @@ use tombi_syntax::SyntaxElement;
 
 pub use common::test_util::{assert_valid_toml, format_syntax, format_toml_str, parse};
 
+mod black_tests;
 mod build_systems_tests;
 mod commitizen_tests;
 mod coverage_tests;


### PR DESCRIPTION
[Black](https://black.readthedocs.io/) ([pyproject.toml config](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file)) is one of the most-installed Python tools (around 124M downloads/month) and `[tool.black]` is the third-most-frequent table in `pyproject.toml` on GitHub (~15k files). ✨ Schema is small — about a dozen keys — but the absence of canonical ordering meant black configs were the one place a formatted `pyproject.toml` still showed user-chosen key order. This brings black in line with ruff, uv, and the other tool sections.

Order follows black's CLI reference: `required-version` → `target-version` → `line-length` → the include/exclude regex family → behavior flags (`skip-string-normalization`, `skip-magic-trailing-comma`, `preview`, `unstable`, `enable-unstable-feature`, `fast`, `workers`) → output flags (`color`, `verbose`, `quiet`).

`target-version` and `enable-unstable-feature` are alphabetized using natural-lexical sort so `py39` precedes `py310`. The `include` / `extend-exclude` / `force-exclude` / `exclude` family are regex strings, not arrays, so they're untouched.

Validated against 29 real-world `pyproject.toml` files sampled from GitHub: all produce valid TOML and round-trip identically through a second pass.

🐛 This PR also carries the same `common` triple-literal string fix as #324 — both branches were cut from `upstream/main` independently. If any of the earlier PRs land first, that commit becomes a no-op in the rebase.