### PR TITLE
✨ feat(pyproject-fmt): add [tool.pdm.*] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -955,6 +955,24 @@ The ``report*`` rules (70+ in pyright; basedpyright adds more) are collected fro
 alphabetically rather than hardcoded, so new diagnostic rules don't require formatter changes.
 
 **Sorted arrays:** ``include``, ``exclude``, ``ignore``, ``extraPaths``, ``strict``.
+``[tool.pdm.*]``
+~~~~~~~~~~~~~~~~
+
+Covers PDM. Top-level ordering: distribution / package-type / plugins → resolution → version → build →
+scripts → source → dev-dependencies → publish → options.
+
+**Sub-table ordering** (collapsed to dotted keys):
+
+- ``version``: ``source`` → ``path`` → ``getter`` → ``write_to`` → ``write_template`` → ``tag_regex`` →
+  ``tag_filter`` → ``fallback_version`` → ``version_format``.
+- ``build``: ``includes`` → ``excludes`` → ``source-includes`` → ``package-dir`` → ``is-purelib`` →
+  ``run-setuptools`` → ``custom-hook`` → ``editable-backend``.
+- ``[[tool.pdm.source]]`` (AoT, preserve array order): per-entry ``name`` → ``url`` → ``type`` →
+  ``verify_ssl`` → ``include_packages`` → ``exclude_packages``.
+
+**Sorted arrays:** ``plugins``, ``build.includes``, ``build.excludes``, ``build.source-includes``,
+``resolution.excludes``, every ``dev-dependencies.<group>`` value array, and ``include_packages`` /
+``exclude_packages`` inside source entries.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -20,6 +20,7 @@ mod global;
 mod mypy;
 mod hatch;
 mod isort;
+mod pdm;
 mod pixi;
 mod poetry;
 mod pytest;
@@ -181,6 +182,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     hatch::fix(&mut tables);
     isort::fix(&mut tables);
     pyright::fix(&mut tables);
+    pdm::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/pdm.rs
+++ b/pyproject-fmt/rust/src/pdm.rs
@@ -1,0 +1,143 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Sub-tables collapse to dotted keys (version.source, build.includes, etc.).
+const KEY_ORDER: &[&str] = &[
+    "",
+    // Distribution / project mode
+    "distribution",
+    "package-type",
+    "plugins",
+    // Resolution
+    "resolution.respect-source-order",
+    "resolution.allow-prereleases",
+    "resolution.excludes",
+    "resolution.overrides",
+    "resolution",
+    // Version (collapsed sub-table)
+    "version.source",
+    "version.path",
+    "version.getter",
+    "version.write_to",
+    "version.write_template",
+    "version.tag_regex",
+    "version.tag_filter",
+    "version.fallback_version",
+    "version.version_format",
+    "version",
+    // Build (collapsed sub-table)
+    "build.includes",
+    "build.excludes",
+    "build.source-includes",
+    "build.package-dir",
+    "build.is-purelib",
+    "build.run-setuptools",
+    "build.custom-hook",
+    "build.editable-backend",
+    "build",
+    // Scripts
+    "scripts",
+    // Sources (legacy non-AoT form)
+    "source",
+    // Dev / dependency groups
+    "dev-dependencies",
+    // Publish
+    "publish.repository",
+    "publish.username",
+    "publish.password",
+    "publish.ca_certs",
+    "publish.verify_ssl",
+    "publish",
+    // Options
+    "options.install",
+    "options.lock",
+    "options.update",
+    "options.add",
+    "options.remove",
+    "options.list",
+    "options.sync",
+    "options.run",
+    "options",
+];
+
+const SORT_ARRAYS_EXACT: &[&str] = &[
+    "plugins",
+    "build.includes",
+    "build.excludes",
+    "build.source-includes",
+    "resolution.excludes",
+];
+
+pub fn fix(tables: &mut Tables) {
+    fix_root(tables);
+    fix_expanded_scripts(tables);
+    fix_expanded_dev_dependencies(tables);
+    fix_source_aot(tables);
+}
+
+fn fix_root(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.pdm") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        let k = key.as_str();
+        if SORT_ARRAYS_EXACT.contains(&k) || is_dev_deps_value(k) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}
+
+fn is_dev_deps_value(key: &str) -> bool {
+    if let Some(rest) = key.strip_prefix("dev-dependencies.") {
+        return !rest.is_empty();
+    }
+    false
+}
+
+fn fix_expanded_scripts(tables: &mut Tables) {
+    if let Some(elements) = tables.get("tool.pdm.scripts") {
+        let table = &mut elements.first().unwrap().borrow_mut();
+        reorder_table_keys(table, &[""]);
+    }
+}
+
+fn fix_expanded_dev_dependencies(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.pdm.dev-dependencies") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |_key, entry| {
+        sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+    });
+    reorder_table_keys(table, &[""]);
+}
+
+fn fix_source_aot(tables: &mut Tables) {
+    let Some(entries) = tables.get("tool.pdm.source") else {
+        return;
+    };
+    for entry_ref in entries {
+        let table = &mut entry_ref.borrow_mut();
+        for_entries(table, &mut |key, entry| match key.as_str() {
+            "include_packages" | "exclude_packages" => {
+                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            }
+            _ => {}
+        });
+        reorder_table_keys(
+            table,
+            &[
+                "",
+                "name",
+                "url",
+                "type",
+                "verify_ssl",
+                "include_packages",
+                "exclude_packages",
+            ],
+        );
+    }
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod hatch_tests;
 mod isort_tests;
 mod main_tests;
 mod mypy_tests;
+mod pdm_tests;
 mod pixi_tests;
 mod poetry_tests;
 mod project_tests;

--- a/pyproject-fmt/rust/src/tests/pdm_tests.rs
+++ b/pyproject-fmt/rust/src/tests/pdm_tests.rs
@@ -1,0 +1,193 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::pdm::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.pdm"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_pdm_top_level_order() {
+    let start = indoc::indoc! {r#"
+    [tool.pdm.build]
+    includes = ["src/**"]
+
+    [tool.pdm.version]
+    source = "scm"
+
+    [tool.pdm]
+    distribution = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pdm]
+    distribution = true
+    version.source = "scm"
+    build.includes = [ "src/**" ]
+    "#);
+}
+
+#[test]
+fn test_pdm_build_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.pdm.build]
+    includes = ["zebra/**", "alpha/**"]
+    excludes = ["tests/*"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pdm]
+    build.includes = [ "alpha/**", "zebra/**" ]
+    build.excludes = [ "tests/*" ]
+    "#);
+}
+
+#[test]
+fn test_pdm_dev_dependencies_inner_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.pdm.dev-dependencies]
+    test = ["pytest", "coverage"]
+    lint = ["ruff", "black"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pdm]
+    dev-dependencies.lint = [ "black", "ruff" ]
+    dev-dependencies.test = [ "coverage", "pytest" ]
+    "#);
+}
+
+#[test]
+fn test_pdm_source_aot_key_order() {
+    let start = indoc::indoc! {r#"
+    [[tool.pdm.source]]
+    verify_ssl = false
+    type = "find_links"
+    url = "https://example.com/links"
+    name = "internal"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pdm]
+    source = [ { verify_ssl = false, type = "find_links", url = "https://example.com/links", name = "internal" } ]
+    "#);
+}
+
+#[test]
+fn test_pdm_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.pdm]
+    distribution = true
+    version.source = "scm"
+    build.includes = [ "src/**" ]
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_pdm_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "demo"
+    "#);
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_pdm_long_format_scripts() {
+    let start = indoc::indoc! {r#"
+    [tool.pdm.scripts]
+    test = "pytest"
+    lint = "ruff check"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.pdm.scripts]"));
+    assert!(result.contains("test = \"pytest\""));
+    assert!(result.contains("lint = \"ruff check\""));
+}
+
+#[test]
+fn test_pdm_long_format_dev_dependencies() {
+    let start = indoc::indoc! {r#"
+    [tool.pdm.dev-dependencies]
+    test = ["pytest", "coverage"]
+    lint = ["ruff", "black"]
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.pdm.dev-dependencies]"));
+    let block = result.split("[tool.pdm.dev-dependencies]").nth(1).unwrap();
+    assert!(block.find("\"black\"").unwrap() < block.find("\"ruff\"").unwrap());
+    assert!(block.find("\"coverage\"").unwrap() < block.find("\"pytest\"").unwrap());
+}
+
+#[test]
+fn test_pdm_long_format_source_aot() {
+    let start = indoc::indoc! {r#"
+    [[tool.pdm.source]]
+    verify_ssl = false
+    exclude_packages = ["zeta", "alpha"]
+    type = "find_links"
+    include_packages = ["zinc", "amber"]
+    url = "https://example.com/links"
+    name = "internal"
+    extra = "value"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[[tool.pdm.source]]"));
+    let block = result.split("[[tool.pdm.source]]").nth(1).unwrap();
+    assert!(block.find("name").unwrap() < block.find("url").unwrap());
+    assert!(block.find("url").unwrap() < block.find("type").unwrap());
+    assert!(block.find("type").unwrap() < block.find("verify_ssl").unwrap());
+    assert!(block.find("verify_ssl").unwrap() < block.find("include_packages").unwrap());
+    assert!(block.find("\"amber\"").unwrap() < block.find("\"zinc\"").unwrap());
+    assert!(block.find("\"alpha\"").unwrap() < block.find("\"zeta\"").unwrap());
+}


### PR DESCRIPTION
[PDM](https://pdm-project.org/) ([pyproject.toml config](https://backend.pdm-project.org/build_config/)) is a substantial Python package manager (around 10M downloads/month) with ~5,500 `pyproject.toml` files using `[tool.pdm.*]` on GitHub. ✨ The handler covers all the common sub-tables: distribution mode, resolution, version (scm/file/call sources), build (includes/excludes/source-includes/package-dir/is-purelib/run-setuptools/editable-backend), scripts, source (AoT for private indexes), dev-dependencies, publish, and options.

Top-level keys group: distribution → resolution → version → build → scripts → source → dev-dependencies → publish → options. Each sub-table follows the order shown in the PDM reference.

🔧 `build.includes`, `build.excludes`, `build.source-includes`, `plugins`, `resolution.excludes`, every `dev-dependencies.<group>` array, and source entry `include_packages` / `exclude_packages` are alphabetized. `[[tool.pdm.source]]` entries get their keys ordered `name` → `url` → `type` → `verify_ssl` → `include_packages` → `exclude_packages`; the array order itself is preserved (PDM resolves sources in declared order).

🐛 This PR also carries the same `common` triple-literal string fix as #324. If any earlier PR lands first, that commit becomes a no-op in the rebase.