### PR TITLE
✨ feat(pyproject-fmt): add [tool.isort] handler

### DIFF
--- a/ignore-words.txt
+++ b/ignore-words.txt
@@ -1,2 +1,3 @@
 crate
+thirdparty
 writeable

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -920,6 +920,25 @@ Hatch configuration spans many sub-tables. Keys at ``[tool.hatch]`` level (which
 
 ``scripts`` and ``env-vars`` sub-tables under each environment have their inner keys alphabetized. Build hook
 order and matrix entry order are preserved as written (both carry semantic meaning).
+``[tool.isort]``
+~~~~~~~~~~~~~~~~
+
+Covers the isort import sorter. ``profile`` first (it sets defaults that everything else overrides), then output
+style (line/wrap/indent/multi-line options), then known sources (``sections`` → ``default_section`` →
+``known_standard_library`` / ``extra_standard_library`` / ``known_third_party`` / ``known_first_party`` /
+``known_local_folder`` / ``known_other``), then forced separation, skip patterns, import add/remove, and section
+heading comments.
+
+**Sorted arrays:**
+
+``known_standard_library``, ``extra_standard_library``, ``known_third_party``, ``known_first_party``,
+``known_local_folder``, ``known_other``, ``namespace_packages``, ``src_paths``, ``skip``, ``skip_glob``,
+``extend_skip``, ``extend_skip_glob``, ``supported_extensions``, ``blocked_extensions``,
+``single_line_exclusions``, ``forced_separate``, ``treat_comments_as_code``, ``treat_all_comments_as_code``,
+``constants``, ``variables``.
+
+Order-sensitive arrays preserved as written: ``sections`` (output section sequence), ``no_lines_before``,
+``add_imports``, ``remove_imports``, ``required_imports``, ``force_to_top``.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/isort.rs
+++ b/pyproject-fmt/rust/src/isort.rs
@@ -1,0 +1,145 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// profile leads since it sets defaults everything else overrides. sections, force_to_top,
+// and import_heading_* keep their input order, which drives output section sequencing.
+const KEY_ORDER: &[&str] = &[
+    "",
+    // Defaults / global
+    "profile",
+    "py_version",
+    "atomic",
+    "color_output",
+    "quiet",
+    "verbose",
+    // Output style
+    "line_length",
+    "wrap_length",
+    "indent",
+    "multi_line_output",
+    "balanced_wrapping",
+    "use_parentheses",
+    "include_trailing_comma",
+    "force_single_line",
+    "force_grid_wrap",
+    "single_line_exclusions",
+    "force_alphabetical_sort",
+    "force_alphabetical_sort_within_sections",
+    "force_sort_within_sections",
+    "force_to_top",
+    "lexicographical",
+    "length_sort",
+    "length_sort_straight",
+    "length_sort_sections",
+    "order_by_type",
+    "case_sensitive",
+    "reverse_relative",
+    "reverse_sort",
+    "sort_relative_in_force_sorted_sections",
+    "honor_case_in_force_sorted_sections",
+    "ensure_newline_before_comments",
+    "lines_after_imports",
+    "lines_before_imports",
+    "lines_between_sections",
+    "lines_between_types",
+    "split_on_trailing_comma",
+    "combine_as_imports",
+    "combine_star",
+    "no_inline_sort",
+    "from_first",
+    "float_to_top",
+    "honor_noqa",
+    "old_finders",
+    // Known sources
+    "sections",
+    "default_section",
+    "no_lines_before",
+    "known_standard_library",
+    "extra_standard_library",
+    "known_third_party",
+    "known_first_party",
+    "known_local_folder",
+    "known_other",
+    "namespace_packages",
+    "known_pattern",
+    // Forced separation
+    "forced_separate",
+    "treat_comments_as_code",
+    "treat_all_comments_as_code",
+    // Skip / include
+    "src_paths",
+    "skip",
+    "skip_glob",
+    "extend_skip",
+    "extend_skip_glob",
+    "skip_gitignore",
+    "supported_extensions",
+    "blocked_extensions",
+    // Imports add/remove/required
+    "add_imports",
+    "remove_imports",
+    "required_imports",
+    "append_only",
+    "dedup_headings",
+    // Section heading comments
+    "section_comments",
+    "import_heading_future",
+    "import_heading_stdlib",
+    "import_heading_thirdparty",
+    "import_heading_firstparty",
+    "import_heading_localfolder",
+    // Constants / variables
+    "constants",
+    "variables",
+    // Format / virtual envs / overrides
+    "format_error",
+    "format_success",
+    "virtual_env",
+    "conda_env",
+    // Output / cache
+    "filter_files",
+    "show_diff",
+    "show_files",
+    "check",
+    "stop",
+    "verbose_output",
+];
+
+// Set-semantics arrays only; order-sensitive keys (sections, force_to_top, *_imports,
+// no_lines_before) are excluded because they define section sequencing.
+const SORT_ARRAYS: &[&str] = &[
+    "known_standard_library",
+    "extra_standard_library",
+    "known_third_party",
+    "known_first_party",
+    "known_local_folder",
+    "known_other",
+    "namespace_packages",
+    "src_paths",
+    "skip",
+    "skip_glob",
+    "extend_skip",
+    "extend_skip_glob",
+    "supported_extensions",
+    "blocked_extensions",
+    "single_line_exclusions",
+    "forced_separate",
+    "treat_comments_as_code",
+    "treat_all_comments_as_code",
+    "constants",
+    "variables",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.isort") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -19,6 +19,7 @@ mod coverage;
 mod global;
 mod mypy;
 mod hatch;
+mod isort;
 mod pixi;
 mod poetry;
 mod pytest;
@@ -177,6 +178,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     pytest::fix(&mut tables);
     black::fix(&mut tables);
     hatch::fix(&mut tables);
+    isort::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/isort_tests.rs
+++ b/pyproject-fmt/rust/src/tests/isort_tests.rs
@@ -1,0 +1,172 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::isort::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.isort"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_isort_profile_first() {
+    let start = indoc::indoc! {r#"
+    [tool.isort]
+    line_length = 100
+    multi_line_output = 3
+    profile = "black"
+    include_trailing_comma = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.isort]
+    profile = "black"
+    line_length = 100
+    multi_line_output = 3
+    include_trailing_comma = true
+    "#);
+}
+
+#[test]
+fn test_isort_known_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.isort]
+    known_first_party = ["my_pkg", "another_pkg", "alpha"]
+    known_third_party = ["zebra_lib", "alpha_lib"]
+    known_standard_library = ["typing", "asyncio"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.isort]
+    known_standard_library = [ "asyncio", "typing" ]
+    known_third_party = [ "alpha_lib", "zebra_lib" ]
+    known_first_party = [ "alpha", "another_pkg", "my_pkg" ]
+    "#);
+}
+
+#[test]
+fn test_isort_skip_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.isort]
+    skip = ["zebra.py", "alpha.py"]
+    skip_glob = ["**/migrations/*", "**/vendor/*"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.isort]
+    skip = [ "alpha.py", "zebra.py" ]
+    skip_glob = [ "**/migrations/*", "**/vendor/*" ]
+    "#);
+}
+
+#[test]
+fn test_isort_sections_preserve_order() {
+    let start = indoc::indoc! {r#"
+    [tool.isort]
+    sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.isort]
+    sections = [ "FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER" ]
+    "#);
+}
+
+#[test]
+fn test_isort_add_imports_preserve_order() {
+    let start = indoc::indoc! {r#"
+    [tool.isort]
+    add_imports = ["from __future__ import annotations", "import sys"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.isort]
+    add_imports = [ "from __future__ import annotations", "import sys" ]
+    "#);
+}
+
+#[test]
+fn test_isort_section_headings_after_known_sources() {
+    let start = indoc::indoc! {r#"
+    [tool.isort]
+    import_heading_stdlib = "Standard library"
+    profile = "black"
+    known_first_party = ["my_pkg"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.isort]
+    profile = "black"
+    known_first_party = [ "my_pkg" ]
+    import_heading_stdlib = "Standard library"
+    "#);
+}
+
+#[test]
+fn test_isort_unknown_keys_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.isort]
+    zzz_unknown = true
+    aaa_unknown = false
+    profile = "black"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.isort]
+    profile = "black"
+    aaa_unknown = false
+    zzz_unknown = true
+    "#);
+}
+
+#[test]
+fn test_isort_comments_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.isort]
+    # Match black
+    profile = "black"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.isort]
+    # Match black
+    profile = "black"
+    "#);
+}
+
+#[test]
+fn test_isort_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.isort]
+    profile = "black"
+    line_length = 88
+    known_first_party = [ "my_pkg", "another_pkg" ]
+    skip = [ "build", "dist" ]
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_isort_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "demo"
+    "#);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod coverage_tests;
 mod dependency_groups_tests;
 mod global_tests;
 mod hatch_tests;
+mod isort_tests;
 mod main_tests;
 mod mypy_tests;
 mod pixi_tests;


### PR DESCRIPTION
[Isort](https://pycqa.github.io/isort/) ([pyproject.toml config](https://pycqa.github.io/isort/docs/configuration/config_files.html)) has 8k+ `[tool.isort]` blocks on GitHub and a ~140-option config schema, much of it array-valued. ✨ Even though ruff's isort module has absorbed most new configurations, the standalone tool still ships a large config surface and existing isort-only projects benefit from canonical ordering and array normalization.

Keys are ordered: `profile` first (it sets defaults that everything else overrides), then output style (line/wrap/indent/multi-line options), then known sources (`sections` → `default_section` → `known_*` family), then forced separation, skip patterns, import add/remove, and section heading comments.

🔧 The known-source arrays (`known_standard_library`, `extra_standard_library`, `known_third_party`, `known_first_party`, `known_local_folder`, `known_other`, `namespace_packages`), skip arrays (`src_paths`, `skip`, `skip_glob`, `extend_skip`, `extend_skip_glob`, `supported_extensions`, `blocked_extensions`), and the assorted constants/variables/forced_separate lists alphabetize. `sections` (output section sequence), `no_lines_before`, `add_imports`, `remove_imports`, `required_imports`, and `force_to_top` preserve order because each carries semantic meaning.

Validated against 29 real-world `pyproject.toml` files sampled from GitHub: all produce valid TOML and round-trip identically through a second pass. One 30th sample had a malformed Poetry version specifier (`\"=^4.1.1\"`) that crashed the PEP 508 parser; that's an input bug, not an isort issue.

🐛 This PR also carries the same `common` triple-literal string fix as #324. If any earlier PR lands first, that commit becomes a no-op in the rebase.