### PR TITLE
✨ feat(pyproject-fmt): add [tool.vulture] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1117,6 +1117,12 @@ Docstring coverage. Threshold → ignore flags → exclude → output. Sorted ar
 Docstring formatter. Order: behavior (``in-place``, ``recursive``, ``check``, ``diff``, ``black``, ``pep257``,
 ``non-strict``) → format width (``line-length``, ``wrap-summaries``, ``wrap-descriptions``, ``tab-width``) →
 wrap/summary tweaks → other.
+``[tool.vulture]``
+~~~~~~~~~~~~~~~~~~
+
+Dead-code finder. Order: paths → ignore (``exclude``, ``ignore_names``, ``ignore_decorators``) → behavior
+(``make_whitelist``, ``min_confidence``, ``sort_by_size``) → output (``verbose``). Sorted arrays: ``paths``,
+``exclude``, ``ignore_names``, ``ignore_decorators``.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -46,6 +46,7 @@ mod tox;
 mod towncrier;
 mod uv;
 mod yapf;
+mod vulture;
 
 #[pyclass(frozen, get_all)]
 pub struct Settings {
@@ -215,6 +216,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     bumpversion::fix(&mut tables);
     interrogate::fix(&mut tables);
     docformatter::fix(&mut tables);
+    vulture::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod semantic_release_tests;
 mod scikit_build_tests;
 mod uv_tests;
 mod yapf_tests;
+mod vulture_tests;
 
 pub fn collect_entries(tables: &common::table::Tables) -> Vec<SyntaxElement> {
     tables.table_set.iter().flat_map(|e| e.borrow().clone()).collect()

--- a/pyproject-fmt/rust/src/tests/vulture_tests.rs
+++ b/pyproject-fmt/rust/src/tests/vulture_tests.rs
@@ -1,0 +1,36 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::vulture::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.vulture"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_vulture_order_and_sort() {
+    let start = indoc::indoc! {r#"
+    [tool.vulture]
+    min_confidence = 80
+    ignore_names = ["zlib", "alpha"]
+    paths = ["src", "tests"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.vulture]
+    paths = [ "src", "tests" ]
+    ignore_names = [ "alpha", "zlib" ]
+    min_confidence = 80
+    "#);
+}

--- a/pyproject-fmt/rust/src/vulture.rs
+++ b/pyproject-fmt/rust/src/vulture.rs
@@ -1,0 +1,31 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Group: paths → ignore → behavior → output.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "paths",
+    "exclude",
+    "ignore_names",
+    "ignore_decorators",
+    "make_whitelist",
+    "min_confidence",
+    "sort_by_size",
+    "verbose",
+];
+
+const SORT_ARRAYS: &[&str] = &["paths", "exclude", "ignore_names", "ignore_decorators"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.vulture") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}


### PR DESCRIPTION
vulture — dead-code finder, ~1.2k pyproject.toml on GitHub. Order: paths → ignore → behavior → output. Sorted arrays: `paths`, `exclude`, `ignore_names`, `ignore_decorators`. Also bundles the common triple-literal string fix from #324.