### PR TITLE
✨ feat(pyproject-fmt): add [tool.cibuildwheel] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -973,6 +973,25 @@ scripts → source → dev-dependencies → publish → options.
 **Sorted arrays:** ``plugins``, ``build.includes``, ``build.excludes``, ``build.source-includes``,
 ``resolution.excludes``, every ``dev-dependencies.<group>`` value array, and ``include_packages`` /
 ``exclude_packages`` inside source entries.
+``[tool.cibuildwheel]``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Covers cibuildwheel. Top-level ordering: selection (``build``, ``skip``, ``test-skip``, ``archs``, ``enable``,
+``free-threaded-support``) → build configuration (``build-frontend``, ``build-verbosity``, ``config-settings``,
+``dependency-versions``, ``environment``, ``environment-pass``) → build phases (``before-all``, ``before-build``,
+``repair-wheel-command``) → test phases (``before-test``, ``test-command``, ``test-requires``, ``test-extras``,
+``test-groups``, ``test-sources``) → platform images (``manylinux-*-image``, ``musllinux-*-image``) →
+``container-engine`` → per-platform sub-tables (``linux``, ``macos``, ``windows``, ``android``, ``ios``,
+``pyodide``) → ``overrides`` last.
+
+Per-platform sub-tables follow the same inner ordering. ``[[tool.cibuildwheel.overrides]]`` entries place
+``select`` first (required), then the regular cibuildwheel keys; the array order itself is preserved (later
+overrides win).
+
+**Sorted arrays:** ``enable``, ``test-extras``, ``test-groups``.
+
+Most other array-valued keys (``test-requires``, ``before-all``, ``test-command``, the various ``environment*``
+fields) are CLI argv or ordered lists and are preserved as written.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/cibuildwheel.rs
+++ b/pyproject-fmt/rust/src/cibuildwheel.rs
@@ -1,0 +1,102 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    // Selection
+    "build",
+    "skip",
+    "test-skip",
+    "archs",
+    "enable",
+    "free-threaded-support",
+    // Build configuration
+    "build-frontend",
+    "build-verbosity",
+    "config-settings",
+    "dependency-versions",
+    "environment",
+    "environment-pass",
+    // Build phases
+    "before-all",
+    "before-build",
+    "repair-wheel-command",
+    // Test phases
+    "before-test",
+    "test-command",
+    "test-requires",
+    "test-extras",
+    "test-groups",
+    "test-sources",
+    // Platform images
+    "manylinux-x86_64-image",
+    "manylinux-i686-image",
+    "manylinux-aarch64-image",
+    "manylinux-ppc64le-image",
+    "manylinux-s390x-image",
+    "manylinux-armv7l-image",
+    "manylinux-pypy_x86_64-image",
+    "manylinux-pypy_i686-image",
+    "manylinux-pypy_aarch64-image",
+    "musllinux-x86_64-image",
+    "musllinux-i686-image",
+    "musllinux-aarch64-image",
+    "musllinux-ppc64le-image",
+    "musllinux-s390x-image",
+    "musllinux-armv7l-image",
+    // Engine
+    "container-engine",
+    // Per-platform sub-tables (collapsed)
+    "linux",
+    "macos",
+    "windows",
+    "android",
+    "ios",
+    "pyodide",
+    // Overrides last
+    "overrides",
+];
+
+// Most arrays are CLI argv (order matters); only these are set semantics.
+const SORT_ARRAYS: &[&str] = &["enable", "test-extras", "test-groups"];
+
+pub fn fix(tables: &mut Tables) {
+    fix_one(tables, "tool.cibuildwheel");
+    // Per-platform tables follow the same order when not collapsed into the parent.
+    for plat in ["linux", "macos", "windows", "android", "ios", "pyodide"] {
+        fix_one(tables, &format!("tool.cibuildwheel.{plat}"));
+    }
+    fix_overrides_aot(tables);
+}
+
+fn fix_one(tables: &mut Tables, table_name: &str) {
+    let Some(elements) = tables.get(table_name) else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}
+
+fn fix_overrides_aot(tables: &mut Tables) {
+    let Some(entries) = tables.get("tool.cibuildwheel.overrides") else {
+        return;
+    };
+    for entry_ref in entries {
+        let table = &mut entry_ref.borrow_mut();
+        for_entries(table, &mut |key, entry| {
+            if SORT_ARRAYS.contains(&key.as_str()) {
+                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            }
+        });
+        // `select` always first (required), then the regular cibuildwheel keys.
+        let mut order: Vec<&str> = vec!["", "select"];
+        order.extend(KEY_ORDER.iter().filter(|k| !k.is_empty() && **k != "overrides"));
+        reorder_table_keys(table, &order);
+    }
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -15,6 +15,7 @@ mod project;
 
 mod commitizen;
 mod black;
+mod cibuildwheel;
 mod coverage;
 mod global;
 mod mypy;
@@ -183,6 +184,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     isort::fix(&mut tables);
     pyright::fix(&mut tables);
     pdm::fix(&mut tables);
+    cibuildwheel::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/cibuildwheel_tests.rs
+++ b/pyproject-fmt/rust/src/tests/cibuildwheel_tests.rs
@@ -1,0 +1,193 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::cibuildwheel::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.cibuildwheel"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_cibw_selection_first() {
+    let start = indoc::indoc! {r#"
+    [tool.cibuildwheel]
+    test-command = "pytest {project}/tests"
+    archs = ["x86_64", "arm64"]
+    skip = ["pp*"]
+    build = "cp3{10,11,12}-*"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.cibuildwheel]
+    build = "cp3{10,11,12}-*"
+    skip = [ "pp*" ]
+    archs = [ "x86_64", "arm64" ]
+    test-command = "pytest {project}/tests"
+    "#);
+}
+
+#[test]
+fn test_cibw_enable_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.cibuildwheel]
+    enable = ["pypy", "cpython-prerelease", "cpython-freethreading"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.cibuildwheel]
+    enable = [ "cpython-freethreading", "cpython-prerelease", "pypy" ]
+    "#);
+}
+
+#[test]
+fn test_cibw_addopts_preserve_order() {
+    let start = indoc::indoc! {r#"
+    [tool.cibuildwheel]
+    before-all = "bash setup.sh"
+    test-requires = ["pytest", "pytest-cov"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.cibuildwheel]
+    before-all = "bash setup.sh"
+    test-requires = [ "pytest", "pytest-cov" ]
+    "#);
+}
+
+#[test]
+fn test_cibw_per_platform_collapsed() {
+    let start = indoc::indoc! {r#"
+    [tool.cibuildwheel.linux]
+    before-all = "yum install -y openssl"
+    archs = ["x86_64"]
+
+    [tool.cibuildwheel.macos]
+    archs = ["x86_64", "arm64"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.cibuildwheel]
+    linux.archs = [ "x86_64" ]
+    linux.before-all = "yum install -y openssl"
+    macos.archs = [ "x86_64", "arm64" ]
+    "#);
+}
+
+#[test]
+fn test_cibw_overrides_aot_select_first() {
+    let start = indoc::indoc! {r#"
+    [[tool.cibuildwheel.overrides]]
+    test-command = "pytest {project}/tests/cpython"
+    select = "cp3{10,11}-*"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.cibuildwheel]
+    overrides = [ { test-command = "pytest {project}/tests/cpython", select = "cp3{10,11}-*" } ]
+    "#);
+}
+
+#[test]
+fn test_cibw_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.cibuildwheel]
+    build = "cp3{10,11,12}-*"
+    skip = [ "pp*" ]
+    archs = [ "x86_64" ]
+    enable = [ "cpython-freethreading", "pypy" ]
+    test-command = "pytest"
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_cibw_no_table_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "x"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "x"
+    "#);
+}
+
+#[test]
+fn test_cibw_long_format_per_platform_tables() {
+    let start = indoc::indoc! {r#"
+    [tool.cibuildwheel.linux]
+    before-all = "yum install -y openssl"
+    enable = ["pypy", "cpython-freethreading"]
+    archs = ["x86_64"]
+
+    [tool.cibuildwheel.macos]
+    enable = ["pypy", "cpython-freethreading"]
+    archs = ["x86_64", "arm64"]
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.cibuildwheel.linux]"));
+    assert!(result.contains("[tool.cibuildwheel.macos]"));
+    assert!(result.find("cpython-freethreading").unwrap() < result.find("pypy").unwrap());
+}
+
+#[test]
+fn test_cibw_long_format_overrides_aot() {
+    let start = indoc::indoc! {r#"
+    [[tool.cibuildwheel.overrides]]
+    test-command = "pytest {project}/tests/cpython"
+    select = "cp3{10,11}-*"
+    enable = ["pypy", "cpython-freethreading"]
+    build = "cp3*-*"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[[tool.cibuildwheel.overrides]]"));
+    let block = result.split("[[tool.cibuildwheel.overrides]]").nth(1).unwrap();
+    assert!(block.find("select").unwrap() < block.find("build").unwrap());
+    assert!(block.find("build").unwrap() < block.find("enable").unwrap());
+    assert!(block.find("cpython-freethreading").unwrap() < block.find("pypy").unwrap());
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -5,6 +5,7 @@ pub use common::test_util::{assert_valid_toml, format_syntax, format_toml_str, p
 mod black_tests;
 mod build_systems_tests;
 mod commitizen_tests;
+mod cibuildwheel_tests;
 mod coverage_tests;
 mod dependency_groups_tests;
 mod global_tests;


### PR DESCRIPTION
[cibuildwheel](https://cibuildwheel.pypa.io/) ([pyproject.toml config](https://cibuildwheel.pypa.io/en/stable/options/#configuration-file)) is the canonical tool for cross-platform Python wheel builds in CI, used in ~2.5k `pyproject.toml` files on GitHub. ✨ Schema is rich (40+ top-level keys, per-platform sub-tables for linux/macos/windows/android/ios/pyodide, `[[overrides]]` AoT) and hand-formatting these blocks is genuinely painful.

Top-level ordering: selection (`build`, `skip`, `test-skip`, `archs`, `enable`, `free-threaded-support`) → build configuration → build phases (`before-all`, `before-build`, `repair-wheel-command`) → test phases → platform images (`manylinux-*-image`, `musllinux-*-image` enumerated for all canonical architectures) → `container-engine` → per-platform sub-tables → overrides last.

🔧 Per-platform sub-tables get the same inner ordering. `[[overrides]]` entries place `select` first (required), then the regular keys; the array order is preserved because later overrides win.

`enable`, `test-extras`, and `test-groups` are alphabetized (set semantics). Other array-valued keys (`test-requires`, build-phase scripts, environment-related fields) are CLI argv or ordered lists and are preserved as written.

🐛 This PR also carries the same `common` triple-literal string fix as #324.