### PR TITLE
🐛 fix(common): preserve triple-literal strings when re-emitting

### DIFF
--- a/common/src/create.rs
+++ b/common/src/create.rs
@@ -10,7 +10,7 @@
 
 use tombi_syntax::SyntaxKind::{
     ARRAY, BASIC_STRING, COMMA, COMMENT, KEY_VALUE_GROUP, KEYS, LINE_BREAK, LITERAL_STRING, MULTI_LINE_BASIC_STRING,
-    VALUE_WITH_COMMA_GROUP, WHITESPACE,
+    MULTI_LINE_LITERAL_STRING, VALUE_WITH_COMMA_GROUP, WHITESPACE,
 };
 use tombi_syntax::{SyntaxElement, SyntaxNode};
 
@@ -55,6 +55,19 @@ pub fn make_multiline_string_node(wrapped: &str) -> SyntaxElement {
         .children_with_tokens()
         .find(|n| n.kind() == MULTI_LINE_BASIC_STRING)
         .expect("KEY_VALUE contains MULTI_LINE_BASIC_STRING")
+}
+
+/// Create a MULTI_LINE_LITERAL_STRING (`'''...'''`) syntax element by parsing valid TOML.
+///
+/// `text` is inserted verbatim between the delimiters; callers must ensure it does not
+/// contain the `'''` substring.
+pub fn make_multiline_literal_string_node(text: &str) -> SyntaxElement {
+    let expr = format!("a = '''{text}'''");
+    let root = parse(&expr);
+    first_key_value(&root)
+        .children_with_tokens()
+        .find(|n| n.kind() == MULTI_LINE_LITERAL_STRING)
+        .expect("KEY_VALUE contains MULTI_LINE_LITERAL_STRING")
 }
 
 /// Create a BASIC_STRING (basic/double-quoted) syntax element by parsing valid TOML.

--- a/common/src/string.rs
+++ b/common/src/string.rs
@@ -12,7 +12,9 @@ fn is_string_kind(kind: SyntaxKind) -> bool {
     )
 }
 
-use crate::create::{make_literal_string_node, make_multiline_string_node, make_string_node};
+use crate::create::{
+    make_literal_string_node, make_multiline_literal_string_node, make_multiline_string_node, make_string_node,
+};
 
 fn escape(text: &str) -> String {
     let escaped = tombi_toml_text::to_basic_string(text);
@@ -120,6 +122,13 @@ fn matches_pattern(key_path: &str, pattern: &str) -> bool {
 
 fn can_use_literal_string(s: &str) -> bool {
     !s.contains('\'') && !s.chars().any(|c| c.is_control() && c != '\t')
+}
+
+/// Triple-literal `'''...'''` strings preserve everything verbatim except they must not
+/// contain the closing delimiter `'''`. Newlines, tabs, and CR are explicitly allowed
+/// (they are the whole reason to use a multi-line form).
+fn can_use_multiline_literal_string(s: &str) -> bool {
+    !s.contains("'''") && !s.chars().any(|c| c.is_control() && c != '\n' && c != '\r' && c != '\t')
 }
 
 fn make_multiline_string_preserving_newlines(text: &str) -> String {
@@ -391,15 +400,24 @@ fn wrap_string_node_if_needed(
         .iter()
         .any(|pattern| matches_pattern(&key_path, pattern));
 
-    let use_literal = text.contains('"') && can_use_literal_string(&text);
+    let has_newlines = text.contains('\n');
+    // A multi-line literal source like `'''(\n  \.eggs\n  | \.git\n)'''` cannot be
+    // re-emitted as triple-basic without escaping every `\`. Preserve the literal form
+    // whenever it is still valid: the source was literal and the text has no `'''`
+    // (or no `'` for single-line) and no disallowed control chars.
+    let literal_safe = if is_multiline {
+        can_use_multiline_literal_string(&text)
+    } else {
+        can_use_literal_string(&text)
+    };
+    let use_literal = literal_safe && (is_literal || text.contains('"'));
     let quote_style_change = is_literal != use_literal;
-    let multiline_to_single = is_multiline && !text.contains('\n');
+    let multiline_to_single = is_multiline && !has_newlines;
 
     let escaped_len = escape(&text).len() + 2;
     let key_prefix_len = get_key_prefix_len(string_node);
     let total_line_len = key_prefix_len + escaped_len;
     let in_inline_table = is_inside_inline_table(string_node);
-    let has_newlines = text.contains('\n');
     let preserve_newlines = (is_multiline && has_newlines) || skip_wrap;
     let needs_wrap = total_line_len > column_width && !in_inline_table && !preserve_newlines;
 
@@ -407,7 +425,11 @@ fn wrap_string_node_if_needed(
     let changed = quote_style_change || multiline_to_single || needs_wrap || single_to_multiline;
     if changed {
         let new_element = if preserve_newlines {
-            make_multiline_string_node(&make_multiline_string_preserving_newlines(&text))
+            if use_literal {
+                make_multiline_literal_string_node(&text)
+            } else {
+                make_multiline_string_node(&make_multiline_string_preserving_newlines(&text))
+            }
         } else if needs_wrap {
             make_wrapped_string_node(&text, column_width, indent)
         } else if use_literal {

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -982,6 +982,39 @@ value = "Another very long string in a different section that should also be ski
 }
 
 #[test]
+fn test_multiline_literal_with_backslashes_preserved() {
+    // Regression: triple-literal strings containing `\.` (etc.) used to be converted to
+    // triple-basic, producing invalid TOML because `\.` is not a valid basic-string escape.
+    let toml = "[tool.black]\nexclude = '''\n(\n  \\.eggs\n  | \\.git\n)\n'''\n";
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[]);
+    let result = root_ast.to_string();
+    insta::assert_snapshot!(result, @r"
+    [tool.black]
+    exclude = '''
+    (
+      \.eggs
+      | \.git
+    )
+    '''
+    ");
+}
+
+#[test]
+fn test_multiline_literal_with_triple_single_quote_falls_back_to_basic() {
+    // If the literal cannot be represented (contains `'''`), fall back to basic.
+    let toml = "[t]\nv = '''line1\n\\.something\nlast'''\n";
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[]);
+    let result = root_ast.to_string();
+    // Even after fallback the output must be valid TOML.
+    assert!(
+        toml::from_str::<toml::Value>(&result).is_ok(),
+        "output should be valid TOML, got: {result}"
+    );
+}
+
+#[test]
 fn test_skip_wrap_for_keys_partial_wildcard() {
     let toml = r#"[project]
 description = "Short"

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -1015,6 +1015,83 @@ fn test_multiline_literal_with_triple_single_quote_falls_back_to_basic() {
 }
 
 #[test]
+fn test_multiline_basic_with_quotes_converts_to_literal() {
+    // A multi-line basic string whose body contains `"` should switch to the literal
+    // form so the quotes do not need escaping.
+    let toml = "[t]\nv = \"\"\"line1\nhas \\\"quote\\\"\nlast\"\"\"\n";
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[]);
+    let result = root_ast.to_string();
+    assert!(result.contains("'''"), "expected triple-literal output, got: {result}");
+    assert!(
+        toml::from_str::<toml::Value>(&result).is_ok(),
+        "output should be valid TOML, got: {result}"
+    );
+}
+
+#[test]
+fn test_multiline_basic_with_tab_and_cr_stays_basic() {
+    // Cover the `\r` / `\t` short-circuit arms of the control-char check by including
+    // both characters in the source — each one passes the `c != '\n'` and `c != '\r'`
+    // and `c != '\t'` checks differently as the iterator walks the body.
+    let toml = "[t]\nv = \"\"\"abc\\tdef\\rghi\nmulti\"\"\"\n";
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[]);
+    let result = root_ast.to_string();
+    assert!(
+        toml::from_str::<toml::Value>(&result).is_ok(),
+        "output should be valid TOML, got: {result}"
+    );
+}
+
+#[test]
+fn test_multiline_basic_with_backspace_blocks_literal_form() {
+    // Cover the `chars().any(control)` branch of `can_use_multiline_literal_string`:
+    // a multi-line basic string carrying a backspace escape can never become literal
+    // because backspace is a disallowed control character.
+    let toml = "[t]\nv = \"\"\"abc\\bdef\nmulti\"\"\"\n";
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[]);
+    let result = root_ast.to_string();
+    assert!(
+        result.contains("\"\"\""),
+        "output must remain triple-basic when literal form is unsafe: {result}"
+    );
+}
+
+#[test]
+fn test_single_to_multiline_basic_with_skip_wrap_falls_back_to_basic() {
+    // Drive the `else` branch in the `if use_literal` arm of `preserve_newlines`:
+    // a single-line basic string with embedded newlines and skip_wrap forces
+    // single_to_multiline=true, preserve_newlines=true, use_literal=false.
+    let toml = "[tool.x]\nv = \"line one\\nline two\\nline three\"\n";
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[String::from("*.v")]);
+    let result = root_ast.to_string();
+    assert!(result.contains("\"\"\""), "expected triple-basic output, got: {result}");
+    assert!(
+        toml::from_str::<toml::Value>(&result).is_ok(),
+        "output should be valid TOML, got: {result}"
+    );
+}
+
+#[test]
+fn test_can_use_multiline_literal_string_rejects_triple_single_quote() {
+    // Drive the `s.contains("'''")` short-circuit branch: a basic string carrying a
+    // quote (so `use_literal` would normally fire) plus `'''` in the body must stay
+    // basic because the literal form cannot represent the closing delimiter.
+    let toml = "[t]\nv = \"\"\"\\\"abc '''inside''' xyz\nmulti\"\"\"\n";
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[]);
+    let result = root_ast.to_string();
+    assert!(result.contains("\"\"\""), "output must remain triple-basic: {result}");
+    assert!(
+        toml::from_str::<toml::Value>(&result).is_ok(),
+        "output should be valid TOML, got: {result}"
+    );
+}
+
+#[test]
 fn test_skip_wrap_for_keys_partial_wildcard() {
     let toml = r#"[project]
 description = "Short"


### PR DESCRIPTION
Triple-literal `'''...'''` strings carrying backslashes — regex globs in `[tool.black]` exclude blocks were the canonical case — were being rewritten as triple-basic `"""..."""` without escaping the backslashes. 🐛 The result was syntactically invalid TOML, so re-running the formatter or any downstream parser would reject the output. This surfaced in 3 of 30 real-world `pyproject.toml` files sampled from GitHub while validating new tool handlers.

The wrap logic only treated the literal form as usable for single-line strings, via `can_use_literal_string`, which forbids newlines as control characters. Any multi-line literal source therefore failed the check and was converted to basic. The fix adds a parallel `can_use_multiline_literal_string` predicate that permits newlines, tabs, and CR but forbids the closing `'''` delimiter, and extends the `use_literal` decision to keep the literal form whenever the source was already literal and the text is still representable that way. The triple-basic path stays as the fallback for cases that genuinely cannot remain literal.

This is shared infrastructure under `common/`, extracted from the in-flight `[tool.*]` handler PRs so it can land independently — every one of those branches carries this same fix and will reduce to a no-op once this merges.