### PR TITLE
✨ feat(pyproject-fmt): add [tool.semantic_release] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1083,6 +1083,12 @@ Meta's type checker. Order: ``python_version`` → ``python_platform`` → ``pyt
 ``project_includes`` → ``project_excludes`` → ``search_path`` → ``site_package_path`` →
 ``use_untyped_imports`` → ``replace_imports_with_any`` → ``ignore_errors_in_generated_code`` → ``errors``.
 Path arrays alphabetize.
+``[tool.semantic_release]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+python-semantic-release. Order: tag/version → assets → version source → repo → commit parser → branches →
+publish → changelog → remote. Sorted arrays: ``version_variables``, ``version_toml``, ``assets``,
+``exclude_commit_patterns``.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -35,6 +35,7 @@ mod pylint;
 mod pyrefly;
 mod ruff;
 mod setuptools;
+mod semantic_release;
 #[cfg(test)]
 mod tests;
 mod tox;
@@ -205,6 +206,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     yapf::fix(&mut tables);
     check_manifest::fix(&mut tables);
     pyrefly::fix(&mut tables);
+    semantic_release::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/semantic_release.rs
+++ b/pyproject-fmt/rust/src/semantic_release.rs
@@ -1,0 +1,46 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Group: tag/version → assets → version source → repo → commit parser → branches →
+// publish → changelog → remote.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "tag_format",
+    "major_on_zero",
+    "allow_zero_version",
+    "version_variables",
+    "version_toml",
+    "version_pattern",
+    "version_translator",
+    "build_command",
+    "build_command_env",
+    "no_git_verify",
+    "assets",
+    "repo_dir",
+    "commit_message",
+    "commit_author",
+    "logging_use_named_masks",
+    "exclude_commit_patterns",
+    "commit_parser",
+    "commit_parser_options",
+    "branches",
+    "publish",
+    "changelog",
+    "remote",
+];
+
+const SORT_ARRAYS: &[&str] = &["version_variables", "version_toml", "assets", "exclude_commit_patterns"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.semantic_release") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -30,6 +30,7 @@ mod ruff_tests;
 mod setuptools_tests;
 mod tox_tests;
 mod towncrier_tests;
+mod semantic_release_tests;
 mod uv_tests;
 mod yapf_tests;
 

--- a/pyproject-fmt/rust/src/tests/semantic_release_tests.rs
+++ b/pyproject-fmt/rust/src/tests/semantic_release_tests.rs
@@ -1,0 +1,36 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::semantic_release::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.semantic_release"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_semantic_release_order() {
+    let start = indoc::indoc! {r#"
+    [tool.semantic_release]
+    version_toml = ["pyproject.toml:project.version"]
+    assets = ["zebra.txt", "alpha.txt"]
+    tag_format = "v{version}"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.semantic_release]
+    tag_format = "v{version}"
+    version_toml = [ "pyproject.toml:project.version" ]
+    assets = [ "alpha.txt", "zebra.txt" ]
+    "#);
+}


### PR DESCRIPTION
[python-semantic-release](https://python-semantic-release.readthedocs.io/) ([pyproject.toml config](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration.html)) — ~1.5k pyproject.toml on GitHub. Order: tag/version → assets → version source → repo → commit parser → branches → publish → changelog → remote. Sorted arrays: `version_variables`, `version_toml`, `assets`, `exclude_commit_patterns`. Also bundles the common triple-literal string fix from #324.