### PR TITLE
✨ feat(pyproject-fmt): add [tool.check-manifest] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1071,6 +1071,11 @@ Profile/scope → formatting → linting → ignores → output. **Sorted arrays
 
 Single flat table. ``based_on_style`` first (it sets defaults), then ``column_limit``, ``indent_width``,
 ``continuation_indent_width``, then the rest alphabetized.
+``[tool.check-manifest]``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ignore`` → ``ignore-bad-ideas`` → ``ignore-default-rules``. Both ``ignore`` and ``ignore-bad-ideas`` (file-glob
+lists) alphabetize.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/check_manifest.rs
+++ b/pyproject-fmt/rust/src/check_manifest.rs
@@ -1,0 +1,20 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Arrays are file-glob lists with set semantics, so they sort.
+const KEY_ORDER: &[&str] = &["", "ignore", "ignore-bad-ideas", "ignore-default-rules"];
+const SORT_ARRAYS: &[&str] = &["ignore", "ignore-bad-ideas"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.check-manifest") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -18,6 +18,7 @@ mod black;
 mod cibuildwheel;
 mod bandit;
 mod codespell;
+mod check_manifest;
 mod coverage;
 mod djlint;
 mod global;
@@ -201,6 +202,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     pylint::fix(&mut tables);
     djlint::fix(&mut tables);
     yapf::fix(&mut tables);
+    check_manifest::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/check_manifest_tests.rs
+++ b/pyproject-fmt/rust/src/tests/check_manifest_tests.rs
@@ -1,0 +1,34 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::check_manifest::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.check-manifest"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_check_manifest_sort() {
+    let start = indoc::indoc! {r#"
+    [tool.check-manifest]
+    ignore-default-rules = true
+    ignore = ["zebra.txt", "alpha.txt"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.check-manifest]
+    ignore = [ "alpha.txt", "zebra.txt" ]
+    ignore-default-rules = true
+    "#);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod build_systems_tests;
 mod commitizen_tests;
 mod cibuildwheel_tests;
 mod codespell_tests;
+mod check_manifest_tests;
 mod coverage_tests;
 mod dependency_groups_tests;
 mod djlint_tests;


### PR DESCRIPTION
[check-manifest](https://github.com/mgedmin/check-manifest) ([pyproject.toml config](https://github.com/mgedmin/check-manifest#configuration)) — ~1.6k pyproject.toml on GitHub. Tiny schema: `ignore` → `ignore-bad-ideas` → `ignore-default-rules`. Both file-glob arrays alphabetize. Also bundles the common triple-literal string fix from #324.