### PR TITLE
✨ feat(pyproject-fmt): add [tool.scikit-build] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1089,6 +1089,16 @@ Path arrays alphabetize.
 python-semantic-release. Order: tag/version → assets → version source → repo → commit parser → branches →
 publish → changelog → remote. Sorted arrays: ``version_variables``, ``version_toml``, ``assets``,
 ``exclude_commit_patterns``.
+``[tool.scikit-build]``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+scikit-build-core (CMake builds for Python). Top-level order: meta keys (``minimum-version``, ``build-dir``,
+``fail``, ``experimental``, ``strict-config``) → ``build`` → ``cmake`` → ``ninja`` → ``sdist`` → ``wheel`` →
+``install`` → ``editable`` → ``logging`` / ``messages`` → ``metadata`` → ``search`` → ``generate`` AoT →
+``overrides`` AoT.
+
+**Sorted arrays:** ``include``, ``exclude``, ``packages``, ``files``, ``targets``, ``components``,
+``exclude-fields``. ``args`` and ``define`` (CLI argv for cmake/ninja) are preserved as written.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -36,6 +36,7 @@ mod pyrefly;
 mod ruff;
 mod setuptools;
 mod semantic_release;
+mod scikit_build;
 #[cfg(test)]
 mod tests;
 mod tox;
@@ -207,6 +208,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     check_manifest::fix(&mut tables);
     pyrefly::fix(&mut tables);
     semantic_release::fix(&mut tables);
+    scikit_build::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/scikit_build.rs
+++ b/pyproject-fmt/rust/src/scikit_build.rs
@@ -1,0 +1,59 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    // top-level
+    "minimum-version",
+    "build-dir",
+    "fail",
+    "experimental",
+    "strict-config",
+    // build
+    "build",
+    // cmake
+    "cmake",
+    "ninja",
+    // distribution
+    "sdist",
+    "wheel",
+    "install",
+    "editable",
+    // logging / messages
+    "logging",
+    "messages",
+    // metadata
+    "metadata",
+    "search",
+    // generate (AoT)
+    "generate",
+    // overrides (AoT)
+    "overrides",
+];
+
+fn is_sortable(key: &str) -> bool {
+    let leaf = key.rsplit('.').next().unwrap_or(key);
+    matches!(
+        leaf,
+        "include" | "exclude" | "packages" | "files" | "args" | "define" | "targets" | "components" | "exclude-fields"
+    )
+}
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.scikit-build") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        // args/define are CLI argv and cache entries: reordering changes behavior.
+        let leaf = key.as_str().rsplit('.').next().unwrap_or(key.as_str());
+        if matches!(leaf, "args" | "define") {
+            return;
+        }
+        if is_sortable(key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod setuptools_tests;
 mod tox_tests;
 mod towncrier_tests;
 mod semantic_release_tests;
+mod scikit_build_tests;
 mod uv_tests;
 mod yapf_tests;
 

--- a/pyproject-fmt/rust/src/tests/scikit_build_tests.rs
+++ b/pyproject-fmt/rust/src/tests/scikit_build_tests.rs
@@ -1,0 +1,166 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::scikit_build::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.scikit-build"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_scikit_build_order() {
+    let start = indoc::indoc! {r#"
+    [tool.scikit-build]
+    wheel.packages = ["src/foo"]
+    cmake.version = ">=3.20"
+    minimum-version = "0.9"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.scikit-build]
+    minimum-version = "0.9"
+    cmake.version = ">=3.20"
+    wheel.packages = [ "src/foo" ]
+    "#);
+}
+
+#[test]
+fn test_scikit_build_no_table_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "x"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "x"
+    "#);
+}
+
+#[test]
+fn test_scikit_build_args_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.scikit-build]
+    cmake.args = ["-DZ=1", "-DA=2"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.scikit-build]
+    cmake.args = [ "-DZ=1", "-DA=2" ]
+    "#);
+}
+
+#[test]
+fn test_scikit_build_define_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.scikit-build.cmake]
+    define = { Z_FLAG = "z", A_FLAG = "a" }
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.scikit-build]
+    cmake.define = { Z_FLAG = "z", A_FLAG = "a" }
+    "#);
+}
+
+#[test]
+fn test_scikit_build_packages_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.scikit-build]
+    wheel.packages = ["src/zeta", "src/alpha", "src/beta"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.scikit-build]
+    wheel.packages = [ "src/alpha", "src/beta", "src/zeta" ]
+    "#);
+}
+
+#[test]
+fn test_scikit_build_exclude_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.scikit-build]
+    sdist.exclude = ["zeta/**", "alpha/**"]
+    sdist.include = ["zinc/*", "amber/*"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.scikit-build]
+    sdist.exclude = [ "alpha/**", "zeta/**" ]
+    sdist.include = [ "amber/*", "zinc/*" ]
+    "#);
+}
+
+#[test]
+fn test_scikit_build_files_targets_components_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.scikit-build]
+    install.components = ["zlib", "alib"]
+    wheel.exclude-fields = ["metadata.version", "metadata.author"]
+    install.targets = ["zt", "at"]
+    sdist.files = ["zf", "af"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.scikit-build]
+    sdist.files = [ "af", "zf" ]
+    wheel.exclude-fields = [ "metadata.author", "metadata.version" ]
+    install.components = [ "alib", "zlib" ]
+    install.targets = [ "at", "zt" ]
+    "#);
+}
+
+#[test]
+fn test_scikit_build_long_format() {
+    let start = indoc::indoc! {r#"
+    [tool.scikit-build]
+    wheel.packages = ["src/zeta", "src/alpha"]
+    cmake.args = ["-DZ=1", "-DA=2"]
+    minimum-version = "0.9"
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.scikit-build]"));
+    assert!(result.contains("minimum-version = \"0.9\""));
+}


### PR DESCRIPTION
[scikit-build-core](https://scikit-build-core.readthedocs.io/) ([pyproject.toml config](https://scikit-build-core.readthedocs.io/en/latest/configuration/index.html)) (CMake builds for Python) — ~1.5k pyproject.toml on GitHub. Deeply nested schema; top-level groups: meta → build → cmake/ninja → sdist/wheel/install/editable → logging/messages → metadata → generate/overrides AoT. Path arrays alphabetize; cmake/ninja `args` and `define` preserve argv order. Also bundles the common triple-literal string fix from #324.