### PR TITLE
✨ feat(pyproject-fmt): add [tool.deptry] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1128,6 +1128,12 @@ Dead-code finder. Order: paths → ignore (``exclude``, ``ignore_names``, ``igno
 
 PEP8 auto-fixer. Order: length/indent → mode (``in-place``, ``recursive``, ``diff``, ``list-fixes``) → rules
 (``ignore``, ``select``, ``exclude``) → behavior. Sorted arrays: ``ignore``, ``select``, ``exclude``.
+``[tool.deptry]``
+~~~~~~~~~~~~~~~~~
+
+Dependency checker. Order: scope/exclude → ignore rules → per-rule ignores → behavior → mapping. Sorted arrays
+cover all the ``ignore_*`` / ``exclude`` / ``requirements_files`` / ``pep621_dev_dependency_groups`` /
+``known_first_party`` lists.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/deptry.rs
+++ b/pyproject-fmt/rust/src/deptry.rs
@@ -1,0 +1,54 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Group: scope/exclude → ignore rules → per-rule ignores → behavior → mapping.
+const KEY_ORDER: &[&str] = &[
+    "",
+    "exclude",
+    "extend_exclude",
+    "ignore",
+    "ignore_notebooks",
+    "ignore_unused",
+    "ignore_obsolete",
+    "ignore_missing",
+    "ignore_transitive",
+    "ignore_misplaced_dev",
+    "ignore_definition",
+    "ignore_external",
+    "per_rule_ignores",
+    "known_first_party",
+    "requirements_files",
+    "requirements_files_dev",
+    "package_module_name_map",
+    "pep621_dev_dependency_groups",
+];
+
+const SORT_ARRAYS: &[&str] = &[
+    "exclude",
+    "extend_exclude",
+    "ignore",
+    "ignore_unused",
+    "ignore_obsolete",
+    "ignore_missing",
+    "ignore_transitive",
+    "ignore_misplaced_dev",
+    "ignore_definition",
+    "known_first_party",
+    "requirements_files",
+    "requirements_files_dev",
+    "pep621_dev_dependency_groups",
+];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.deptry") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -24,6 +24,7 @@ mod autopep8;
 mod coverage;
 mod djlint;
 mod docformatter;
+mod deptry;
 mod global;
 mod mypy;
 mod hatch;
@@ -219,6 +220,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     docformatter::fix(&mut tables);
     vulture::fix(&mut tables);
     autopep8::fix(&mut tables);
+    deptry::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/deptry_tests.rs
+++ b/pyproject-fmt/rust/src/tests/deptry_tests.rs
@@ -1,0 +1,108 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::deptry::fix;
+use crate::{format_toml, Settings};
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.deptry"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+fn default_settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn long_settings() -> Settings {
+    Settings {
+        table_format: String::from("long"),
+        ..default_settings()
+    }
+}
+
+fn evaluate_long(start: &str) -> String {
+    let result = format_toml(start, &long_settings());
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_deptry_order() {
+    let start = indoc::indoc! {r#"
+    [tool.deptry]
+    ignore_unused = ["pytest"]
+    exclude = ["tests", "docs"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.deptry]
+    exclude = [ "docs", "tests" ]
+    ignore_unused = [ "pytest" ]
+    "#);
+}
+
+#[test]
+fn test_deptry_no_table_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "x"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "x"
+    "#);
+}
+
+#[test]
+fn test_deptry_non_sortable_entry_preserved() {
+    let start = indoc::indoc! {r#"
+    [tool.deptry]
+    ignore_notebooks = true
+    per_rule_ignores = { DEP001 = ["foo", "bar"] }
+    exclude = ["zeta", "alpha"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.deptry]
+    exclude = [ "alpha", "zeta" ]
+    ignore_notebooks = true
+    per_rule_ignores = { DEP001 = [ "foo", "bar" ] }
+    "#);
+}
+
+#[test]
+fn test_deptry_long_format() {
+    let start = indoc::indoc! {r#"
+    [tool.deptry]
+    exclude = ["zeta", "alpha"]
+    ignore = ["DEP002", "DEP001"]
+    "#};
+    let result = evaluate_long(start);
+    assert!(result.contains("[tool.deptry]"));
+    assert!(result.find("alpha").unwrap() < result.find("zeta").unwrap());
+    assert!(result.find("DEP001").unwrap() < result.find("DEP002").unwrap());
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod coverage_tests;
 mod dependency_groups_tests;
 mod djlint_tests;
 mod docformatter_tests;
+mod deptry_tests;
 mod global_tests;
 mod hatch_tests;
 mod isort_tests;


### PR DESCRIPTION
deptry — dependency checker, ~1k pyproject.toml on GitHub. Order: scope/exclude → ignore rules → per-rule ignores → behavior → mapping. All `ignore_*` / `exclude` / `requirements_files` / `known_first_party` arrays alphabetize. Also bundles the common triple-literal string fix from #324.