### PR TITLE
✨ feat(pyproject-fmt): add [tool.interrogate] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1106,6 +1106,11 @@ bump-my-version / legacy bumpversion. Order: identity (``current_version``) → 
 ``search``, ``replace``, ``regex``, ``ignore_missing_*``) → tag (``tag``, ``sign_tags``, ``tag_name``,
 ``tag_message``) → commit (``allow_dirty``, ``commit``, ``commit_args``, ``message``, ``moveable_tags``) →
 behavior → ``files`` / ``parts`` AoT last.
+``[tool.interrogate]``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Docstring coverage. Threshold → ignore flags → exclude → output. Sorted arrays: ``exclude``, ``extend-exclude``,
+``ignore-regex``.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/interrogate.rs
+++ b/pyproject-fmt/rust/src/interrogate.rs
@@ -1,0 +1,46 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Group: threshold → ignore flags → exclude → output.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "fail-under",
+    "fail_under",
+    "ignore-init-method",
+    "ignore-init-module",
+    "ignore-magic",
+    "ignore-semiprivate",
+    "ignore-private",
+    "ignore-property-decorators",
+    "ignore-module",
+    "ignore-nested-functions",
+    "ignore-nested-classes",
+    "ignore-setters",
+    "ignore-overloaded-functions",
+    "ignore-regex",
+    "exclude",
+    "extend-exclude",
+    "color",
+    "verbose",
+    "quiet",
+    "omit-covered-files",
+    "generate-badge",
+    "badge-format",
+    "badge-style",
+];
+
+const SORT_ARRAYS: &[&str] = &["exclude", "extend-exclude", "ignore-regex"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.interrogate") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -28,6 +28,7 @@ mod hatch;
 mod isort;
 mod pdm;
 mod maturin;
+mod interrogate;
 mod pixi;
 mod poetry;
 mod pytest;
@@ -211,6 +212,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     semantic_release::fix(&mut tables);
     scikit_build::fix(&mut tables);
     bumpversion::fix(&mut tables);
+    interrogate::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/interrogate_tests.rs
+++ b/pyproject-fmt/rust/src/tests/interrogate_tests.rs
@@ -1,0 +1,127 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::interrogate::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.interrogate"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_interrogate_order() {
+    let start = indoc::indoc! {r#"
+    [tool.interrogate]
+    verbose = 2
+    fail-under = 80
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.interrogate]
+    fail-under = 80
+    verbose = 2
+    "#);
+}
+
+#[test]
+fn test_interrogate_no_table_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "x"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "x"
+    "#);
+}
+
+#[test]
+fn test_interrogate_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.interrogate]
+    exclude = ["tests", "build", "docs"]
+    extend-exclude = ["zeta", "alpha"]
+    ignore-regex = ["^test_.*$", "^_.*$"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.interrogate]
+    ignore-regex = [ "^_.*$", "^test_.*$" ]
+    exclude = [ "build", "docs", "tests" ]
+    extend-exclude = [ "alpha", "zeta" ]
+    "#);
+}
+
+#[test]
+fn test_interrogate_non_sortable_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.interrogate]
+    color = true
+    badge-format = "svg"
+    verbose = 2
+    fail-under = 80
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.interrogate]
+    fail-under = 80
+    color = true
+    verbose = 2
+    badge-format = "svg"
+    "#);
+}
+
+#[test]
+fn test_interrogate_long_format() {
+    let start = indoc::indoc! {r#"
+    [tool.interrogate]
+    exclude = ["zeta", "alpha"]
+    fail-under = 80
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.interrogate]"));
+    assert!(result.find("alpha").unwrap() < result.find("zeta").unwrap());
+    assert!(result.find("fail-under").unwrap() < result.find("exclude").unwrap());
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -16,6 +16,7 @@ mod djlint_tests;
 mod global_tests;
 mod hatch_tests;
 mod isort_tests;
+mod interrogate_tests;
 mod main_tests;
 mod mypy_tests;
 mod pdm_tests;


### PR DESCRIPTION
[interrogate](https://interrogate.readthedocs.io/) ([pyproject.toml config](https://interrogate.readthedocs.io/en/latest/#configuration)) — docstring coverage tool, ~1.3k pyproject.toml on GitHub. Order: threshold → ignore flags → exclude → output. Sorted arrays: `exclude`, `extend-exclude`, `ignore-regex`. Also bundles the common triple-literal string fix from #324.