### PR TITLE
✨ feat(pyproject-fmt): add [tool.docformatter] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1111,6 +1111,12 @@ behavior → ``files`` / ``parts`` AoT last.
 
 Docstring coverage. Threshold → ignore flags → exclude → output. Sorted arrays: ``exclude``, ``extend-exclude``,
 ``ignore-regex``.
+``[tool.docformatter]``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Docstring formatter. Order: behavior (``in-place``, ``recursive``, ``check``, ``diff``, ``black``, ``pep257``,
+``non-strict``) → format width (``line-length``, ``wrap-summaries``, ``wrap-descriptions``, ``tab-width``) →
+wrap/summary tweaks → other.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/docformatter.rs
+++ b/pyproject-fmt/rust/src/docformatter.rs
@@ -1,0 +1,37 @@
+use common::table::{reorder_table_keys, Tables};
+
+// Group: behavior → format width → wrap → other.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "in-place",
+    "recursive",
+    "check",
+    "diff",
+    "black",
+    "pep257",
+    "non-strict",
+    "line-length",
+    "wrap-summaries",
+    "wrap-descriptions",
+    "tab-width",
+    "make-summary-multi-line",
+    "close-quotes-on-newline",
+    "pre-summary-newline",
+    "pre-summary-multi-line",
+    "pre-summary-space",
+    "post-description-blank",
+    "force-wrap",
+    "line-range",
+    "docstring-length",
+    "non-cap",
+    "exclude",
+    "config",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.docformatter") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -22,6 +22,7 @@ mod check_manifest;
 mod bumpversion;
 mod coverage;
 mod djlint;
+mod docformatter;
 mod global;
 mod mypy;
 mod hatch;
@@ -213,6 +214,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     scikit_build::fix(&mut tables);
     bumpversion::fix(&mut tables);
     interrogate::fix(&mut tables);
+    docformatter::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/docformatter_tests.rs
+++ b/pyproject-fmt/rust/src/tests/docformatter_tests.rs
@@ -1,0 +1,34 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::docformatter::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.docformatter"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_docformatter_order() {
+    let start = indoc::indoc! {r#"
+    [tool.docformatter]
+    line-length = 100
+    in-place = true
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.docformatter]
+    in-place = true
+    line-length = 100
+    "#);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod bumpversion_tests;
 mod coverage_tests;
 mod dependency_groups_tests;
 mod djlint_tests;
+mod docformatter_tests;
 mod global_tests;
 mod hatch_tests;
 mod isort_tests;


### PR DESCRIPTION
[docformatter](https://github.com/PyCQA/docformatter) ([pyproject.toml config](https://docformatter.readthedocs.io/en/latest/configuration.html#pyproject-toml)) — docstring formatter, ~1.3k pyproject.toml on GitHub. Order: behavior → format width → wrap/summary tweaks → other. Also bundles the common triple-literal string fix from #324.