### PR TITLE
✨ feat(pyproject-fmt): add [tool.autopep8] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1123,6 +1123,11 @@ wrap/summary tweaks → other.
 Dead-code finder. Order: paths → ignore (``exclude``, ``ignore_names``, ``ignore_decorators``) → behavior
 (``make_whitelist``, ``min_confidence``, ``sort_by_size``) → output (``verbose``). Sorted arrays: ``paths``,
 ``exclude``, ``ignore_names``, ``ignore_decorators``.
+``[tool.autopep8]``
+~~~~~~~~~~~~~~~~~~~
+
+PEP8 auto-fixer. Order: length/indent → mode (``in-place``, ``recursive``, ``diff``, ``list-fixes``) → rules
+(``ignore``, ``select``, ``exclude``) → behavior. Sorted arrays: ``ignore``, ``select``, ``exclude``.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/autopep8.rs
+++ b/pyproject-fmt/rust/src/autopep8.rs
@@ -1,0 +1,39 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    "max_line_length",
+    "indent_size",
+    "in-place",
+    "recursive",
+    "diff",
+    "list-fixes",
+    "ignore",
+    "select",
+    "exclude",
+    "hang-closing",
+    "aggressive",
+    "experimental",
+    "pep8_passes",
+    "max_doc_length",
+    "global-config",
+    "ignore-local-config",
+    "verbose",
+];
+
+const SORT_ARRAYS: &[&str] = &["ignore", "select", "exclude"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.autopep8") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -20,6 +20,7 @@ mod bandit;
 mod codespell;
 mod check_manifest;
 mod bumpversion;
+mod autopep8;
 mod coverage;
 mod djlint;
 mod docformatter;
@@ -217,6 +218,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     interrogate::fix(&mut tables);
     docformatter::fix(&mut tables);
     vulture::fix(&mut tables);
+    autopep8::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/autopep8_tests.rs
+++ b/pyproject-fmt/rust/src/tests/autopep8_tests.rs
@@ -1,0 +1,125 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::autopep8::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.autopep8"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_autopep8_order() {
+    let start = indoc::indoc! {r#"
+    [tool.autopep8]
+    recursive = true
+    max_line_length = 100
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.autopep8]
+    max_line_length = 100
+    recursive = true
+    "#);
+}
+
+#[test]
+fn test_autopep8_no_table_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "x"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "x"
+    "#);
+}
+
+#[test]
+fn test_autopep8_arrays_sorted() {
+    let start = indoc::indoc! {r#"
+    [tool.autopep8]
+    select = ["E501", "E302", "E401"]
+    ignore = ["W503", "E203"]
+    exclude = ["build", "dist", "tests"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.autopep8]
+    ignore = [ "E203", "W503" ]
+    select = [ "E302", "E401", "E501" ]
+    exclude = [ "build", "dist", "tests" ]
+    "#);
+}
+
+#[test]
+fn test_autopep8_non_sortable_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.autopep8]
+    verbose = 2
+    aggressive = 1
+    max_line_length = 100
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.autopep8]
+    max_line_length = 100
+    aggressive = 1
+    verbose = 2
+    "#);
+}
+
+#[test]
+fn test_autopep8_long_format() {
+    let start = indoc::indoc! {r#"
+    [tool.autopep8]
+    select = ["E501", "E302"]
+    max_line_length = 100
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.autopep8]"));
+    assert!(result.find("E302").unwrap() < result.find("E501").unwrap());
+    assert!(result.find("max_line_length").unwrap() < result.find("select").unwrap());
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -4,6 +4,7 @@ pub use common::test_util::{assert_valid_toml, format_syntax, format_toml_str, p
 
 mod black_tests;
 mod bandit_tests;
+mod autopep8_tests;
 mod build_systems_tests;
 mod commitizen_tests;
 mod cibuildwheel_tests;


### PR DESCRIPTION
autopep8 — PEP8 auto-fixer, ~1.1k pyproject.toml on GitHub. Order: length/indent → mode → rules → behavior. Sorted arrays: `ignore`, `select`, `exclude`. Also bundles the common triple-literal string fix from #324.