### PR TITLE
✨ feat(pyproject-fmt): add [tool.towncrier] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1032,6 +1032,19 @@ Top-level ordering: dictionaries (``builtin``, ``dictionary``, ``ignore-words``,
 ``interactive``, ``enable-colors``, ``disable-colors``) → output (``count``, ``quiet-level``, ``summary``).
 
 **Sorted arrays:** ``builtin``, ``dictionary``, ``skip``, ``ignore-words-list``, ``uri-ignore-words-list``.
+``[tool.towncrier]``
+~~~~~~~~~~~~~~~~~~~~
+
+Top-level ordering: package identity (``name``, ``version``, ``package``, ``package_dir``) → news location
+(``directory``, ``filename``, ``start_string``, ``template``, ``title_format``, ``issue_format``, ``underlines``)
+→ rendering (``wrap``, ``all_bullets``, ``single_file``, ``orphan_prefix``, ``create_eof_newline``,
+``create_add_extension``) → behavior (``ignore``) → ``type`` and ``section`` (AoT, last).
+
+``[[tool.towncrier.type]]`` entries get keys ordered ``directory`` → ``name`` → ``showcontent``;
+``[[tool.towncrier.section]]`` entries get ``path`` → ``name`` → ``showcontent``. Array order is preserved
+(display order in the rendered changelog).
+
+**Sorted arrays:** ``ignore`` (file globs to skip).
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -34,6 +34,7 @@ mod setuptools;
 #[cfg(test)]
 mod tests;
 mod tox;
+mod towncrier;
 mod uv;
 
 #[pyclass(frozen, get_all)]
@@ -193,6 +194,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     bandit::fix(&mut tables);
     maturin::fix(&mut tables);
     codespell::fix(&mut tables);
+    towncrier::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -25,6 +25,7 @@ mod pyright_tests;
 mod ruff_tests;
 mod setuptools_tests;
 mod tox_tests;
+mod towncrier_tests;
 mod uv_tests;
 
 pub fn collect_entries(tables: &common::table::Tables) -> Vec<SyntaxElement> {

--- a/pyproject-fmt/rust/src/tests/towncrier_tests.rs
+++ b/pyproject-fmt/rust/src/tests/towncrier_tests.rs
@@ -1,0 +1,168 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::towncrier::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.towncrier"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_towncrier_order() {
+    let start = indoc::indoc! {r#"
+    [tool.towncrier]
+    wrap = true
+    directory = "changes"
+    filename = "CHANGELOG.md"
+    package = "my_pkg"
+    name = "My Project"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.towncrier]
+    name = "My Project"
+    package = "my_pkg"
+    directory = "changes"
+    filename = "CHANGELOG.md"
+    wrap = true
+    "#);
+}
+
+#[test]
+fn test_towncrier_type_aot_inner_order() {
+    let start = indoc::indoc! {r#"
+    [[tool.towncrier.type]]
+    showcontent = true
+    name = "Added"
+    directory = "added"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.towncrier]
+    type = [ { showcontent = true, name = "Added", directory = "added" } ]
+    "#);
+}
+
+#[test]
+fn test_towncrier_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.towncrier]
+    name = "Demo"
+    package = "demo"
+    directory = "changes"
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}
+
+#[test]
+fn test_towncrier_no_table_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "x"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "x"
+    "#);
+}
+
+#[test]
+fn test_towncrier_ignore_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.towncrier]
+    package = "p"
+    ignore = ["zeta.rst", "alpha.rst", "beta.rst"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.towncrier]
+    package = "p"
+    ignore = [ "alpha.rst", "beta.rst", "zeta.rst" ]
+    "#);
+}
+
+#[test]
+fn test_towncrier_long_format_type_aot() {
+    let start = indoc::indoc! {r#"
+    [tool.towncrier]
+    package = "p"
+
+    [[tool.towncrier.type]]
+    showcontent = true
+    name = "Added"
+    directory = "added"
+
+    [[tool.towncrier.type]]
+    showcontent = false
+    name = "Removed"
+    directory = "removed"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[[tool.towncrier.type]]"));
+    let first_block = result.split("[[tool.towncrier.type]]").nth(1).unwrap();
+    assert!(first_block.find("directory").unwrap() < first_block.find("name").unwrap());
+    assert!(first_block.find("name").unwrap() < first_block.find("showcontent").unwrap());
+}
+
+#[test]
+fn test_towncrier_long_format_section_aot() {
+    let start = indoc::indoc! {r#"
+    [tool.towncrier]
+    package = "p"
+
+    [[tool.towncrier.section]]
+    showcontent = true
+    name = "Core"
+    path = "src/core"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[[tool.towncrier.section]]"));
+    let block = result.split("[[tool.towncrier.section]]").nth(1).unwrap();
+    assert!(block.find("path").unwrap() < block.find("name").unwrap());
+    assert!(block.find("name").unwrap() < block.find("showcontent").unwrap());
+}

--- a/pyproject-fmt/rust/src/towncrier.rs
+++ b/pyproject-fmt/rust/src/towncrier.rs
@@ -1,0 +1,71 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    // Package identity
+    "name",
+    "version",
+    "package",
+    "package_dir",
+    // News location
+    "directory",
+    "filename",
+    "start_string",
+    "template",
+    "title_format",
+    "issue_format",
+    "underlines",
+    // Rendering
+    "wrap",
+    "all_bullets",
+    "single_file",
+    "orphan_prefix",
+    "create_eof_newline",
+    "create_add_extension",
+    // Behavior
+    "ignore",
+    // AoT entries last
+    "type",
+    "section",
+];
+
+pub fn fix(tables: &mut Tables) {
+    fix_root(tables);
+    fix_type_aot(tables);
+    fix_section_aot(tables);
+}
+
+fn fix_root(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.towncrier") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if key.as_str() == "ignore" {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}
+
+fn fix_type_aot(tables: &mut Tables) {
+    let Some(entries) = tables.get("tool.towncrier.type") else {
+        return;
+    };
+    for entry_ref in entries {
+        let table = &mut entry_ref.borrow_mut();
+        reorder_table_keys(table, &["", "directory", "name", "showcontent"]);
+    }
+}
+
+fn fix_section_aot(tables: &mut Tables) {
+    let Some(entries) = tables.get("tool.towncrier.section") else {
+        return;
+    };
+    for entry_ref in entries {
+        let table = &mut entry_ref.borrow_mut();
+        reorder_table_keys(table, &["", "path", "name", "showcontent"]);
+    }
+}


### PR DESCRIPTION
[Towncrier](https://towncrier.readthedocs.io/) ([pyproject.toml config](https://towncrier.readthedocs.io/en/stable/configuration.html)) appears in ~1.3k `pyproject.toml` on GitHub. ✨ Keys group: package identity → news location → rendering → behavior → AoT entries last. `[[tool.towncrier.type]]` entries get `directory` → `name` → `showcontent` ordering; `[[tool.towncrier.section]]` entries get `path` → `name` → `showcontent`. Array order itself is preserved (display order in the rendered changelog). The `ignore` array alphabetizes.

🐛 This PR also carries the same `common` triple-literal string fix as #324.