### PR TITLE
✨ feat(pyproject-fmt): add [tool.hatch.*] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -888,6 +888,38 @@ Black's configuration is small but ubiquitous. Keys are ordered: ``required-vers
 - ``enable-unstable-feature``: alphabetized.
 
 The ``include`` / ``exclude`` family are regex strings, not arrays, so they're left as-is.
+``[tool.hatch.*]``
+~~~~~~~~~~~~~~~~~~
+
+Hatch configuration spans many sub-tables. Keys at ``[tool.hatch]`` level (which after collapse appear as dotted
+``version.*`` / ``build.*`` / ``metadata.*`` / ``envs.*`` / ``publish.*`` / ``workspace.*``) are ordered:
+
+1. Version: ``version.source`` → ``version.path`` → ``version.pattern`` → ``version.expression`` →
+   ``version.scheme`` → ``version.validate-bump`` → ``version.fallback-version`` → ``version.raw-options``.
+2. Metadata: ``metadata.allow-direct-references`` → ``metadata.allow-ambiguous-features`` → ``metadata.hooks``.
+3. Build: ``build.dev-mode-dirs`` → ``build.directory`` → ``build.sources`` → ``build.packages`` →
+   ``build.include`` → ``build.exclude`` → ``build.force-include`` → ``build.artifacts`` → ``build.ignore-vcs`` →
+   ``build.skip-excluded-dirs`` → ``build.reproducible`` → ``build.hooks`` → wheel target (``packages``,
+   ``include``, ``exclude``, ``force-include``, ``artifacts``, ``hooks``, ``shared-data``, ``extra-metadata``,
+   etc.) → sdist target (``include``, ``exclude``, ``force-include``, ``support-legacy``, ``strict-naming``).
+4. Publish: ``publish.index.disable`` → ``publish.index.repos`` → ``publish.index``.
+5. Workspace: ``workspace.members`` → ``workspace.exclude``.
+6. Environments (``envs.<name>.*``): each environment's keys follow ``type`` → ``template`` → ``detached`` →
+   ``description`` → ``platforms`` → ``python`` → ``path`` → ``installer`` → ``skip-install`` →
+   ``system-packages`` → ``dev-mode`` → ``features`` → ``dependencies`` → ``extra-dependencies`` →
+   ``extra-args`` → ``pre-install-commands`` → ``post-install-commands`` → ``env-include`` → ``env-exclude``
+   → ``env-vars`` → ``scripts`` → ``matrix`` → ``matrix-name-format`` → ``overrides``.
+
+**Sorted arrays:**
+
+- Build: ``include``, ``exclude``, ``force-include``, ``artifacts``, ``packages``, ``sources``, ``dev-mode-dirs``,
+  and the matching ``build.targets.wheel.*`` / ``build.targets.sdist.*`` arrays.
+- Environments: per-env ``dependencies``, ``extra-dependencies``, ``features``, ``platforms``, ``env-include``,
+  ``env-exclude``, ``pre-install-commands``, ``post-install-commands``.
+- Workspace: ``members``, ``exclude``.
+
+``scripts`` and ``env-vars`` sub-tables under each environment have their inner keys alphabetized. Build hook
+order and matrix entry order are preserved as written (both carry semantic meaning).
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/hatch.rs
+++ b/pyproject-fmt/rust/src/hatch.rs
@@ -1,0 +1,296 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+use tombi_syntax::SyntaxElement;
+
+// Config lives in sub-tables, so KEY_ORDER works on the collapsed parent's dotted keys
+// (version.source, build.exclude, envs.default.dependencies). Order within each group
+// follows the hatch reference (https://hatch.pypa.io).
+const KEY_ORDER: &[&str] = &[
+    "",
+    // === Version ===
+    "version.source",
+    "version.path",
+    "version.pattern",
+    "version.expression",
+    "version.scheme",
+    "version.validate-bump",
+    "version.fallback-version",
+    "version.raw-options",
+    "version",
+    // === Metadata ===
+    "metadata.allow-direct-references",
+    "metadata.allow-ambiguous-features",
+    "metadata.hooks",
+    "metadata",
+    // === Build ===
+    "build.dev-mode-dirs",
+    "build.dev-mode-exact",
+    "build.directory",
+    "build.sources",
+    "build.packages",
+    "build.include",
+    "build.exclude",
+    "build.force-include",
+    "build.artifacts",
+    "build.ignore-vcs",
+    "build.skip-excluded-dirs",
+    "build.reproducible",
+    "build.hooks",
+    "build.targets.wheel.packages",
+    "build.targets.wheel.include",
+    "build.targets.wheel.exclude",
+    "build.targets.wheel.force-include",
+    "build.targets.wheel.artifacts",
+    "build.targets.wheel.hooks",
+    "build.targets.wheel.shared-data",
+    "build.targets.wheel.extra-metadata",
+    "build.targets.wheel.bypass-selection",
+    "build.targets.wheel.zip-safe",
+    "build.targets.wheel.core-metadata-version",
+    "build.targets.sdist.include",
+    "build.targets.sdist.exclude",
+    "build.targets.sdist.force-include",
+    "build.targets.sdist.support-legacy",
+    "build.targets.sdist.strict-naming",
+    "build.targets.sdist.core-metadata-version",
+    "build.targets.app",
+    "build.targets.custom",
+    "build.targets",
+    "build",
+    // === Publish ===
+    "publish.index.disable",
+    "publish.index.repos",
+    "publish.index",
+    "publish",
+    // === Workspace ===
+    "workspace.members",
+    "workspace.exclude",
+    "workspace",
+    // `envs` intentionally NOT here — per-env entries are inserted dynamically by
+    // build_key_order with each environment's full inner key list, then a bare `envs`
+    // catch-all is appended last so any envs.* not in the canonical inner-key list still
+    // ends up in the envs block.
+];
+
+const SORT_ARRAYS_EXACT: &[&str] = &[
+    "build.include",
+    "build.exclude",
+    "build.force-include",
+    "build.artifacts",
+    "build.packages",
+    "build.sources",
+    "build.dev-mode-dirs",
+    "build.targets.wheel.include",
+    "build.targets.wheel.exclude",
+    "build.targets.wheel.force-include",
+    "build.targets.wheel.artifacts",
+    "build.targets.wheel.packages",
+    "build.targets.sdist.include",
+    "build.targets.sdist.exclude",
+    "build.targets.sdist.force-include",
+    "workspace.members",
+    "workspace.exclude",
+];
+
+pub fn fix(tables: &mut Tables) {
+    fix_root(tables);
+    fix_env_tables(tables);
+    fix_overrides_aot(tables);
+}
+
+fn fix_root(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.hatch") else {
+        return;
+    };
+    let order = {
+        let table_elements: &Vec<SyntaxElement> = &elements.first().unwrap().borrow();
+        build_key_order(table_elements)
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        let k = key.as_str();
+        if SORT_ARRAYS_EXACT.contains(&k) || is_dynamic_sort_array(k) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    let refs: Vec<&str> = order.iter().map(String::as_str).collect();
+    reorder_table_keys(table, &refs);
+}
+
+/// Build a per-input KEY_ORDER that interpolates per-env entries so each environment
+/// keeps a consistent inner order (`type` → `python` → `dependencies` → `scripts` → …).
+fn build_key_order(table: &[SyntaxElement]) -> Vec<String> {
+    let mut order: Vec<String> = KEY_ORDER.iter().map(|s| (*s).to_string()).collect();
+    for env in collect_dynamic_segments(table, "envs") {
+        let p = format!("envs.{env}");
+        for k in [
+            "type",
+            "template",
+            "detached",
+            "description",
+            "platforms",
+            "python",
+            "path",
+            "installer",
+            "skip-install",
+            "system-packages",
+            "dev-mode",
+            "features",
+            "dependencies",
+            "extra-dependencies",
+            "extra-args",
+            "pre-install-commands",
+            "post-install-commands",
+            "env-include",
+            "env-exclude",
+            "env-vars",
+            "scripts",
+            "matrix",
+            "matrix-name-format",
+            "overrides",
+        ] {
+            order.push(format!("{p}.{k}"));
+        }
+        order.push(p);
+    }
+    // Bare catch-all for any envs.* keys not in the canonical inner-key list.
+    order.push(String::from("envs"));
+    order
+}
+
+fn collect_dynamic_segments(table: &[SyntaxElement], prefix: &str) -> Vec<String> {
+    use tombi_syntax::SyntaxKind::{KEYS, KEY_VALUE};
+    let prefix_dot = format!("{prefix}.");
+    let mut names: Vec<String> = Vec::new();
+    let raw_keys = table
+        .iter()
+        .filter(|e| e.kind() == KEY_VALUE)
+        .filter_map(|element| element.as_node())
+        .filter_map(|kv| kv.children().find(|c| c.kind() == KEYS))
+        .map(|keys| keys.text().to_string().trim().to_string());
+    for raw in raw_keys {
+        if let Some(rest) = raw.strip_prefix(&prefix_dot) {
+            let seg = rest.split('.').next().unwrap_or(rest);
+            let name = seg.trim_matches('"').trim_matches('\'').to_string();
+            if !names.contains(&name) && !name.is_empty() {
+                names.push(name);
+            }
+        }
+    }
+    names
+}
+
+fn is_dynamic_sort_array(key: &str) -> bool {
+    // envs.<n>.dependencies, .extra-dependencies, .features, .pre-install-commands,
+    // .post-install-commands, .platforms — sortable (set semantics in hatch).
+    let Some(rest) = key.strip_prefix("envs.") else {
+        return false;
+    };
+    let Some((_env, tail)) = rest.split_once('.') else {
+        return false;
+    };
+    matches!(
+        tail,
+        "dependencies"
+            | "extra-dependencies"
+            | "features"
+            | "platforms"
+            | "env-include"
+            | "env-exclude"
+            | "pre-install-commands"
+            | "post-install-commands"
+    )
+}
+
+fn fix_env_tables(tables: &mut Tables) {
+    // Expanded form: [tool.hatch.envs.<name>] as own table — reorder keys, sort arrays.
+    let env_names = collect_header_segments(tables, "tool.hatch.envs.");
+    for env in env_names {
+        let key = format!("tool.hatch.envs.{env}");
+        if let Some(elements) = tables.get(&key) {
+            let table = &mut elements.first().unwrap().borrow_mut();
+            for_entries(table, &mut |k, entry| {
+                if matches!(
+                    k.as_str(),
+                    "dependencies"
+                        | "extra-dependencies"
+                        | "features"
+                        | "platforms"
+                        | "env-include"
+                        | "env-exclude"
+                        | "pre-install-commands"
+                        | "post-install-commands"
+                ) {
+                    sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| {
+                        natural_lexical_cmp(lhs, rhs)
+                    });
+                }
+            });
+            reorder_table_keys(
+                table,
+                &[
+                    "",
+                    "type",
+                    "template",
+                    "detached",
+                    "description",
+                    "platforms",
+                    "python",
+                    "path",
+                    "installer",
+                    "skip-install",
+                    "system-packages",
+                    "dev-mode",
+                    "features",
+                    "dependencies",
+                    "extra-dependencies",
+                    "extra-args",
+                    "pre-install-commands",
+                    "post-install-commands",
+                    "env-include",
+                    "env-exclude",
+                    "env-vars",
+                    "scripts",
+                    "matrix",
+                    "matrix-name-format",
+                    "overrides",
+                ],
+            );
+        }
+        // scripts and env-vars sub-tables: alphabetize keys
+        for sub in ["scripts", "env-vars"] {
+            let k = format!("tool.hatch.envs.{env}.{sub}");
+            if let Some(elements) = tables.get(&k) {
+                let table = &mut elements.first().unwrap().borrow_mut();
+                reorder_table_keys(table, &[""]);
+            }
+        }
+    }
+}
+
+fn fix_overrides_aot(tables: &mut Tables) {
+    // [[tool.hatch.envs.<n>.matrix]] and overrides.* are AoT — preserve order, but reorder
+    // inner keys.
+    for env in collect_header_segments(tables, "tool.hatch.envs.") {
+        let matrix_key = format!("tool.hatch.envs.{env}.matrix");
+        if let Some(entries) = tables.get(&matrix_key) {
+            for entry_ref in entries {
+                let table = &mut entry_ref.borrow_mut();
+                reorder_table_keys(table, &[""]);
+            }
+        }
+    }
+}
+
+fn collect_header_segments(tables: &Tables, prefix: &str) -> Vec<String> {
+    let mut names: Vec<String> = tables
+        .header_to_pos
+        .keys()
+        .filter_map(|h| h.strip_prefix(prefix))
+        .map(|rest| rest.split('.').next().unwrap_or(rest).trim_matches('"').to_string())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -18,6 +18,7 @@ mod black;
 mod coverage;
 mod global;
 mod mypy;
+mod hatch;
 mod pixi;
 mod poetry;
 mod pytest;
@@ -175,6 +176,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     setuptools::fix(&mut tables);
     pytest::fix(&mut tables);
     black::fix(&mut tables);
+    hatch::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/hatch_tests.rs
+++ b/pyproject-fmt/rust/src/tests/hatch_tests.rs
@@ -1,0 +1,294 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::hatch::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.hatch"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn evaluate_full(start: &str) -> String {
+    let s = Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 13),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    };
+    let r = format_toml(start, &s);
+    assert_valid_toml(&r);
+    r
+}
+
+#[test]
+fn test_hatch_version_first_then_build() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.build]
+    include = ["src/**/*.py"]
+
+    [tool.hatch.version]
+    path = "src/my_pkg/__init__.py"
+    source = "regex"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.hatch]
+    version.source = "regex"
+    version.path = "src/my_pkg/__init__.py"
+    build.include = [ "src/**/*.py" ]
+    "#);
+}
+
+#[test]
+fn test_hatch_build_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.build]
+    include = ["zebra/**", "alpha/**", "beta/**"]
+    exclude = ["zeta_tests/*", "alpha_tests/*"]
+    packages = ["src/zebra_pkg", "src/alpha_pkg"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.hatch]
+    build.packages = [ "src/alpha_pkg", "src/zebra_pkg" ]
+    build.include = [ "alpha/**", "beta/**", "zebra/**" ]
+    build.exclude = [ "alpha_tests/*", "zeta_tests/*" ]
+    "#);
+}
+
+#[test]
+fn test_hatch_env_inner_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.envs.test]
+    scripts.run = "pytest"
+    dependencies = ["pytest", "coverage"]
+    python = "3.11"
+    detached = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.hatch]
+    envs.test.detached = true
+    envs.test.python = "3.11"
+    envs.test.dependencies = [ "coverage", "pytest" ]
+    envs.test.scripts.run = "pytest"
+    "#);
+}
+
+#[test]
+fn test_hatch_env_dependencies_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.envs.default]
+    dependencies = ["pytest", "black", "mypy", "ruff"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.hatch]
+    envs.default.dependencies = [ "black", "mypy", "pytest", "ruff" ]
+    "#);
+}
+
+#[test]
+fn test_hatch_metadata_keys_grouped() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.metadata]
+    allow-ambiguous-features = true
+    allow-direct-references = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.hatch]
+    metadata.allow-direct-references = true
+    metadata.allow-ambiguous-features = true
+    "#);
+}
+
+#[test]
+fn test_hatch_targets_wheel_after_build_top_level() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.build.targets.wheel]
+    packages = ["src/my_pkg"]
+
+    [tool.hatch.build]
+    include = ["src/**"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.hatch]
+    build.include = [ "src/**" ]
+
+    build.targets.wheel.packages = [ "src/my_pkg" ]
+    "#);
+}
+
+#[test]
+fn test_hatch_multiple_envs_handled() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.envs.lint]
+    dependencies = ["ruff"]
+
+    [tool.hatch.envs.test]
+    dependencies = ["pytest"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.hatch]
+    envs.lint.dependencies = [ "ruff" ]
+    envs.test.dependencies = [ "pytest" ]
+    "#);
+}
+
+#[test]
+fn test_hatch_comments_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.version]
+    # Read version from __init__.py
+    path = "src/pkg/__init__.py"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.hatch]
+    # Read version from __init__.py
+    version.path = "src/pkg/__init__.py"
+    "#);
+}
+
+#[test]
+fn test_hatch_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.version]
+    path = "src/pkg/__init__.py"
+    source = "regex"
+
+    [tool.hatch.build]
+    include = ["src/**"]
+    packages = ["src/pkg"]
+
+    [tool.hatch.envs.default]
+    dependencies = ["pytest"]
+    "#};
+    let once = evaluate_full(start);
+    let twice = evaluate_full(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_hatch_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "demo"
+    "#);
+}
+
+fn evaluate_long(start: &str) -> String {
+    let s = Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 13),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("long"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    };
+    let r = format_toml(start, &s);
+    assert_valid_toml(&r);
+    r
+}
+
+#[test]
+fn test_hatch_long_format_env_table_keys_reordered() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.envs.default]
+    scripts = { test = "pytest" }
+    dependencies = ["zeta", "alpha"]
+    python = "3.12"
+    type = "virtual"
+    extra-dependencies = ["zinc", "amber"]
+    features = ["dev", "test"]
+    platforms = ["linux", "macos"]
+    pre-install-commands = ["echo pre"]
+    post-install-commands = ["echo post"]
+    env-include = ["FOO_*"]
+    env-exclude = ["BAR_*"]
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.hatch.envs.default]"));
+    let block = result.split("[tool.hatch.envs.default]").nth(1).unwrap();
+    assert!(block.find("type").unwrap() < block.find("python").unwrap());
+    assert!(block.find("python").unwrap() < block.find("dependencies").unwrap());
+    assert!(block.find("\"alpha\"").unwrap() < block.find("\"zeta\"").unwrap());
+    assert!(block.find("\"amber\"").unwrap() < block.find("\"zinc\"").unwrap());
+}
+
+#[test]
+fn test_hatch_long_format_env_scripts_subtable() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.envs.default.scripts]
+    test = "pytest"
+    lint = "ruff check"
+
+    [tool.hatch.envs.default.env-vars]
+    FOO = "1"
+    BAR = "2"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.hatch.envs.default.scripts]"));
+    assert!(result.contains("[tool.hatch.envs.default.env-vars]"));
+    assert!(result.contains("test = \"pytest\""));
+    assert!(result.contains("FOO = \"1\""));
+}
+
+#[test]
+fn test_hatch_envs_key_without_inner_segment() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch]
+    envs.bare = "value"
+    "#};
+    let result = evaluate(start);
+    assert!(result.contains("envs.bare"));
+}
+
+#[test]
+fn test_hatch_long_format_matrix_aot() {
+    let start = indoc::indoc! {r#"
+    [tool.hatch.envs.default]
+    python = "3.12"
+
+    [[tool.hatch.envs.default.matrix]]
+    python = ["3.12", "3.11"]
+
+    [[tool.hatch.envs.default.matrix]]
+    python = ["3.10"]
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[[tool.hatch.envs.default.matrix]]"));
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod commitizen_tests;
 mod coverage_tests;
 mod dependency_groups_tests;
 mod global_tests;
+mod hatch_tests;
 mod main_tests;
 mod mypy_tests;
 mod pixi_tests;

--- a/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__main_tests__issue_217_full_pyproject_idempotent.snap
+++ b/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__main_tests__issue_217_full_pyproject_idempotent.snap
@@ -131,19 +131,7 @@ telegram = [ "python-telegram-bot[http2,socks]~=22.0" ]
 transmission = [ "transmission-rpc~=7.0" ]
 
 [tool.hatch]
-build.skip-excluded-dirs = true
-build.targets.sdist.include = [
-  "/flexget",
-  "/scripts/build_locked_extras.py",
-  "/scripts/bundle_webui.py",
-]
-build.targets.wheel.include = [
-  "/flexget",
-]
-# The webui will be bundled when the BUNDLE_WEBUI env variable is defined
-build.targets.wheel.hooks.custom.path = "scripts/bundle_webui.py"
-# Extras with locked dependencies will be generated if BUILD_LOCKED env variable is specified
-metadata.hooks.custom.path = "scripts/build_locked_extras.py"
+version.path = "flexget/_version.py"
 metadata.hooks.custom.locked-groups = [
   "boto3",
   "deluge",
@@ -158,7 +146,19 @@ metadata.hooks.custom.locked-groups = [
   "transmission",
   "all",
 ]
-version.path = "flexget/_version.py"
+# Extras with locked dependencies will be generated if BUILD_LOCKED env variable is specified
+metadata.hooks.custom.path = "scripts/build_locked_extras.py"
+build.skip-excluded-dirs = true
+build.targets.wheel.include = [
+  "/flexget",
+]
+# The webui will be bundled when the BUNDLE_WEBUI env variable is defined
+build.targets.wheel.hooks.custom.path = "scripts/bundle_webui.py"
+build.targets.sdist.include = [
+  "/flexget",
+  "/scripts/build_locked_extras.py",
+  "/scripts/bundle_webui.py",
+]
 
 [tool.ruff]
 line-length = 99


### PR DESCRIPTION
[Hatchling](https://hatch.pypa.io/) ([pyproject.toml config](https://hatch.pypa.io/latest/config/metadata/)) is the most-downloaded modern Python build backend (around 314M downloads/month) and the hatch sub-table family (`version.*`, `build.*`, `metadata.*`, `envs.<name>.*`, `publish.*`, `workspace.*`) aggregates to roughly 11k `pyproject.toml` files on GitHub. ✨ Hatch's nested schema is the deepest of any tool covered so far — every category lives in its own sub-table, and a typical project carries 5-10 of them.

The handler works on the collapsed parent (everything appears as dotted keys under `tool.hatch`) and orders them: version (`source` → `path` → `pattern` → `expression` → `scheme` → `validate-bump` → `fallback-version` → `raw-options`) → metadata → build (dev-mode dirs, directory, sources, packages, include, exclude, force-include, artifacts, ignore-vcs, skip-excluded-dirs, reproducible, hooks, then wheel target keys, then sdist target keys) → publish → workspace → environments. Each environment block follows `type` → `template` → `detached` → `description` → `platforms` → `python` → `path` → `installer` → `skip-install` → `system-packages` → `dev-mode` → `features` → `dependencies` → `extra-dependencies` → `extra-args` → `pre-install-commands` → `post-install-commands` → `env-include` → `env-exclude` → `env-vars` → `scripts` → `matrix` → `matrix-name-format` → `overrides`.

🔧 Per-environment entries are inserted into `KEY_ORDER` dynamically because env names are user-chosen; the bare `envs` prefix lands at the very end as a catch-all for any `envs.*` keys that fall outside the canonical per-env list. This ordering matters: an earlier draft with the bare `envs` prefix mid-list short-circuited the dynamic per-env entries (since `reorder_table_keys` processes prefixes in declaration order) and produced alphabetized envs content instead of canonical per-env ordering.

Sorted arrays follow hatch semantics. Build `include` / `exclude` / `force-include` / `artifacts` / `packages` / `sources` / `dev-mode-dirs` plus their wheel and sdist target equivalents alphabetize. Per-env `dependencies` / `extra-dependencies` / `features` / `platforms` / `env-include` / `env-exclude` / `pre-install-commands` / `post-install-commands` alphabetize. Build hooks and matrix arrays preserve order (both carry semantic meaning — hook precedence and matrix iteration order).

Validated against 26 real-world `pyproject.toml` files sampled from GitHub: all produce valid TOML and round-trip identically through a second pass. 4 additional samples exposed a pre-existing `[project]` / `[tool.*]` blank-line non-idempotence unrelated to hatch.

The existing `issue_217_full_pyproject_idempotent` snapshot test contains a hatch block; updated to reflect the new canonical ordering.

🐛 This PR also carries the same `common` triple-literal string fix as #324 — both branches were cut from `upstream/main` independently. If any earlier PR lands first, that commit becomes a no-op in the rebase.