### PR TITLE
✨ feat(pyproject-fmt): add [tool.bumpversion] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1099,6 +1099,13 @@ scikit-build-core (CMake builds for Python). Top-level order: meta keys (``minim
 
 **Sorted arrays:** ``include``, ``exclude``, ``packages``, ``files``, ``targets``, ``components``,
 ``exclude-fields``. ``args`` and ``define`` (CLI argv for cmake/ninja) are preserved as written.
+``[tool.bumpversion]``
+~~~~~~~~~~~~~~~~~~~~~~
+
+bump-my-version / legacy bumpversion. Order: identity (``current_version``) → format (``parse``, ``serialize``,
+``search``, ``replace``, ``regex``, ``ignore_missing_*``) → tag (``tag``, ``sign_tags``, ``tag_name``,
+``tag_message``) → commit (``allow_dirty``, ``commit``, ``commit_args``, ``message``, ``moveable_tags``) →
+behavior → ``files`` / ``parts`` AoT last.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/bumpversion.rs
+++ b/pyproject-fmt/rust/src/bumpversion.rs
@@ -1,0 +1,35 @@
+use common::table::{reorder_table_keys, Tables};
+
+// Group: identity → format → tag → commit → behavior → [[files]]/[[parts]] (AoT, last).
+const KEY_ORDER: &[&str] = &[
+    "",
+    "current_version",
+    "parse",
+    "serialize",
+    "search",
+    "replace",
+    "regex",
+    "ignore_missing_version",
+    "ignore_missing_files",
+    "tag",
+    "sign_tags",
+    "tag_name",
+    "tag_message",
+    "allow_dirty",
+    "commit",
+    "commit_args",
+    "message",
+    "moveable_tags",
+    "pre_n_label",
+    "pre_l_label",
+    "files",
+    "parts",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.bumpversion") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -19,6 +19,7 @@ mod cibuildwheel;
 mod bandit;
 mod codespell;
 mod check_manifest;
+mod bumpversion;
 mod coverage;
 mod djlint;
 mod global;
@@ -209,6 +210,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     pyrefly::fix(&mut tables);
     semantic_release::fix(&mut tables);
     scikit_build::fix(&mut tables);
+    bumpversion::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/bumpversion_tests.rs
+++ b/pyproject-fmt/rust/src/tests/bumpversion_tests.rs
@@ -1,0 +1,36 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::bumpversion::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.bumpversion"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_bumpversion_order() {
+    let start = indoc::indoc! {r#"
+    [tool.bumpversion]
+    commit = true
+    tag = true
+    current_version = "1.0.0"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.bumpversion]
+    current_version = "1.0.0"
+    tag = true
+    commit = true
+    "#);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod commitizen_tests;
 mod cibuildwheel_tests;
 mod codespell_tests;
 mod check_manifest_tests;
+mod bumpversion_tests;
 mod coverage_tests;
 mod dependency_groups_tests;
 mod djlint_tests;


### PR DESCRIPTION
[bump-my-version](https://callowayproject.github.io/bump-my-version/) ([pyproject.toml config](https://callowayproject.github.io/bump-my-version/reference/configuration/)) / legacy bumpversion — ~1.4k pyproject.toml on GitHub. Order: identity → format → tag → commit → behavior → `files` / `parts` AoT last. Also bundles the common triple-literal string fix from #324.