### PR TITLE
✨ feat(pyproject-fmt): add [tool.codespell] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1023,6 +1023,15 @@ Maturin builds Rust extensions for Python. Top-level ordering: module identity (
 
 **Sorted arrays:** ``python-packages``, ``include``, ``exclude``, ``sdist-include``, ``features`` (all
 set-semantics). ``cargo-extra-args`` / ``rustc-extra-args`` are CLI argv and preserved.
+``[tool.codespell]``
+~~~~~~~~~~~~~~~~~~~~
+
+Top-level ordering: dictionaries (``builtin``, ``dictionary``, ``ignore-words``, ``ignore-words-list``,
+``ignore-regex``, ``ignore-multiline-regex``, ``exclude-file``) → scope (``skip``, ``uri-ignore-words-list``,
+``check-filenames``, ``check-hidden``, ``hidden``, ``regex``, ``user-input``) → fix behavior (``write-changes``,
+``interactive``, ``enable-colors``, ``disable-colors``) → output (``count``, ``quiet-level``, ``summary``).
+
+**Sorted arrays:** ``builtin``, ``dictionary``, ``skip``, ``ignore-words-list``, ``uri-ignore-words-list``.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/codespell.rs
+++ b/pyproject-fmt/rust/src/codespell.rs
@@ -1,0 +1,52 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    // Dictionaries
+    "builtin",
+    "dictionary",
+    "ignore-words",
+    "ignore-words-list",
+    "ignore-regex",
+    "ignore-multiline-regex",
+    "exclude-file",
+    // Scope
+    "skip",
+    "uri-ignore-words-list",
+    "check-filenames",
+    "check-hidden",
+    "hidden",
+    "regex",
+    "user-input",
+    // Fix behavior
+    "write-changes",
+    "interactive",
+    "enable-colors",
+    "disable-colors",
+    "count",
+    "quiet-level",
+    "summary",
+];
+
+const SORT_ARRAYS: &[&str] = &[
+    "builtin",
+    "dictionary",
+    "skip",
+    "ignore-words-list",
+    "uri-ignore-words-list",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.codespell") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -17,6 +17,7 @@ mod commitizen;
 mod black;
 mod cibuildwheel;
 mod bandit;
+mod codespell;
 mod coverage;
 mod global;
 mod mypy;
@@ -191,6 +192,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     tox::fix(&mut tables);
     bandit::fix(&mut tables);
     maturin::fix(&mut tables);
+    codespell::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/codespell_tests.rs
+++ b/pyproject-fmt/rust/src/tests/codespell_tests.rs
@@ -1,0 +1,50 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::codespell::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.codespell"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_codespell_order_and_sorted_arrays() {
+    let start = indoc::indoc! {r#"
+    [tool.codespell]
+    write-changes = true
+    skip = ["./vendor", "./build"]
+    ignore-words-list = ["fo", "ba"]
+    builtin = "clear,rare"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.codespell]
+    builtin = "clear,rare"
+    ignore-words-list = [ "ba", "fo" ]
+    skip = [ "./build", "./vendor" ]
+    write-changes = true
+    "#);
+}
+
+#[test]
+fn test_codespell_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.codespell]
+    skip = [ "build", "dist" ]
+    ignore-words-list = [ "fo", "ba" ]
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod bandit_tests;
 mod build_systems_tests;
 mod commitizen_tests;
 mod cibuildwheel_tests;
+mod codespell_tests;
 mod coverage_tests;
 mod dependency_groups_tests;
 mod global_tests;

--- a/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__main_tests__issue_217_full_pyproject_idempotent.snap
+++ b/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__main_tests__issue_217_full_pyproject_idempotent.snap
@@ -234,10 +234,10 @@ skip = [
   "flexget/api/templates/swagger-ui.html",
   "flexget/utils/bittorrent.py",
   "flexget/utils/parsers/series.py",
+  "pyproject.toml",
   "tests/couchpotato_movie_list_test_response.json",
   "tests/LICENSE.torrent",
   "tests/test_thetvdb.py",
-  "pyproject.toml",
 ]
 
 [tool.pyproject-fmt]


### PR DESCRIPTION
[Codespell](https://github.com/codespell-project/codespell) ([pyproject.toml config](https://github.com/codespell-project/codespell#using-a-config-file)) appears in ~2k `pyproject.toml` files. ✨ Small schema; keys group as dictionaries → scope → fix behavior → output. `builtin`, `dictionary`, `skip`, `ignore-words-list`, `uri-ignore-words-list` alphabetize.

🐛 This PR also carries the same `common` triple-literal string fix as #324.