### PR TITLE
✨ feat(pyproject-fmt): add [tool.yapf] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1066,6 +1066,11 @@ regardless of which sub-table it appears in.
 
 Profile/scope → formatting → linting → ignores → output. **Sorted arrays:** ``exclude``, ``extend_exclude``,
 ``custom_blocks``, ``custom_html``, ``ignore``, ``ignore_blocks``.
+``[tool.yapf]``
+~~~~~~~~~~~~~~~
+
+Single flat table. ``based_on_style`` first (it sets defaults), then ``column_limit``, ``indent_width``,
+``continuation_indent_width``, then the rest alphabetized.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -38,6 +38,7 @@ mod tests;
 mod tox;
 mod towncrier;
 mod uv;
+mod yapf;
 
 #[pyclass(frozen, get_all)]
 pub struct Settings {
@@ -199,6 +200,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     towncrier::fix(&mut tables);
     pylint::fix(&mut tables);
     djlint::fix(&mut tables);
+    yapf::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -29,6 +29,7 @@ mod setuptools_tests;
 mod tox_tests;
 mod towncrier_tests;
 mod uv_tests;
+mod yapf_tests;
 
 pub fn collect_entries(tables: &common::table::Tables) -> Vec<SyntaxElement> {
     tables.table_set.iter().flat_map(|e| e.borrow().clone()).collect()

--- a/pyproject-fmt/rust/src/tests/yapf_tests.rs
+++ b/pyproject-fmt/rust/src/tests/yapf_tests.rs
@@ -1,0 +1,36 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::yapf::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.yapf"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_yapf_based_on_style_first() {
+    let start = indoc::indoc! {r#"
+    [tool.yapf]
+    column_limit = 120
+    indent_width = 4
+    based_on_style = "google"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.yapf]
+    based_on_style = "google"
+    column_limit = 120
+    indent_width = 4
+    "#);
+}

--- a/pyproject-fmt/rust/src/yapf.rs
+++ b/pyproject-fmt/rust/src/yapf.rs
@@ -1,0 +1,19 @@
+use common::table::{reorder_table_keys, Tables};
+
+// based_on_style sets defaults and column_limit is most-used, so they lead; the rest
+// alphabetizes via the fallback.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "based_on_style",
+    "column_limit",
+    "indent_width",
+    "continuation_indent_width",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.yapf") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    reorder_table_keys(table, KEY_ORDER);
+}


### PR DESCRIPTION
[yapf](https://github.com/google/yapf) ([pyproject.toml config](https://github.com/google/yapf#knobs)) — ~1.7k pyproject.toml on GitHub. Single flat table; `based_on_style` first (it sets defaults), then `column_limit`, `indent_width`, `continuation_indent_width`, then the rest alphabetized. Also bundles the common triple-literal string fix from #324.