### PR TITLE
👷 build: bundle toml-fmt-common into consumer wheels, stop publishing it

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -97,6 +97,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: source
+      - name: 📦 Bundle toml-fmt-common
+        if: inputs.package-name != 'toml-fmt-common'
+        run: python3 tasks/bundle_common.py "${{ inputs.package-name }}"
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -134,6 +137,9 @@ jobs:
         with:
           python-version: ${{ matrix.platform.python }}
           architecture: ${{ matrix.platform.target == 'x86' && 'x86' || matrix.platform.target == 'aarch64' && 'arm64' || 'x64' }}
+      - name: 📦 Bundle toml-fmt-common
+        if: inputs.package-name != 'toml-fmt-common'
+        run: python tasks/bundle_common.py "${{ inputs.package-name }}"
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -163,6 +169,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: source
+      - name: 📦 Bundle toml-fmt-common
+        if: inputs.package-name != 'toml-fmt-common'
+        run: python3 tasks/bundle_common.py "${{ inputs.package-name }}"
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -184,6 +193,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: source
+      - name: 📦 Bundle toml-fmt-common
+        if: inputs.package-name != 'toml-fmt-common'
+        run: python3 tasks/bundle_common.py "${{ inputs.package-name }}"
       - name: 📦 Build sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -195,6 +207,26 @@ jobs:
           name: wheels-sdist
           path: dist
 
+  smoke:
+    name: 🚬 smoke (bundled wheel)
+    needs: [linux]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 📥 Download wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: wheels-linux-x86_64
+          path: dist
+          merge-multiple: "true"
+      - name: 📦 Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: 🚬 Import the bundled wheel in isolation
+        run: |
+          wheel=$(ls dist/*.whl | head -n1)
+          # No project, no workspace: the wheel must satisfy its own imports without
+          # toml-fmt-common on the index — this is the exact #355 failure mode.
+          uv run --isolated --no-project --with "$wheel" -- "${{ inputs.package-name }}" --version
+
   release:
     name: 🚀 release
     runs-on: ubuntu-24.04
@@ -205,7 +237,7 @@ jobs:
       id-token: write
       contents: write
     if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
-    needs: [bump, sdist, linux, macos, windows]
+    needs: [bump, sdist, linux, macos, windows, smoke]
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -103,6 +103,7 @@ jobs:
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
         run: uv run tasks/bundle_common.py "$PACKAGE"
+        shell: bash
         env:
           PACKAGE: ${{ inputs.package-name }}
       - name: 🔨 Build wheels
@@ -148,6 +149,7 @@ jobs:
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
         run: uv run tasks/bundle_common.py "$PACKAGE"
+        shell: bash
         env:
           PACKAGE: ${{ inputs.package-name }}
       - name: 🔨 Build wheels
@@ -185,6 +187,7 @@ jobs:
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
         run: uv run tasks/bundle_common.py "$PACKAGE"
+        shell: bash
         env:
           PACKAGE: ${{ inputs.package-name }}
       - name: 🔨 Build wheels
@@ -214,6 +217,7 @@ jobs:
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
         run: uv run tasks/bundle_common.py "$PACKAGE"
+        shell: bash
         env:
           PACKAGE: ${{ inputs.package-name }}
       - name: 📦 Build sdist

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -97,9 +97,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: source
+      - name: 📦 Setup uv
+        if: inputs.package-name != 'toml-fmt-common'
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
-        run: python3 tasks/bundle_common.py "${{ inputs.package-name }}"
+        run: uv run tasks/bundle_common.py "${{ inputs.package-name }}"
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -137,9 +140,12 @@ jobs:
         with:
           python-version: ${{ matrix.platform.python }}
           architecture: ${{ matrix.platform.target == 'x86' && 'x86' || matrix.platform.target == 'aarch64' && 'arm64' || 'x64' }}
+      - name: 📦 Setup uv
+        if: inputs.package-name != 'toml-fmt-common'
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
-        run: python tasks/bundle_common.py "${{ inputs.package-name }}"
+        run: uv run tasks/bundle_common.py "${{ inputs.package-name }}"
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -169,9 +175,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: source
+      - name: 📦 Setup uv
+        if: inputs.package-name != 'toml-fmt-common'
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
-        run: python3 tasks/bundle_common.py "${{ inputs.package-name }}"
+        run: uv run tasks/bundle_common.py "${{ inputs.package-name }}"
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -193,9 +202,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: source
+      - name: 📦 Setup uv
+        if: inputs.package-name != 'toml-fmt-common'
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
-        run: python3 tasks/bundle_common.py "${{ inputs.package-name }}"
+        run: uv run tasks/bundle_common.py "${{ inputs.package-name }}"
       - name: 📦 Build sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -102,7 +102,9 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
-        run: uv run tasks/bundle_common.py "${{ inputs.package-name }}"
+        run: uv run tasks/bundle_common.py "$PACKAGE"
+        env:
+          PACKAGE: ${{ inputs.package-name }}
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -145,7 +147,9 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
-        run: uv run tasks/bundle_common.py "${{ inputs.package-name }}"
+        run: uv run tasks/bundle_common.py "$PACKAGE"
+        env:
+          PACKAGE: ${{ inputs.package-name }}
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -180,7 +184,9 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
-        run: uv run tasks/bundle_common.py "${{ inputs.package-name }}"
+        run: uv run tasks/bundle_common.py "$PACKAGE"
+        env:
+          PACKAGE: ${{ inputs.package-name }}
       - name: 🔨 Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -207,7 +213,9 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: 📦 Bundle toml-fmt-common
         if: inputs.package-name != 'toml-fmt-common'
-        run: uv run tasks/bundle_common.py "${{ inputs.package-name }}"
+        run: uv run tasks/bundle_common.py "$PACKAGE"
+        env:
+          PACKAGE: ${{ inputs.package-name }}
       - name: 📦 Build sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -237,7 +245,9 @@ jobs:
           wheel=$(ls dist/*.whl | head -n1)
           # No project, no workspace: the wheel must satisfy its own imports without
           # toml-fmt-common on the index — this is the exact #355 failure mode.
-          uv run --isolated --no-project --with "$wheel" -- "${{ inputs.package-name }}" --version
+          uv run --isolated --no-project --with "$wheel" -- "$PACKAGE" --version
+        env:
+          PACKAGE: ${{ inputs.package-name }}
 
   release:
     name: 🚀 release

--- a/.github/workflows/toml_fmt_common_build.yaml
+++ b/.github/workflows/toml_fmt_common_build.yaml
@@ -1,13 +1,8 @@
 name: 📦 toml-fmt-common
+# toml-fmt-common is no longer published: it is bundled into each consumer wheel at
+# release time (see tasks/bundle_common.py). This workflow only builds it for CI.
 on:
   workflow_dispatch:
-    inputs:
-      release:
-        description: "🚀 Release (semver bump)?"
-        required: true
-        default: "no"
-        type: choice
-        options: ["no", patch, minor, major]
   push:
     branches: ["main"]
   pull_request:
@@ -66,11 +61,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-      - name: 🔖 Bump version
-        if: github.event.inputs.release != 'no' && github.event.inputs.release != null
-        run: uv version --frozen --bump "$RELEASE_TYPE"
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release }}
       - name: 📝 Generate changelog
         id: v
         run: |
@@ -85,60 +75,6 @@ jobs:
         with:
           name: ${{ env.dists-artifact-name }}
           path: toml-fmt-common/dist/*
-
-  release:
-    name: 🚀 release
-    needs: [build]
-    runs-on: ubuntu-latest
-    environment:
-      name: release
-      url: https://pypi.org/project/toml-fmt-common/${{ needs.build.outputs.version }}
-    permissions:
-      id-token: write
-      contents: write
-    if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: true
-      - name: 📦 Setup uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0 # zizmor: ignore[cache-poisoning]
-      - name: 🔖 Bump version
-        working-directory: toml-fmt-common
-        run: uv version --frozen --bump "$RELEASE_TYPE"
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release }}
-      - name: 💾 Commit release
-        run: |
-          git config --global user.name 'Bernat Gabor'
-          git config --global user.email 'gaborbernat@users.noreply.github.com'
-          git commit -am "Release toml-fmt-common ${VERSION} [skip ci]"
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-      - name: 📥 Download all the dists
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ env.dists-artifact-name }}
-          path: dist/
-      - name: 🚀 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          attestations: true
-      - name: 📢 Create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          VERSION: ${{ needs.build.outputs.version }}
-          CHANGELOG: ${{ needs.build.outputs.changelog }}
-        run: |
-          git pull --rebase origin main
-          git tag "toml-fmt-common/${VERSION}"
-          git push
-          git push --tags
-          gh release create "toml-fmt-common/${VERSION}" \
-              --title="toml-fmt-common/${VERSION}" --verify-tag \
-            --notes "${CHANGELOG}"
 
   all-pass:
     name: ✅ toml-fmt-common-build

--- a/tasks/bundle_common.py
+++ b/tasks/bundle_common.py
@@ -1,0 +1,77 @@
+"""Bundle ``toml-fmt-common`` into a consumer wheel at build time.
+
+The consumers (``pyproject-fmt``, ``tox-toml-fmt``) import ``toml_fmt_common`` from a
+sibling workspace package during development, so editable installs and tox keep resolving
+it from the worktree. At release the published wheel must not carry an external
+``toml-fmt-common`` dependency — a new common release would otherwise retroactively break
+every published consumer (tox-dev/toml-fmt#355).
+
+This script runs only in the release build, on the throwaway checkout: it copies common
+into the consumer's private ``_vendor`` namespace, repoints the single import there, and
+replaces the ``toml-fmt-common`` dependency with common's own runtime dependencies. The
+private namespace avoids a top-level ``toml_fmt_common`` collision when both tools share
+an environment. Nothing here is committed; local development never sees it.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from pathlib import Path
+
+VENDOR_NAME = "toml_fmt_common"
+
+
+def main(package: str) -> None:
+    module = package.replace("-", "_")
+    root = Path(__file__).resolve().parent.parent
+    common_pkg = root / "toml-fmt-common" / "src" / VENDOR_NAME
+    consumer_src = root / package / "src" / module
+    vendor_root = consumer_src / "_vendor"
+
+    bundle_package(common_pkg, vendor_root)
+    repoint_imports(consumer_src, vendor_root, module)
+    swap_dependency(root / "toml-fmt-common" / "pyproject.toml", root / package / "pyproject.toml")
+
+
+def bundle_package(common_pkg: Path, vendor_root: Path) -> None:
+    target = vendor_root / VENDOR_NAME
+    shutil.rmtree(vendor_root, ignore_errors=True)
+    shutil.copytree(common_pkg, target)
+    (vendor_root / "__init__.py").write_text("", encoding="utf-8")
+
+
+def repoint_imports(consumer_src: Path, vendor_root: Path, module: str) -> None:
+    pattern = re.compile(rf"\b{re.escape(VENDOR_NAME)}\b")
+    replacement = f"{module}._vendor.{VENDOR_NAME}"
+    for file in consumer_src.rglob("*.py"):
+        if file.is_relative_to(vendor_root):
+            continue
+        text = file.read_text(encoding="utf-8")
+        if (updated := pattern.sub(replacement, text)) != text:
+            file.write_text(updated, encoding="utf-8")
+
+
+def swap_dependency(common_pyproject: Path, consumer_pyproject: Path) -> None:
+    # tomllib is 3.11+, but this runs on the 3.10 Windows wheel runner, so parse the
+    # top-level dependencies array with a regex instead.
+    common_text = common_pyproject.read_text(encoding="utf-8")
+    block = re.search(r"(?ms)^dependencies = \[(.*?)\]", common_text)
+    common_deps = re.findall(r'"([^"]*)"', block.group(1)) if block else []
+
+    text = consumer_pyproject.read_text(encoding="utf-8")
+    indent = "  "
+    replacement = "".join(f'{indent}"{dep}",\n' for dep in common_deps)
+    pattern = re.compile(rf'^{indent}"toml-fmt-common[^"]*",\n', re.MULTILINE)
+    if not pattern.search(text):
+        msg = f"toml-fmt-common dependency entry not found in {consumer_pyproject}"
+        raise SystemExit(msg)
+    consumer_pyproject.write_text(pattern.sub(replacement, text), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:  # noqa: PLR2004
+        print("Usage: bundle_common.py <package-name>")
+        raise SystemExit(1)
+    main(sys.argv[1])

--- a/tasks/bundle_common.py
+++ b/tasks/bundle_common.py
@@ -1,3 +1,6 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
 """Bundle ``toml-fmt-common`` into a consumer wheel at build time.
 
 The consumers (``pyproject-fmt``, ``tox-toml-fmt``) import ``toml_fmt_common`` from a
@@ -17,8 +20,10 @@ from __future__ import annotations
 
 import re
 import shutil
-import sys
+from argparse import ArgumentParser
 from pathlib import Path
+
+import tomllib
 
 VENDOR_NAME = "toml_fmt_common"
 
@@ -54,16 +59,13 @@ def repoint_imports(consumer_src: Path, vendor_root: Path, module: str) -> None:
 
 
 def swap_dependency(common_pyproject: Path, consumer_pyproject: Path) -> None:
-    # tomllib is 3.11+, but this runs on the 3.10 Windows wheel runner, so parse the
-    # top-level dependencies array with a regex instead.
-    common_text = common_pyproject.read_text(encoding="utf-8")
-    block = re.search(r"(?ms)^dependencies = \[(.*?)\]", common_text)
-    common_deps = re.findall(r'"([^"]*)"', block.group(1)) if block else []
+    with common_pyproject.open("rb") as handle:
+        common_deps = tomllib.load(handle)["project"].get("dependencies", [])
 
-    text = consumer_pyproject.read_text(encoding="utf-8")
     indent = "  "
     replacement = "".join(f'{indent}"{dep}",\n' for dep in common_deps)
     pattern = re.compile(rf'^{indent}"toml-fmt-common[^"]*",\n', re.MULTILINE)
+    text = consumer_pyproject.read_text(encoding="utf-8")
     if not pattern.search(text):
         msg = f"toml-fmt-common dependency entry not found in {consumer_pyproject}"
         raise SystemExit(msg)
@@ -71,7 +73,6 @@ def swap_dependency(common_pyproject: Path, consumer_pyproject: Path) -> None:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:  # noqa: PLR2004
-        print("Usage: bundle_common.py <package-name>")
-        raise SystemExit(1)
-    main(sys.argv[1])
+    parser = ArgumentParser(description="Bundle toml-fmt-common into a consumer wheel at build time.")
+    parser.add_argument("package", help="consumer package name, e.g. pyproject-fmt")
+    main(parser.parse_args().package)


### PR DESCRIPTION
A new `toml-fmt-common` release can retroactively break every published `pyproject-fmt` and `tox-toml-fmt`, because both declared it as a floating runtime dependency — that is what #355 was. Pinning only protects releases cut after the pin, and leaning on backward-compatibility or a release-time contract gate still depends on someone remembering to do the right thing. 🧱 This removes the shared runtime dependency entirely so the failure mode cannot recur.

At release build, each consumer wheel bundles `toml-fmt-common` under its own private `_vendor` namespace: the package is copied in, the single `from toml_fmt_common import …` is repointed to `<pkg>._vendor.toml_fmt_common`, and the `toml-fmt-common` requirement is replaced by common's own runtime deps. The published wheel is therefore self-contained — no `Requires-Dist: toml-fmt-common` — so a common release can never be resolved into an existing consumer. `toml-fmt-common` is no longer published.

The bundling runs only inside the wheel/sdist build jobs on the throwaway checkout (`tasks/bundle_common.py`), never committed. The repo keeps `toml-fmt-common` as a single, separately-maintained workspace package, and local development, tests, and tox keep resolving the editable worktree member exactly as before — `from toml_fmt_common import …` is unchanged in the tree. The private namespace avoids a top-level `toml_fmt_common` collision when both tools are installed in one environment.

Because tox exercises the editable form rather than the bundled artifact, a `smoke` job installs the built wheel in a fully isolated environment and runs it — the precise #355 failure mode — and the release is gated on it.