### PR TITLE
✨ feat(pyproject-fmt): add [tool.pyrefly] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1076,6 +1076,13 @@ Single flat table. ``based_on_style`` first (it sets defaults), then ``column_li
 
 ``ignore`` → ``ignore-bad-ideas`` → ``ignore-default-rules``. Both ``ignore`` and ``ignore-bad-ideas`` (file-glob
 lists) alphabetize.
+``[tool.pyrefly]``
+~~~~~~~~~~~~~~~~~~
+
+Meta's type checker. Order: ``python_version`` → ``python_platform`` → ``python_interpreter`` →
+``project_includes`` → ``project_excludes`` → ``search_path`` → ``site_package_path`` →
+``use_untyped_imports`` → ``replace_imports_with_any`` → ``ignore_errors_in_generated_code`` → ``errors``.
+Path arrays alphabetize.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -32,6 +32,7 @@ mod poetry;
 mod pytest;
 mod pyright;
 mod pylint;
+mod pyrefly;
 mod ruff;
 mod setuptools;
 #[cfg(test)]
@@ -203,6 +204,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     djlint::fix(&mut tables);
     yapf::fix(&mut tables);
     check_manifest::fix(&mut tables);
+    pyrefly::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/pyrefly.rs
+++ b/pyproject-fmt/rust/src/pyrefly.rs
@@ -1,0 +1,40 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Group: platform → paths → behavior → errors.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "python_version",
+    "python_platform",
+    "python_interpreter",
+    "project_includes",
+    "project_excludes",
+    "search_path",
+    "site_package_path",
+    "use_untyped_imports",
+    "replace_imports_with_any",
+    "ignore_errors_in_generated_code",
+    "errors",
+];
+
+const SORT_ARRAYS: &[&str] = &[
+    "project_includes",
+    "project_excludes",
+    "search_path",
+    "site_package_path",
+    "replace_imports_with_any",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.pyrefly") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -25,6 +25,7 @@ mod project_tests;
 mod pytest_tests;
 mod pyright_tests;
 mod pylint_tests;
+mod pyrefly_tests;
 mod ruff_tests;
 mod setuptools_tests;
 mod tox_tests;

--- a/pyproject-fmt/rust/src/tests/pyrefly_tests.rs
+++ b/pyproject-fmt/rust/src/tests/pyrefly_tests.rs
@@ -1,0 +1,129 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::pyrefly::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.pyrefly"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_pyrefly_order() {
+    let start = indoc::indoc! {r#"
+    [tool.pyrefly]
+    project_includes = ["src"]
+    python_version = "3.12"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyrefly]
+    python_version = "3.12"
+    project_includes = [ "src" ]
+    "#);
+}
+
+#[test]
+fn test_pyrefly_no_table_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "x"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "x"
+    "#);
+}
+
+#[test]
+fn test_pyrefly_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.pyrefly]
+    project_includes = ["zeta/**", "alpha/**"]
+    project_excludes = ["zbuild", "abuild"]
+    search_path = ["z_path", "a_path"]
+    site_package_path = ["z_site", "a_site"]
+    replace_imports_with_any = ["z_pkg", "a_pkg"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyrefly]
+    project_includes = [ "alpha/**", "zeta/**" ]
+    project_excludes = [ "abuild", "zbuild" ]
+    search_path = [ "a_path", "z_path" ]
+    site_package_path = [ "a_site", "z_site" ]
+    replace_imports_with_any = [ "a_pkg", "z_pkg" ]
+    "#);
+}
+
+#[test]
+fn test_pyrefly_non_sortable_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.pyrefly]
+    python_interpreter = "/usr/bin/python3"
+    use_untyped_imports = true
+    python_version = "3.12"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyrefly]
+    python_version = "3.12"
+    python_interpreter = "/usr/bin/python3"
+    use_untyped_imports = true
+    "#);
+}
+
+#[test]
+fn test_pyrefly_long_format() {
+    let start = indoc::indoc! {r#"
+    [tool.pyrefly]
+    project_includes = ["zeta/**", "alpha/**"]
+    python_version = "3.12"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.pyrefly]"));
+    assert!(result.find("alpha").unwrap() < result.find("zeta").unwrap());
+    assert!(result.find("python_version").unwrap() < result.find("project_includes").unwrap());
+}


### PR DESCRIPTION
[Pyrefly](https://pyrefly.org/) ([pyproject.toml config](https://pyrefly.org/en/docs/configuration/)) (Meta's Python type checker) — ~1.6k pyproject.toml on GitHub. Order: platform → paths → behavior → errors table. Path arrays alphabetize. Also bundles the common triple-literal string fix from #324.