### PR TITLE
✨ feat(pyproject-fmt): add [tool.djlint] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1061,6 +1061,11 @@ Sub-table order: ``main`` (and legacy alias ``master``) → ``messages_control``
 ``known-third-party``, ``known-standard-library``, ``allowed-modules``, ``expected-line-ending-format``,
 ``overgeneral-exceptions``, ``defining-attr-methods``, ``exclude-protected``. Match is on the leaf key name
 regardless of which sub-table it appears in.
+``[tool.djlint]``
+~~~~~~~~~~~~~~~~~
+
+Profile/scope → formatting → linting → ignores → output. **Sorted arrays:** ``exclude``, ``extend_exclude``,
+``custom_blocks``, ``custom_html``, ``ignore``, ``ignore_blocks``.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/djlint.rs
+++ b/pyproject-fmt/rust/src/djlint.rs
@@ -1,0 +1,68 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    // Profile / scope
+    "profile",
+    "extension",
+    "include",
+    "exclude",
+    "extend_exclude",
+    "use_gitignore",
+    // Formatting
+    "indent",
+    "indent_css",
+    "indent_js",
+    "max_attribute_length",
+    "max_blank_lines",
+    "max_line_length",
+    "preserve_blank_lines",
+    "preserve_leading_space",
+    "blank_line_after_tag",
+    "blank_line_before_tag",
+    "line_break_after_multiline_tag",
+    "close_void_tags",
+    "no_function_formatting",
+    "no_set_formatting",
+    "no_line_after_yaml",
+    "format_attribute_template_tags",
+    "format_css",
+    "format_js",
+    "custom_blocks",
+    "custom_html",
+    // Linting
+    "lint",
+    "reformat",
+    "statistics",
+    "require_pragma",
+    "ignore_case",
+    "ignore_blocks",
+    "ignore",
+    "per_file_ignores",
+    // Output
+    "quiet",
+];
+
+const SORT_ARRAYS: &[&str] = &[
+    "exclude",
+    "extend_exclude",
+    "custom_blocks",
+    "custom_html",
+    "ignore",
+    "ignore_blocks",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.djlint") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -19,6 +19,7 @@ mod cibuildwheel;
 mod bandit;
 mod codespell;
 mod coverage;
+mod djlint;
 mod global;
 mod mypy;
 mod hatch;
@@ -197,6 +198,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     codespell::fix(&mut tables);
     towncrier::fix(&mut tables);
     pylint::fix(&mut tables);
+    djlint::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/djlint_tests.rs
+++ b/pyproject-fmt/rust/src/tests/djlint_tests.rs
@@ -1,0 +1,50 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::djlint::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.djlint"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_djlint_order_and_sort() {
+    let start = indoc::indoc! {r#"
+    [tool.djlint]
+    max_line_length = 120
+    indent = 2
+    ignore = ["H006", "H013", "H005"]
+    profile = "django"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.djlint]
+    profile = "django"
+    indent = 2
+    max_line_length = 120
+    ignore = [ "H005", "H006", "H013" ]
+    "#);
+}
+
+#[test]
+fn test_djlint_idempotent() {
+    let start = indoc::indoc! {r#"
+    [tool.djlint]
+    profile = "django"
+    indent = 2
+    "#};
+    let once = evaluate(start);
+    let twice = evaluate(&once);
+    assert_eq!(once, twice);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod cibuildwheel_tests;
 mod codespell_tests;
 mod coverage_tests;
 mod dependency_groups_tests;
+mod djlint_tests;
 mod global_tests;
 mod hatch_tests;
 mod isort_tests;


### PR DESCRIPTION
[djlint](https://www.djlint.com/) ([pyproject.toml config](https://www.djlint.com/docs/configuration/)) (Django/Jinja templating linter+formatter) — ~1.7k pyproject.toml on GitHub. Top-level order: profile/scope → formatting → linting → ignores → output. Sorted arrays: `exclude`, `extend_exclude`, `custom_blocks`, `custom_html`, `ignore`, `ignore_blocks`. Also bundles the common triple-literal string fix from #324.