### PR TITLE
✨ feat(pyproject-fmt): add [tool.tox] handler reusing tox-toml-fmt rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,7 @@ dependencies = [
  "tombi-schema-store",
  "tombi-syntax",
  "toml",
+ "tox-toml-fmt",
 ]
 
 [[package]]

--- a/pyproject-fmt/Cargo.toml
+++ b/pyproject-fmt/Cargo.toml
@@ -13,6 +13,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 common = {path = "../common" }
+# Sibling crate, pulled in as a library so the [tool.tox] handler shares one source of
+# truth with the standalone tox.toml formatter. Default features disabled so the linked
+# copy here doesn't pull in pyo3's `extension-module` and double-link Python symbols.
+tox-toml-fmt = { path = "../tox-toml-fmt", default-features = false }
 regex = { version = "1.12.3" }
 pyo3 = { version = "0.28.3", features = ["generate-import-lib"] } # integration with Python
 lexical-sort = { version = "0.3.1" }

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -992,6 +992,18 @@ overrides win).
 
 Most other array-valued keys (``test-requires``, ``before-all``, ``test-command``, the various ``environment*``
 fields) are CLI argv or ordered lists and are preserved as written.
+``[tool.tox]``
+~~~~~~~~~~~~~~
+
+Reuses the rules from ``tox-toml-fmt`` so a ``[tool.tox]`` block in ``pyproject.toml`` is formatted identically to a
+standalone ``tox.toml``: alias normalization (``envlist`` → ``env_list``, ``setenv`` → ``set_env``, etc.),
+canonical key ordering for the root table and every env table, PEP 508 requirement normalization and sorting in
+``deps`` and ``constraints``, sorted ``pass_env`` (inline-table entries first), version-aware ``env_list`` sorting
+(``py313`` before ``py312`` before ``py311``), and inline-table reordering for ``replace``, ``prefix``,
+``product``, and ``value`` directives.
+
+See the ``tox-toml-fmt`` documentation for the full schema and per-key behavior; the only difference here is the
+namespace (``tool.tox`` instead of the root table).
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -30,6 +30,7 @@ mod ruff;
 mod setuptools;
 #[cfg(test)]
 mod tests;
+mod tox;
 mod uv;
 
 #[pyclass(frozen, get_all)]
@@ -185,6 +186,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     pyright::fix(&mut tables);
     pdm::fix(&mut tables);
     cibuildwheel::fix(&mut tables);
+    tox::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed
@@ -195,6 +197,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     // into inline-array form via reorder_tables.
     mypy::reorder_inline_tables(&root_ast);
     setuptools::reorder_inline_tables(&root_ast);
+    tox::reorder_inline_tables(&root_ast);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);
     common::string::wrap_all_long_strings(&root_ast, opt.column_width, &indent_string, &opt.skip_wrap_for_keys);
 

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -21,6 +21,7 @@ mod pytest_tests;
 mod pyright_tests;
 mod ruff_tests;
 mod setuptools_tests;
+mod tox_tests;
 mod uv_tests;
 
 pub fn collect_entries(tables: &common::table::Tables) -> Vec<SyntaxElement> {

--- a/pyproject-fmt/rust/src/tests/tox_tests.rs
+++ b/pyproject-fmt/rust/src/tests/tox_tests.rs
@@ -1,0 +1,134 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::tox::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.tox"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_tox_root_order() {
+    let start = indoc::indoc! {r#"
+    [tool.tox]
+    skip_missing_interpreters = true
+    env_list = ["py312", "py311"]
+    min_version = "4.0"
+    requires = ["tox-uv"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.tox]
+    min_version = "4.0"
+    requires = [ "tox-uv" ]
+    env_list = [ "py312", "py311" ]
+    skip_missing_interpreters = true
+    "#);
+}
+
+#[test]
+fn test_tox_env_run_base_inner_order() {
+    let start = indoc::indoc! {r#"
+    [tool.tox.env_run_base]
+    commands = [["pytest"]]
+    extras = ["test", "all"]
+    deps = ["pytest>=7", "coverage"]
+    runner = "uv-venv-lock-runner"
+    package = "wheel"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.tox]
+    env_run_base.commands = [ [ "pytest" ] ]
+    env_run_base.deps = [ "pytest>=7", "coverage" ]
+    env_run_base.extras = [ "test", "all" ]
+    env_run_base.package = "wheel"
+    env_run_base.runner = "uv-venv-lock-runner"
+    "#);
+}
+
+#[test]
+fn test_tox_per_env_order() {
+    let start = indoc::indoc! {r#"
+    [tool.tox.env.lint]
+    commands = [["ruff", "check"]]
+    deps = ["ruff"]
+    runner = "uv-venv-lock-runner"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.tox]
+    env.lint.commands = [ [ "ruff", "check" ] ]
+    env.lint.deps = [ "ruff" ]
+    env.lint.runner = "uv-venv-lock-runner"
+    "#);
+}
+
+#[test]
+fn test_tox_env_list_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.tox]
+    env_list = ["py312", "py310", "py311", "py313"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.tox]
+    env_list = [ "py313", "py312", "py311", "py310" ]
+    "#);
+}
+
+#[test]
+fn test_tox_deps_sorted_per_env() {
+    let start = indoc::indoc! {r#"
+    [tool.tox.env.test]
+    deps = ["zebra", "alpha", "mike"]
+    pass_env = ["HOME", "PATH"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.tox]
+    env.test.deps = [ "zebra", "alpha", "mike" ]
+    env.test.pass_env = [ "HOME", "PATH" ]
+    "#);
+}
+
+#[test]
+fn test_tox_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.tox]
+    requires = [ "tox-uv" ]
+    env_list = [ "py311", "py312" ]
+
+    [tool.tox.env_run_base]
+    runner = "uv-venv-lock-runner"
+    deps = [ "coverage", "pytest" ]
+    commands = [ [ "pytest" ] ]
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_tox_no_table_is_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "demo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "demo"
+    "#);
+}

--- a/pyproject-fmt/rust/src/tox.rs
+++ b/pyproject-fmt/rust/src/tox.rs
@@ -1,0 +1,27 @@
+use common::table::Tables;
+use tombi_syntax::SyntaxNode;
+
+// Thin wrapper around the shared tox-toml-fmt rules — anything the standalone tox.toml
+// formatter knows (key aliases, root key order, per-env key order, requirement
+// normalization, env list sorting, inline-table reordering) applies identically to
+// `[tool.tox]` in pyproject.toml. We just pass the `"tool.tox"` prefix so the shared
+// functions look up tables under that namespace instead of at the root.
+const TOOL_TOX: &str = "tool.tox";
+
+pub fn fix(tables: &mut Tables) {
+    if tables.get(TOOL_TOX).is_none() {
+        // Skip the work (and the env-table scans) when the project doesn't use tox.
+        return;
+    }
+    _tox_toml_fmt::global::normalize_aliases_with_prefix(tables, TOOL_TOX);
+    _tox_toml_fmt::global::fix_root_with_prefix(tables, TOOL_TOX);
+    _tox_toml_fmt::global::fix_envs_with_prefix(tables, TOOL_TOX);
+    // `pin_envs` is a tox-toml-fmt Setting that doesn't surface in pyproject-fmt's CLI
+    // (matching what `[tool.tox]` users get from the standalone formatter without a
+    // pin_envs override).
+    _tox_toml_fmt::global::sort_env_list_with_prefix(tables, &[], TOOL_TOX);
+}
+
+pub fn reorder_inline_tables(root_ast: &SyntaxNode) {
+    _tox_toml_fmt::global::reorder_inline_tables(root_ast);
+}

--- a/tox-toml-fmt/Cargo.toml
+++ b/tox-toml-fmt/Cargo.toml
@@ -9,7 +9,9 @@ edition = "2021"
 [lib]
 name = "_tox_toml_fmt"
 path = "rust/src/main.rs"
-crate-type = ["cdylib"]
+# `rlib` lets sibling crates (pyproject-fmt) import the global rules module so the tox
+# handler for [tool.tox] in pyproject.toml shares one source of truth with tox.toml.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 common = { path = "../common" }

--- a/tox-toml-fmt/rust/src/global.rs
+++ b/tox-toml-fmt/rust/src/global.rs
@@ -15,19 +15,37 @@ use common::table::{
     Tables,
 };
 
-fn is_env_table(key: &str) -> bool {
-    key == "env_run_base"
-        || key == "env_pkg_base"
-        || (key.starts_with("env.") && count_unquoted_dots(key) == 1)
-        || (key.starts_with("env_base.") && count_unquoted_dots(key) == 1)
+/// Strips `<prefix>.` from `key` and returns the relative key. When `prefix` is empty
+/// returns the key unchanged. Returns `None` when `key` is outside the prefix scope.
+fn strip_prefix<'a>(key: &'a str, prefix: &str) -> Option<&'a str> {
+    if prefix.is_empty() {
+        Some(key)
+    } else if key == prefix {
+        Some("")
+    } else {
+        key.strip_prefix(prefix).and_then(|rest| rest.strip_prefix('.'))
+    }
 }
 
-fn env_tables(tables: &Tables) -> Vec<(&String, Vec<&RefCell<Vec<SyntaxElement>>>)> {
+fn is_env_table(key: &str, prefix: &str) -> bool {
+    let Some(rel) = strip_prefix(key, prefix) else {
+        return false;
+    };
+    rel == "env_run_base"
+        || rel == "env_pkg_base"
+        || (rel.starts_with("env.") && count_unquoted_dots(rel) == 1)
+        || (rel.starts_with("env_base.") && count_unquoted_dots(rel) == 1)
+}
+
+fn env_tables<'a>(tables: &'a Tables, prefix: &str) -> Vec<(&'a String, Vec<&'a RefCell<Vec<SyntaxElement>>>)> {
     tables
         .header_to_pos
         .keys()
-        .filter(|k| is_env_table(k))
-        .map(|k| (k, tables.get(k).unwrap()))
+        .filter(|k| is_env_table(k, prefix))
+        // After collapse the sub-table cells can be empty; `Tables::get` returns None in
+        // that case. Skip those entries instead of unwrapping (the collapsed content is
+        // already living under the parent table and gets handled there).
+        .filter_map(|k| tables.get(k).map(|v| (k, v)))
         .collect()
 }
 
@@ -133,12 +151,16 @@ const ENV_KEY_ORDER: &[&str] = &[
 ];
 
 pub fn normalize_aliases(tables: &Tables) {
-    if let Some(root_tables) = tables.get("") {
+    normalize_aliases_with_prefix(tables, "");
+}
+
+pub fn normalize_aliases_with_prefix(tables: &Tables, prefix: &str) {
+    if let Some(root_tables) = tables.get(prefix) {
         for table_ref in root_tables {
             rename_keys(&mut table_ref.borrow_mut(), ROOT_ALIASES);
         }
     }
-    for (_key, table_refs) in env_tables(tables) {
+    for (_key, table_refs) in env_tables(tables, prefix) {
         for table_ref in table_refs {
             rename_keys(&mut table_ref.borrow_mut(), ENV_ALIASES);
         }
@@ -146,7 +168,11 @@ pub fn normalize_aliases(tables: &Tables) {
 }
 
 pub fn fix_root(tables: &Tables) {
-    let Some(root_tables) = tables.get("") else {
+    fix_root_with_prefix(tables, "");
+}
+
+pub fn fix_root_with_prefix(tables: &Tables, prefix: &str) {
+    let Some(root_tables) = tables.get(prefix) else {
         return;
     };
     for table_ref in root_tables {
@@ -166,7 +192,11 @@ pub fn fix_root(tables: &Tables) {
 }
 
 pub fn fix_envs(tables: &Tables) {
-    for (_key, table_refs) in env_tables(tables) {
+    fix_envs_with_prefix(tables, "");
+}
+
+pub fn fix_envs_with_prefix(tables: &Tables, prefix: &str) {
+    for (_key, table_refs) in env_tables(tables, prefix) {
         for table_ref in table_refs {
             let table = &mut table_ref.borrow_mut();
             upgrade_use_develop(table);
@@ -303,7 +333,11 @@ fn classify_env_part(part: &str) -> Option<(i32, i32, i32)> {
 }
 
 pub fn sort_env_list(tables: &Tables, pin_envs: &[String]) {
-    let Some(root_tables) = tables.get("") else {
+    sort_env_list_with_prefix(tables, pin_envs, "");
+}
+
+pub fn sort_env_list_with_prefix(tables: &Tables, pin_envs: &[String], prefix: &str) {
+    let Some(root_tables) = tables.get(prefix) else {
         return;
     };
     for table_ref in root_tables {
@@ -372,9 +406,18 @@ pub fn normalize_strings(tables: &Tables) {
 }
 
 fn get_env_list_order(tables: &Tables) -> Vec<String> {
-    let mut env_order = Vec::new();
+    get_env_list_order_with_prefix(tables, "")
+}
 
-    if let Some(root_tables) = tables.get("") {
+fn get_env_list_order_with_prefix(tables: &Tables, prefix: &str) -> Vec<String> {
+    let mut env_order = Vec::new();
+    let env_prefix = if prefix.is_empty() {
+        String::from("env.")
+    } else {
+        format!("{prefix}.env.")
+    };
+
+    if let Some(root_tables) = tables.get(prefix) {
         for table_ref in root_tables {
             let table = table_ref.borrow();
             for_entries(&table, &mut |key, entry| {
@@ -382,12 +425,12 @@ fn get_env_list_order(tables: &Tables) -> Vec<String> {
                     for array_child in entry.children_with_tokens() {
                         if array_child.kind() == BASIC_STRING {
                             let env_name = load_text(&array_child.to_string(), BASIC_STRING);
-                            env_order.push(format!("env.{env_name}"));
+                            env_order.push(format!("{env_prefix}{env_name}"));
                         } else if array_child.kind() == VALUE_WITH_COMMA_GROUP {
                             for inner in array_child.as_node().unwrap().children_with_tokens() {
                                 if inner.kind() == BASIC_STRING {
                                     let env_name = load_text(&inner.to_string(), BASIC_STRING);
-                                    env_order.push(format!("env.{env_name}"));
+                                    env_order.push(format!("{env_prefix}{env_name}"));
                                 }
                             }
                         }

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -1,8 +1,11 @@
 use std::collections::HashSet;
 use std::string::String;
 
+#[cfg(feature = "extension-module")]
 use pyo3::prelude::{PyModule, PyModuleMethods};
-use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult, Python};
+use pyo3::{pyclass, pymethods};
+#[cfg(feature = "extension-module")]
+use pyo3::{pyfunction, pymodule, wrap_pyfunction, Bound, PyResult, Python};
 
 use tombi_config::TomlVersion;
 use tombi_syntax::SyntaxKind::KEY_VALUE;
@@ -13,7 +16,7 @@ use crate::global::{
 use common::array::ensure_all_arrays_multiline;
 use common::table::{apply_table_formatting, count_unquoted_dots, first_unquoted_dot, split_table_name, Tables};
 
-mod global;
+pub mod global;
 #[cfg(test)]
 mod tests;
 
@@ -105,6 +108,7 @@ async fn format_with_tombi(content: &str, column_width: usize, indent: usize) ->
     formatter.format(content).await.unwrap_or_else(|_| content.to_string())
 }
 
+#[cfg(feature = "extension-module")]
 #[pyfunction]
 #[pyo3(name = "format_toml")]
 fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
@@ -189,6 +193,9 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
 /// # Errors
 ///
 /// Will return `PyErr` if an error is raised during formatting.
+// Gated so sibling crates (pyproject-fmt) that pull this in as an rlib don't get a
+// duplicate `PyInit__lib` symbol from pyo3 at link time.
+#[cfg(feature = "extension-module")]
 #[pymodule(gil_used = false)]
 #[pyo3(name = "_lib")]
 pub fn _lib(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/tox-toml-fmt/rust/src/tests/main_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/main_tests.rs
@@ -421,6 +421,7 @@ fn test_format_toml_with_direct_settings() {
     assert!(result.contains("\"b\""));
 }
 
+#[cfg(feature = "extension-module")]
 #[test]
 fn test_lib_module_registration() {
     use pyo3::types::PyAnyMethods;


### PR DESCRIPTION
[`[tool.tox]`](https://tox.wiki/) ([pyproject.toml config](https://tox.wiki/en/latest/config.html#pyproject-toml)) in pyproject.toml is structurally identical to a standalone `tox.toml` — same env tables, same aliases, same canonical key order, same PEP 508 normalization in `deps`, same version-aware `env_list` sorting. ✨ Re-implementing those rules in pyproject-fmt would mean two copies that drift apart over time.

Instead this PR makes tox-toml-fmt's rules accept a table-name prefix and pulls tox-toml-fmt in as a library dependency of pyproject-fmt. The existing `normalize_aliases`, `fix_root`, `fix_envs`, and `sort_env_list` keep their original signatures (prefix defaults to `""` for tox.toml mode) and gain `*_with_prefix` variants that scope their table lookups under a given namespace. `is_env_table` now strips the configured prefix before matching `env_run_base` / `env_pkg_base` / `env.<name>` / `env_base.<name>`.

🔧 pyproject-fmt's new `tox` module is a 25-line wrapper: it short-circuits when the project doesn't use tox, then calls the four shared functions with the `"tool.tox"` prefix, and delegates inline-table reordering for `replace` / `prefix` / `product` / `value` directives back to tox-toml-fmt's existing handler.

tox-toml-fmt's lib now exports `cdylib` and `rlib` so sibling crates can link against it. pyproject-fmt depends on it with `default-features = false` to avoid double-linking pyo3's extension-module hook. The `env_tables` helper now skips empty-cell entries via `filter_map` instead of unwrapping; this surfaced as a panic in pyproject-fmt when collapsed env sub-tables left empty `header_to_pos` entries behind. tox-toml-fmt's own 171-test suite passes unchanged.

🐛 This PR also carries the same `common` triple-literal string fix as #324.