### PR TITLE
✨ feat(pyproject-fmt): add [tool.commitizen] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -591,6 +591,15 @@ Report phase:
     report.omit = ["tests/*"]
     report.exclude_also = ["if TYPE_CHECKING:"]
 
+``[tool.commitizen]``
+~~~~~~~~~~~~~~~~~~~~~
+
+Top-level ordering: rule selection (``name``, ``schema``, ``schema_pattern``, ``allowed_prefixes``) → version
+source (``version``, ``version_scheme``, ``version_provider``, ``version_files``) → bump behavior → tag/sign →
+changelog → hooks (``pre_bump_hooks``, ``post_bump_hooks``) → ``customize``.
+
+**Sorted arrays:** ``version_files``, ``allowed_prefixes``, ``extras``, ``extra_files``.
+
 Other Tables
 ~~~~~~~~~~~~
 

--- a/pyproject-fmt/rust/src/commitizen.rs
+++ b/pyproject-fmt/rust/src/commitizen.rs
@@ -1,0 +1,63 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    // Rule selection
+    "name",
+    "version_type",
+    "schema",
+    "schema_pattern",
+    "allowed_prefixes",
+    // Version source
+    "version",
+    "version_scheme",
+    "version_provider",
+    "version_files",
+    // Bump behavior
+    "bump_message",
+    "always_signoff",
+    "retry_after_failure",
+    "encoding",
+    "major_version_zero",
+    // Tag / sign
+    "tag_format",
+    "annotated_tag",
+    "annotated_tag_message",
+    "gpg_sign",
+    "use_shortcuts",
+    // Changelog
+    "changelog_file",
+    "changelog_format",
+    "changelog_incremental",
+    "changelog_start_rev",
+    "changelog_merge_prerelease",
+    "update_changelog_on_bump",
+    "changelog_pattern",
+    "extras",
+    "extra_files",
+    "template",
+    // Hooks
+    "pre_bump_hooks",
+    "post_bump_hooks",
+    // Customization
+    "customize",
+    // Commit
+    "discover_secret",
+];
+
+const SORT_ARRAYS: &[&str] = &["version_files", "allowed_prefixes", "extras", "extra_files"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.commitizen") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -13,6 +13,7 @@ mod build_system;
 mod dependency_groups;
 mod project;
 
+mod commitizen;
 mod coverage;
 mod global;
 mod pixi;
@@ -163,6 +164,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     ruff::fix(&mut tables);
     uv::fix(&mut tables);
     pixi::fix(&mut tables);
+    commitizen::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     ensure_all_arrays_multiline(&root_ast, opt.column_width);

--- a/pyproject-fmt/rust/src/tests/commitizen_tests.rs
+++ b/pyproject-fmt/rust/src/tests/commitizen_tests.rs
@@ -1,0 +1,52 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::commitizen::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.commitizen"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_commitizen_order() {
+    let start = indoc::indoc! {r#"
+    [tool.commitizen]
+    update_changelog_on_bump = true
+    version_files = ["src/pkg/__init__.py", "pyproject.toml"]
+    tag_format = "v$version"
+    version = "1.0.0"
+    name = "cz_conventional_commits"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.commitizen]
+    name = "cz_conventional_commits"
+    version = "1.0.0"
+    version_files = [ "pyproject.toml", "src/pkg/__init__.py" ]
+    tag_format = "v$version"
+    update_changelog_on_bump = true
+    "#);
+}
+
+#[test]
+fn test_commitizen_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.commitizen]
+    name = "cz_conventional_commits"
+    version = "1.0.0"
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -3,6 +3,7 @@ use tombi_syntax::SyntaxElement;
 pub use common::test_util::{assert_valid_toml, format_syntax, format_toml_str, parse};
 
 mod build_systems_tests;
+mod commitizen_tests;
 mod coverage_tests;
 mod dependency_groups_tests;
 mod global_tests;


### PR DESCRIPTION
[Commitizen](https://commitizen-tools.github.io/commitizen/) ([pyproject.toml config](https://commitizen-tools.github.io/commitizen/config/)) (~1.6k `pyproject.toml` on GitHub) handles conventional-commit parsing, version bumping, and changelog generation. ✨ Keys group: rule selection → version source → bump behavior → tag/sign → changelog → hooks → `customize`. `version_files` / `allowed_prefixes` / `extras` / `extra_files` alphabetize.

🐛 This PR also carries the same `common` triple-literal string fix as #324.