### PR TITLE
🐛 fix(ci): use --frozen so uv version skips workspace re-lock

### DIFF
--- a/.github/workflows/toml_fmt_common_build.yaml
+++ b/.github/workflows/toml_fmt_common_build.yaml
@@ -68,7 +68,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: 🔖 Bump version
         if: github.event.inputs.release != 'no' && github.event.inputs.release != null
-        run: uv version --no-sync --bump "$RELEASE_TYPE"
+        run: uv version --frozen --bump "$RELEASE_TYPE"
         env:
           RELEASE_TYPE: ${{ github.event.inputs.release }}
       - name: 📝 Generate changelog
@@ -107,7 +107,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0 # zizmor: ignore[cache-poisoning]
       - name: 🔖 Bump version
         working-directory: toml-fmt-common
-        run: uv version --no-sync --bump "$RELEASE_TYPE"
+        run: uv version --frozen --bump "$RELEASE_TYPE"
         env:
           RELEASE_TYPE: ${{ github.event.inputs.release }}
       - name: 💾 Commit release


### PR DESCRIPTION
Dispatching the `📦 toml-fmt-common` release workflow keeps failing on the 🔖 Bump version step. The previous fix in #322 reached for `--no-sync`, but that flag only skips the post-lock venv install — uv still re-locks the workspace, which resolves metadata for every member. `pyproject-fmt` uses the maturin backend and its `readme` field points at a `README.rst` that is generated at build time by a tox env, so the file is absent from source and `prepare_metadata_for_build_editable` aborts before the version bump ever finishes. Run 26557205628 is the latest example.

Switching to `--frozen` skips both the re-lock and the sync, so `uv version` only rewrites `toml-fmt-common/pyproject.toml`, which is the only edit the bump step needs. The lock stays internally consistent because nothing else changes in the same command; the subsequent `uv build` step still picks up the new version when it resolves the workspace for the wheel build.

Reproduced locally against the current tree: `uv version --no-sync --bump patch` triggers the maturin/`README.rst` error, while `uv version --frozen --bump patch` succeeds and only touches `toml-fmt-common/pyproject.toml`.