### PR TITLE
✨ feat(pyproject-fmt): add [tool.bandit] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1004,6 +1004,13 @@ canonical key ordering for the root table and every env table, PEP 508 requireme
 
 See the ``tox-toml-fmt`` documentation for the full schema and per-key behavior; the only difference here is the
 namespace (``tool.tox`` instead of the root table).
+``[tool.bandit]``
+~~~~~~~~~~~~~~~~~
+
+Top-level ordering: ``exclude_dirs`` → ``targets`` → ``tests`` → ``skips`` → per-plugin sub-tables
+(``assert_used``, ``hardcoded_tmp_directory``, etc.).
+
+All array values alphabetize (rule IDs, directory paths, function-name lists — all set semantics).
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/bandit.rs
+++ b/pyproject-fmt/rust/src/bandit.rs
@@ -1,0 +1,47 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Group: scope (exclude_dirs, targets) → plugins (tests, skips) → plugin sub-tables.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "exclude_dirs",
+    "targets",
+    "tests",
+    "skips",
+    // plugin sub-tables collapse to dotted keys (assert_used.skips, ...)
+    "assert_used",
+    "hardcoded_tmp_directory",
+    "hardcoded_bind_all_interfaces",
+    "any_other_function_with_shell_equals_true",
+    "ssl_with_bad_version",
+    "ssl_with_bad_defaults",
+    "weak_cryptographic_key",
+];
+
+// All array values are set semantics (rule IDs, paths, names), so they sort.
+const SORT_ARRAYS_EXACT: &[&str] = &["exclude_dirs", "targets", "tests", "skips"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.bandit") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        let k = key.as_str();
+        if SORT_ARRAYS_EXACT.contains(&k) || is_inner_array(k) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}
+
+fn is_inner_array(key: &str) -> bool {
+    key.contains('.')
+        && (key.ends_with(".skips")
+            || key.ends_with(".tmp_dirs")
+            || key.ends_with(".no_shell")
+            || key.ends_with(".shell")
+            || key.ends_with(".subprocess")
+            || key.ends_with(".tests"))
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -16,6 +16,7 @@ mod project;
 mod commitizen;
 mod black;
 mod cibuildwheel;
+mod bandit;
 mod coverage;
 mod global;
 mod mypy;
@@ -187,6 +188,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     pdm::fix(&mut tables);
     cibuildwheel::fix(&mut tables);
     tox::fix(&mut tables);
+    bandit::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/bandit_tests.rs
+++ b/pyproject-fmt/rust/src/tests/bandit_tests.rs
@@ -1,0 +1,211 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::bandit::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.bandit"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_bandit_top_level_order() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit]
+    skips = ["B101"]
+    tests = ["B201"]
+    targets = ["src"]
+    exclude_dirs = ["tests"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bandit]
+    exclude_dirs = [ "tests" ]
+    targets = [ "src" ]
+    tests = [ "B201" ]
+    skips = [ "B101" ]
+    "#);
+}
+
+#[test]
+fn test_bandit_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit]
+    skips = ["B311", "B101", "B201"]
+    tests = ["B999", "B101"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bandit]
+    tests = [ "B101", "B999" ]
+    skips = [ "B101", "B201", "B311" ]
+    "#);
+}
+
+#[test]
+fn test_bandit_assert_used_inner() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit.assert_used]
+    skips = ["*_test.py", "test_*.py"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bandit]
+    assert_used.skips = [ "*_test.py", "test_*.py" ]
+    "#);
+}
+
+#[test]
+fn test_bandit_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit]
+    exclude_dirs = [ "tests" ]
+    skips = [ "B101", "B201" ]
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_bandit_no_table_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "x"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "x"
+    "#);
+}
+
+#[test]
+fn test_bandit_inner_tmp_dirs_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit.hardcoded_tmp_directory]
+    tmp_dirs = ["/var/tmp", "/tmp", "/dev/shm"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bandit]
+    hardcoded_tmp_directory.tmp_dirs = [ "/dev/shm", "/tmp", "/var/tmp" ]
+    "#);
+}
+
+#[test]
+fn test_bandit_inner_no_shell_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit.any_other_function_with_shell_equals_true]
+    no_shell = ["os.system", "os.popen"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bandit]
+    any_other_function_with_shell_equals_true.no_shell = [ "os.popen", "os.system" ]
+    "#);
+}
+
+#[test]
+fn test_bandit_inner_shell_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit.shell_injection]
+    shell = ["zsh", "bash", "sh"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bandit]
+    shell_injection.shell = [ "bash", "sh", "zsh" ]
+    "#);
+}
+
+#[test]
+fn test_bandit_inner_subprocess_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit.shell_injection]
+    subprocess = ["subprocess.run", "subprocess.Popen"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bandit]
+    shell_injection.subprocess = [ "subprocess.Popen", "subprocess.run" ]
+    "#);
+}
+
+#[test]
+fn test_bandit_inner_tests_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit.some_plugin]
+    tests = ["B999", "B101"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bandit]
+    some_plugin.tests = [ "B101", "B999" ]
+    "#);
+}
+
+#[test]
+fn test_bandit_inner_non_matching_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit.assert_used]
+    word_list = ["zeta", "alpha"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bandit]
+    assert_used.word_list = [ "zeta", "alpha" ]
+    "#);
+}
+
+#[test]
+fn test_bandit_long_format() {
+    let start = indoc::indoc! {r#"
+    [tool.bandit]
+    skips = ["B311", "B101"]
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.bandit]"));
+    assert!(result.find("B101").unwrap() < result.find("B311").unwrap());
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -3,6 +3,7 @@ use tombi_syntax::SyntaxElement;
 pub use common::test_util::{assert_valid_toml, format_syntax, format_toml_str, parse};
 
 mod black_tests;
+mod bandit_tests;
 mod build_systems_tests;
 mod commitizen_tests;
 mod cibuildwheel_tests;


### PR DESCRIPTION
[Bandit](https://bandit.readthedocs.io/) ([pyproject.toml config](https://bandit.readthedocs.io/en/latest/config.html)) appears in ~2.3k `pyproject.toml` files. ✨ Schema is small (`exclude_dirs`, `targets`, `tests`, `skips`, plus per-plugin sub-tables) and all array values are set-semantics rule IDs or paths.

Top-level keys: `exclude_dirs` → `targets` → `tests` → `skips` → per-plugin sub-tables (`assert_used`, `hardcoded_tmp_directory`, `hardcoded_bind_all_interfaces`, `any_other_function_with_shell_equals_true`, `ssl_with_bad_*`, `weak_crypto*`).

🔧 All arrays alphabetize, including the per-plugin `skips`, `tmp_dirs`, `no_shell`, `shell`, `subprocess`, and `tests` lists nested under sub-table keys.

🐛 This PR also carries the same `common` triple-literal string fix as #324.