### PR TITLE
✨ feat(pyproject-fmt): add [tool.pylint.*] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1045,6 +1045,22 @@ Top-level ordering: package identity (``name``, ``version``, ``package``, ``pack
 (display order in the rendered changelog).
 
 **Sorted arrays:** ``ignore`` (file globs to skip).
+``[tool.pylint.*]``
+~~~~~~~~~~~~~~~~~~~
+
+Sub-table order: ``main`` (and legacy alias ``master``) → ``messages_control`` → ``reports`` → ``basic`` →
+``format`` → ``design`` → ``classes`` → ``exceptions`` → ``imports`` → ``logging`` → ``method_args`` →
+``refactoring`` → ``similarities`` → ``spelling`` → ``string`` → ``typecheck`` → ``variables`` →
+``miscellaneous``.
+
+**Sorted arrays:** ``enable``, ``disable``, ``load-plugins``, ``extension-pkg-allow-list``,
+``extension-pkg-whitelist``, ``ignore``, ``ignore-patterns``, ``ignore-paths``, ``ignored-modules``,
+``ignored-classes``, ``ignored-argument-names``, ``good-names``, ``bad-names``, ``logging-modules``,
+``valid-classmethod-first-arg``, ``valid-metaclass-classmethod-first-arg``, ``callbacks``,
+``additional-builtins``, ``allowed-redefined-builtins``, ``preferred-modules``, ``deprecated-modules``,
+``known-third-party``, ``known-standard-library``, ``allowed-modules``, ``expected-line-ending-format``,
+``overgeneral-exceptions``, ``defining-attr-methods``, ``exclude-protected``. Match is on the leaf key name
+regardless of which sub-table it appears in.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -29,6 +29,7 @@ mod pixi;
 mod poetry;
 mod pytest;
 mod pyright;
+mod pylint;
 mod ruff;
 mod setuptools;
 #[cfg(test)]
@@ -195,6 +196,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     maturin::fix(&mut tables);
     codespell::fix(&mut tables);
     towncrier::fix(&mut tables);
+    pylint::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/pylint.rs
+++ b/pyproject-fmt/rust/src/pylint.rs
@@ -1,0 +1,82 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Sub-table order follows the pylint docs (main → messages_control → category checks);
+// keys within each sub-table alphabetize, since a hand-curated full order would rot.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "main",
+    "master", // legacy alias of `main`
+    "messages_control",
+    "messages control", // historic ini-style key name
+    "reports",
+    "basic",
+    "format",
+    "design",
+    "classes",
+    "exceptions",
+    "imports",
+    "logging",
+    "method_args",
+    "refactoring",
+    "similarities",
+    "spelling",
+    "string",
+    "typecheck",
+    "variables",
+    "miscellaneous",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.pylint") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if is_sortable_array(key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}
+
+fn is_sortable_array(key: &str) -> bool {
+    // Match the leaf key: identifier/rule-code/module-path lists are all set semantics.
+    let leaf = key.rsplit('.').next().unwrap_or(key);
+    matches!(
+        leaf,
+        "enable"
+            | "disable"
+            | "load-plugins"
+            | "extension-pkg-allow-list"
+            | "extension-pkg-whitelist"
+            | "ignore"
+            | "ignore-patterns"
+            | "ignore-paths"
+            | "ignored-modules"
+            | "ignored-classes"
+            | "ignored-argument-names"
+            | "good-names"
+            | "bad-names"
+            | "init-import"
+            | "logging-modules"
+            | "valid-classmethod-first-arg"
+            | "valid-metaclass-classmethod-first-arg"
+            | "callbacks"
+            | "additional-builtins"
+            | "allowed-redefined-builtins"
+            | "dummy-variables-rgx"
+            | "exclude-too-few-public-methods"
+            | "preferred-modules"
+            | "deprecated-modules"
+            | "known-third-party"
+            | "known-standard-library"
+            | "allowed-modules"
+            | "expected-line-ending-format"
+            | "overgeneral-exceptions"
+            | "defining-attr-methods"
+            | "exclude-protected"
+            | "valid-class-attribute-rgx"
+    )
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -22,6 +22,7 @@ mod poetry_tests;
 mod project_tests;
 mod pytest_tests;
 mod pyright_tests;
+mod pylint_tests;
 mod ruff_tests;
 mod setuptools_tests;
 mod tox_tests;

--- a/pyproject-fmt/rust/src/tests/pylint_tests.rs
+++ b/pyproject-fmt/rust/src/tests/pylint_tests.rs
@@ -1,0 +1,68 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::pylint::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.pylint"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_pylint_main_before_messages_control() {
+    let start = indoc::indoc! {r#"
+    [tool.pylint.format]
+    max-line-length = 120
+
+    [tool.pylint.messages_control]
+    disable = ["C0114", "C0115"]
+
+    [tool.pylint.main]
+    jobs = 4
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pylint]
+    main.jobs = 4
+    messages_control.disable = [ "C0114", "C0115" ]
+    format.max-line-length = 120
+    "#);
+}
+
+#[test]
+fn test_pylint_disable_enable_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.pylint.messages_control]
+    disable = ["W0621", "C0114", "R0903", "C0115"]
+    enable = ["W0612", "C0103"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pylint]
+    messages_control.disable = [ "C0114", "C0115", "R0903", "W0621" ]
+    messages_control.enable = [ "C0103", "W0612" ]
+    "#);
+}
+
+#[test]
+fn test_pylint_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.pylint.main]
+    jobs = 4
+    [tool.pylint.messages_control]
+    disable = [ "C0114", "C0115" ]
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}


### PR DESCRIPTION
[Pylint](https://pylint.readthedocs.io/) ([pyproject.toml config](https://pylint.readthedocs.io/en/stable/user_guide/configuration/index.html)) (~4k aggregated `pyproject.toml` on GitHub) groups its hundreds of options into ~18 named sub-tables. ✨ The handler orders them `main` → `messages_control` → `reports` → `basic` → `format` → `design` → `classes` → `exceptions` → `imports` → `logging` → `method_args` → `refactoring` → `similarities` → `spelling` → `string` → `typecheck` → `variables` → `miscellaneous`. Within each sub-table, keys alphabetize via the default `reorder_table_keys` fallback.

🔧 Array sorting is keyed on the leaf key name (`enable`, `disable`, `load-plugins`, `ignore`, `ignored-modules`, `good-names`, etc.) so it fires regardless of which sub-table the array lives in. The full alphabetized list of recognized array-leaf names covers pylint's canonical "list of identifiers / rule codes / module paths" keys.

🐛 This PR also carries the same `common` triple-literal string fix as #324.