### PR TITLE
✨ feat(pyproject-fmt): add [tool.pyright] + [tool.basedpyright] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -939,6 +939,22 @@ heading comments.
 
 Order-sensitive arrays preserved as written: ``sections`` (output section sequence), ``no_lines_before``,
 ``add_imports``, ``remove_imports``, ``required_imports``, ``force_to_top``.
+``[tool.pyright]`` and ``[tool.basedpyright]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both type checkers share the same configuration schema. Keys are ordered: platform/interpreter
+(``pythonVersion`` → ``pythonPlatform`` → ``pythonPath`` → ``venv`` → ``venvPath`` → ``typeshedPath`` →
+``stubPath``) → mode flags (``typeCheckingMode`` → ``strict`` → ``failOnWarnings`` →
+``useLibraryCodeForTypes``) → paths (``include`` → ``exclude`` → ``ignore`` → ``extraPaths``) → strict-flavor
+toggles (``strictListInference``, ``strictDictionaryInference``, ``strictSetInference``,
+``strictParameterNoneValue``, ``enableExperimentalFeatures``, ``enableTypeIgnoreComments``,
+``analyzeUnannotatedFunctions``, ``disableBytesTypePromotions``, ``deprecateTypingAliases``) →
+``defineConstant`` → **all ``report*`` rules alphabetized** → ``executionEnvironments`` (last).
+
+The ``report*`` rules (70+ in pyright; basedpyright adds more) are collected from the input and inserted
+alphabetically rather than hardcoded, so new diagnostic rules don't require formatter changes.
+
+**Sorted arrays:** ``include``, ``exclude``, ``ignore``, ``extraPaths``, ``strict``.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -23,6 +23,7 @@ mod isort;
 mod pixi;
 mod poetry;
 mod pytest;
+mod pyright;
 mod ruff;
 mod setuptools;
 #[cfg(test)]
@@ -179,6 +180,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     black::fix(&mut tables);
     hatch::fix(&mut tables);
     isort::fix(&mut tables);
+    pyright::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/pyright.rs
+++ b/pyproject-fmt/rust/src/pyright.rs
@@ -1,0 +1,98 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+use tombi_syntax::SyntaxElement;
+
+// Shared schema for [tool.pyright] and [tool.basedpyright].
+const KEY_ORDER_PRE_REPORTS: &[&str] = &[
+    "",
+    // Platform / interpreter
+    "pythonVersion",
+    "pythonPlatform",
+    "pythonPath",
+    "venv",
+    "venvPath",
+    "typeshedPath",
+    "stubPath",
+    // Mode flags
+    "typeCheckingMode",
+    "strict",
+    "failOnWarnings",
+    "useLibraryCodeForTypes",
+    // Paths
+    "include",
+    "exclude",
+    "ignore",
+    "extraPaths",
+    // Strict-flavor toggles
+    "strictListInference",
+    "strictDictionaryInference",
+    "strictSetInference",
+    "strictParameterNoneValue",
+    "enableExperimentalFeatures",
+    "enableTypeIgnoreComments",
+    "analyzeUnannotatedFunctions",
+    "disableBytesTypePromotions",
+    "deprecateTypingAliases",
+    // Constants
+    "defineConstant",
+];
+
+// report* rules are inserted between PRE and POST; this block trails them.
+const KEY_ORDER_POST_REPORTS: &[&str] = &["executionEnvironments"];
+
+const SORT_ARRAYS: &[&str] = &["include", "exclude", "ignore", "extraPaths", "strict"];
+
+pub fn fix(tables: &mut Tables) {
+    for table_name in ["tool.pyright", "tool.basedpyright"] {
+        fix_one(tables, table_name);
+    }
+}
+
+fn fix_one(tables: &mut Tables, table_name: &str) {
+    let Some(elements) = tables.get(table_name) else {
+        return;
+    };
+    let order = {
+        let table_elements: &Vec<SyntaxElement> = &elements.first().unwrap().borrow();
+        build_key_order(table_elements)
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    let refs: Vec<&str> = order.iter().map(String::as_str).collect();
+    reorder_table_keys(table, &refs);
+}
+
+/// Build a per-input KEY_ORDER. Pre-report keys are static; report* rules are collected
+/// from the input table and inserted alphabetized between the static blocks. This handles
+/// pyright's 70+ diagnostic rules plus any basedpyright extensions without hardcoding
+/// the full list (which evolves between releases).
+fn build_key_order(table: &[SyntaxElement]) -> Vec<String> {
+    use tombi_syntax::SyntaxKind::{KEYS, KEY_VALUE};
+    let mut order: Vec<String> = KEY_ORDER_PRE_REPORTS.iter().map(|s| (*s).to_string()).collect();
+
+    let mut report_keys: Vec<String> = Vec::new();
+    let key_names = table
+        .iter()
+        .filter(|e| e.kind() == KEY_VALUE)
+        .filter_map(|element| element.as_node())
+        .filter_map(|kv| kv.children().find(|c| c.kind() == KEYS))
+        .map(|keys| {
+            let raw = keys.text().to_string().trim().to_string();
+            raw.split('.').next().unwrap_or(&raw).trim_matches('"').to_string()
+        });
+    for name in key_names {
+        if name.starts_with("report") && !report_keys.contains(&name) {
+            report_keys.push(name);
+        }
+    }
+    report_keys.sort_by(|a, b| natural_lexical_cmp(&a.to_lowercase(), &b.to_lowercase()));
+    order.extend(report_keys);
+
+    order.extend(KEY_ORDER_POST_REPORTS.iter().map(|s| (*s).to_string()));
+    order
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod pixi_tests;
 mod poetry_tests;
 mod project_tests;
 mod pytest_tests;
+mod pyright_tests;
 mod ruff_tests;
 mod setuptools_tests;
 mod uv_tests;

--- a/pyproject-fmt/rust/src/tests/pyright_tests.rs
+++ b/pyproject-fmt/rust/src/tests/pyright_tests.rs
@@ -1,0 +1,179 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::pyright::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.pyright", "tool.basedpyright"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_pyright_top_level_key_order() {
+    let start = indoc::indoc! {r#"
+    [tool.pyright]
+    strict = ["strict_file.py"]
+    typeCheckingMode = "strict"
+    pythonVersion = "3.12"
+    exclude = ["build"]
+    include = ["src"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyright]
+    pythonVersion = "3.12"
+    typeCheckingMode = "strict"
+    strict = [ "strict_file.py" ]
+    include = [ "src" ]
+    exclude = [ "build" ]
+    "#);
+}
+
+#[test]
+fn test_pyright_path_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.pyright]
+    include = ["zebra", "alpha"]
+    exclude = ["build", "dist", "**/.venv"]
+    ignore = ["zeta/*.py", "alpha/*.py"]
+    extraPaths = ["src", "stubs"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyright]
+    include = [ "alpha", "zebra" ]
+    exclude = [ "**/.venv", "build", "dist" ]
+    ignore = [ "alpha/*.py", "zeta/*.py" ]
+    extraPaths = [ "src", "stubs" ]
+    "#);
+}
+
+#[test]
+fn test_pyright_report_rules_alphabetized() {
+    let start = indoc::indoc! {r#"
+    [tool.pyright]
+    reportUnusedVariable = "warning"
+    reportMissingImports = "error"
+    reportGeneralTypeIssues = "error"
+    pythonVersion = "3.11"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyright]
+    pythonVersion = "3.11"
+    reportGeneralTypeIssues = "error"
+    reportMissingImports = "error"
+    reportUnusedVariable = "warning"
+    "#);
+}
+
+#[test]
+fn test_pyright_strict_toggles_after_paths() {
+    let start = indoc::indoc! {r#"
+    [tool.pyright]
+    strictListInference = true
+    enableExperimentalFeatures = true
+    include = ["src"]
+    pythonVersion = "3.12"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyright]
+    pythonVersion = "3.12"
+    include = [ "src" ]
+    strictListInference = true
+    enableExperimentalFeatures = true
+    "#);
+}
+
+#[test]
+fn test_pyright_execution_environments_last() {
+    let start = indoc::indoc! {r#"
+    [tool.pyright]
+    executionEnvironments = [{ root = "src" }]
+    pythonVersion = "3.12"
+    reportMissingImports = "error"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyright]
+    pythonVersion = "3.12"
+    reportMissingImports = "error"
+    executionEnvironments = [ { root = "src" } ]
+    "#);
+}
+
+#[test]
+fn test_basedpyright_uses_same_schema() {
+    let start = indoc::indoc! {r#"
+    [tool.basedpyright]
+    reportMissingImports = "error"
+    failOnWarnings = true
+    typeCheckingMode = "all"
+    pythonVersion = "3.13"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.basedpyright]
+    pythonVersion = "3.13"
+    typeCheckingMode = "all"
+    failOnWarnings = true
+    reportMissingImports = "error"
+    "#);
+}
+
+#[test]
+fn test_pyright_unknown_keys_alphabetized_after_known() {
+    let start = indoc::indoc! {r#"
+    [tool.pyright]
+    zzz_unknown = true
+    aaa_unknown = false
+    pythonVersion = "3.12"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyright]
+    pythonVersion = "3.12"
+    aaa_unknown = false
+    zzz_unknown = true
+    "#);
+}
+
+#[test]
+fn test_pyright_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.pyright]
+    pythonVersion = "3.12"
+    typeCheckingMode = "strict"
+    include = [ "src" ]
+    exclude = [ "build" ]
+    reportMissingImports = "error"
+    reportUnusedVariable = "warning"
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_pyright_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "demo"
+    "#);
+}


### PR DESCRIPTION
[Pyright](https://microsoft.github.io/pyright/) ([pyproject.toml config](https://microsoft.github.io/pyright/#/configuration)) is Microsoft's Python type checker (around 33M downloads/month) and [basedpyright](https://docs.basedpyright.com/) ([pyproject.toml config](https://docs.basedpyright.com/latest/configuration/config-files/)) is a community fork that extends pyright's diagnostic rules. Together they appear in ~6.7k `pyproject.toml` files on GitHub. ✨ Both share the same configuration schema (basedpyright is a superset), so one handler covers both. Without the handler the 70+ `report*` diagnostic-rule keys ended up in whatever order the user typed them — the single biggest quality-of-life win available for type-checker config.

Keys are ordered: platform/interpreter (`pythonVersion`, `pythonPlatform`, `pythonPath`, `venv`, `venvPath`, `typeshedPath`, `stubPath`) → mode flags (`typeCheckingMode`, `strict`, `failOnWarnings`, `useLibraryCodeForTypes`) → paths (`include`, `exclude`, `ignore`, `extraPaths`) → strict-flavor toggles → `defineConstant` → all `report*` rules alphabetized → `executionEnvironments` last.

🔧 The `report*` rules are collected from the input table and inserted alphabetized rather than hardcoded. Both projects release new diagnostic rules frequently; this approach means they land in the right place without a formatter update.

The `include`, `exclude`, `ignore`, `extraPaths`, and `strict` arrays alphabetize. Other keys are scalars.

🐛 This PR also carries the same `common` triple-literal string fix as #324. If any earlier PR lands first, that commit becomes a no-op in the rebase.