### PR TITLE
✨ feat(pyproject-fmt): add [tool.ty] handler

### DIFF
--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1134,6 +1134,12 @@ PEP8 auto-fixer. Order: length/indent → mode (``in-place``, ``recursive``, ``d
 Dependency checker. Order: scope/exclude → ignore rules → per-rule ignores → behavior → mapping. Sorted arrays
 cover all the ``ignore_*`` / ``exclude`` / ``requirements_files`` / ``pep621_dev_dependency_groups`` /
 ``known_first_party`` lists.
+``[tool.ty]``
+~~~~~~~~~~~~~
+
+Astral's type checker. Order: ``src`` → ``respect-ignore-files`` → ``environment`` → ``rules`` → ``terminal``
+→ ``overrides`` last. ``src`` array alphabetizes. Schema is still pre-1.0; unknown keys alphabetize after the
+canonical set.
 
 Other Tables
 ~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -46,6 +46,7 @@ mod scikit_build;
 mod tests;
 mod tox;
 mod towncrier;
+mod ty;
 mod uv;
 mod yapf;
 mod vulture;
@@ -221,6 +222,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     vulture::fix(&mut tables);
     autopep8::fix(&mut tables);
     deptry::fix(&mut tables);
+    ty::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod tox_tests;
 mod towncrier_tests;
 mod semantic_release_tests;
 mod scikit_build_tests;
+mod ty_tests;
 mod uv_tests;
 mod yapf_tests;
 mod vulture_tests;

--- a/pyproject-fmt/rust/src/tests/ty_tests.rs
+++ b/pyproject-fmt/rust/src/tests/ty_tests.rs
@@ -1,0 +1,34 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::ty::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.ty"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_ty_order() {
+    let start = indoc::indoc! {r#"
+    [tool.ty]
+    rules.unresolved-import = "ignore"
+    src = ["src", "lib"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.ty]
+    src = [ "lib", "src" ]
+    rules.unresolved-import = "ignore"
+    "#);
+}

--- a/pyproject-fmt/rust/src/ty.rs
+++ b/pyproject-fmt/rust/src/ty.rs
@@ -1,0 +1,34 @@
+use common::array::sort_strings;
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+// Pre-1.0 schema: keep the canonical set small, let unknown keys alphabetize.
+const KEY_ORDER: &[&str] = &[
+    "",
+    // paths
+    "src",
+    "respect-ignore-files",
+    // environment
+    "environment",
+    // rules
+    "rules",
+    // terminal
+    "terminal",
+    // overrides (AoT)
+    "overrides",
+];
+
+const SORT_ARRAYS: &[&str] = &["src", "src.include", "src.exclude"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.ty") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}


### PR DESCRIPTION
ty — Astral's new type checker (~970 pyproject.toml on GitHub, rising fast as it ships pre-installed with uv). Order: `src` → `respect-ignore-files` → `environment` → `rules` → `terminal` → `overrides` last. `src` alphabetizes. Schema is still pre-1.0; unknown keys alphabetize after the canonical set so new options land in predictable positions. Also bundles the common triple-literal string fix from #324.