### PR TITLE
✨ feat(pyproject-fmt): add [tool.maturin] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1011,6 +1011,18 @@ Top-level ordering: ``exclude_dirs`` → ``targets`` → ``tests`` → ``skips``
 (``assert_used``, ``hardcoded_tmp_directory``, etc.).
 
 All array values alphabetize (rule IDs, directory paths, function-name lists — all set semantics).
+``[tool.maturin]``
+~~~~~~~~~~~~~~~~~~
+
+Maturin builds Rust extensions for Python. Top-level ordering: module identity (``module-name``, ``bindings``,
+``python-source``, ``python-packages``, ``python-bin-path``) → source layout (``src``, ``manifest-path``,
+``include``, ``exclude``, ``sdist-include``, ``sdist-generator``, ``data``) → cargo settings (``features``,
+``no-default-features``, ``all-features``, ``cargo-extra-args``, ``rustc-extra-args``, ``config``, ``profile``,
+``target``, ``target-dir``) → compatibility / strip (``compatibility``, ``auditwheel``, ``skip-auditwheel``,
+``strip``, ``frozen``, ``locked``, ``offline``, ``zig``) → behavior (``use-cross``).
+
+**Sorted arrays:** ``python-packages``, ``include``, ``exclude``, ``sdist-include``, ``features`` (all
+set-semantics). ``cargo-extra-args`` / ``rustc-extra-args`` are CLI argv and preserved.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -23,6 +23,7 @@ mod mypy;
 mod hatch;
 mod isort;
 mod pdm;
+mod maturin;
 mod pixi;
 mod poetry;
 mod pytest;
@@ -189,6 +190,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     cibuildwheel::fix(&mut tables);
     tox::fix(&mut tables);
     bandit::fix(&mut tables);
+    maturin::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/maturin.rs
+++ b/pyproject-fmt/rust/src/maturin.rs
@@ -1,0 +1,57 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    // Module identity
+    "module-name",
+    "bindings",
+    "python-source",
+    "python-packages",
+    "python-bin-path",
+    // Source layout
+    "src",
+    "manifest-path",
+    "include",
+    "exclude",
+    "sdist-include",
+    "sdist-generator",
+    "data",
+    // Cargo
+    "features",
+    "no-default-features",
+    "all-features",
+    "cargo-extra-args",
+    "rustc-extra-args",
+    "config",
+    "profile",
+    "target",
+    "target-dir",
+    // Compatibility / strip
+    "compatibility",
+    "auditwheel",
+    "skip-auditwheel",
+    "strip",
+    "frozen",
+    "locked",
+    "offline",
+    "zig",
+    // Behavior
+    "use-cross",
+];
+
+const SORT_ARRAYS: &[&str] = &["python-packages", "include", "exclude", "sdist-include", "features"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.maturin") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/tests/maturin_tests.rs
+++ b/pyproject-fmt/rust/src/tests/maturin_tests.rs
@@ -1,0 +1,69 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::maturin::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.maturin"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_maturin_top_level_order() {
+    let start = indoc::indoc! {r#"
+    [tool.maturin]
+    compatibility = "manylinux2014"
+    features = ["pyo3/extension-module"]
+    python-source = "python"
+    bindings = "pyo3"
+    module-name = "my_pkg._lib"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.maturin]
+    module-name = "my_pkg._lib"
+    bindings = "pyo3"
+    python-source = "python"
+    features = [ "pyo3/extension-module" ]
+    compatibility = "manylinux2014"
+    "#);
+}
+
+#[test]
+fn test_maturin_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.maturin]
+    features = ["zebra", "alpha", "mike"]
+    include = ["src/**/*.rs", "*.toml"]
+    exclude = ["zeta/*", "alpha/*"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.maturin]
+    include = [ "*.toml", "src/**/*.rs" ]
+    exclude = [ "alpha/*", "zeta/*" ]
+    features = [ "alpha", "mike", "zebra" ]
+    "#);
+}
+
+#[test]
+fn test_maturin_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.maturin]
+    bindings = "pyo3"
+    features = [ "extension-module" ]
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod isort_tests;
 mod main_tests;
 mod mypy_tests;
 mod pdm_tests;
+mod maturin_tests;
 mod pixi_tests;
 mod poetry_tests;
 mod project_tests;


### PR DESCRIPTION
[Maturin](https://www.maturin.rs/) ([pyproject.toml config](https://www.maturin.rs/config)) is the dominant build backend for Rust/Python extensions (~13.9M downloads/month, ~2k `pyproject.toml` on GitHub). ✨ The handler groups keys by function: module identity → source layout → cargo settings → compatibility/strip → behavior. `python-packages` / `include` / `exclude` / `sdist-include` / `features` alphabetize (set semantics); `cargo-extra-args` and `rustc-extra-args` preserve argv order.

🐛 This PR also carries the same `common` triple-literal string fix as #324.