### PR TITLE
👷 ci: generate sibling README before workspace-aware tox runs

### DIFF
--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -153,6 +153,9 @@ jobs:
       - name: 📝 Generate README.rst
         run: tox run -e readme
         working-directory: pyproject-fmt
+      - name: 📝 Generate tox-toml-fmt README.rst
+        run: tox run -e readme
+        working-directory: tox-toml-fmt
       - name: 🔧 Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.py }}
       - name: ✅ Run tests
@@ -191,6 +194,9 @@ jobs:
       - name: 📝 Generate README.rst
         run: tox run -e readme
         working-directory: pyproject-fmt
+      - name: 📝 Generate tox-toml-fmt README.rst
+        run: tox run -e readme
+        working-directory: tox-toml-fmt
       - name: 🔧 Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.env }}
       - name: ✅ Run tests

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -153,6 +153,9 @@ jobs:
       - name: 📝 Generate README.rst
         run: tox run -e readme
         working-directory: tox-toml-fmt
+      - name: 📝 Generate pyproject-fmt README.rst
+        run: tox run -e readme
+        working-directory: pyproject-fmt
       - name: 🔧 Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.py }}
       - name: ✅ Run tests
@@ -191,6 +194,9 @@ jobs:
       - name: 📝 Generate README.rst
         run: tox run -e readme
         working-directory: tox-toml-fmt
+      - name: 📝 Generate pyproject-fmt README.rst
+        run: tox run -e readme
+        working-directory: pyproject-fmt
       - name: 🔧 Setup test suite
         run: tox run -vv --notest --skip-missing-interpreters false -e ${{ matrix.env }}
       - name: ✅ Run tests


### PR DESCRIPTION
`README.rst` is a generated artifact — built from `CHANGELOG.md` by `tasks/generate_readme.py` and gitignored — so it is never present in a fresh checkout. Each package's workflow already generates its own README before running tox. The gap is the sibling package.

When uv prepares a tox environment it discovers the whole workspace. If the sibling's cached metadata is stale — which happens the moment that sibling's source changes on a branch — uv re-runs `maturin prepare_metadata` for it, and maturin reads the `readme = README.rst` field. With the file absent the build dies before the package's own tests even start. 💥 On `main` this stays green only because the sibling's metadata is cached and never rebuilt; it is one stale cache away from the same failure, and any PR that touches a sibling's Rust source hits it deterministically.

The fix adds a sibling README generation step to the `py` and `check` jobs of both workflows: the tox-toml-fmt workflow now also generates pyproject-fmt's README, and vice versa. The step is harmless when the sibling is not rebuilt and load-bearing when it is.

Extracted from the in-flight `[tool.*]` handler PRs so it can land first — those branches all change pyproject-fmt source, which is exactly what triggers the sibling rebuild.