### PR TITLE
🐛 fix(common): resolve duplicate format flags for old consumers

### DIFF
--- a/toml-fmt-common/src/toml_fmt_common/__init__.py
+++ b/toml-fmt-common/src/toml_fmt_common/__init__.py
@@ -246,7 +246,12 @@ def build_cli(of: TOMLFormatter[T]) -> tuple[ArgumentParser, Mapping[str, Callab
         metavar="path",
     )
 
-    format_group = parser.add_argument_group("formatting behavior")
+    # conflict_handler="resolve": released consumers (pyproject-fmt <=2.21.2) re-register
+    # these same flags in their add_format_flags, since 1.3.2 didn't define them here.
+    # Resolving lets the consumer's identical definition override ours instead of raising
+    # ArgumentError, so a fresh resolve of toml-fmt-common doesn't break them
+    # (tox-dev/toml-fmt#355).
+    format_group = parser.add_argument_group("formatting behavior", conflict_handler="resolve")
     format_group.add_argument(
         "--column-width",
         type=int,

--- a/toml-fmt-common/tests/test_app.py
+++ b/toml-fmt-common/tests/test_app.py
@@ -488,3 +488,19 @@ def test_build_cli_underscore_alias_preserved() -> None:
     # _build_cli is the pre-1.3.3 name every released pyproject-fmt/tox-toml-fmt imports;
     # dropping it breaks those wheels on a fresh resolve (tox-dev/toml-fmt#355).
     assert _build_cli is build_cli
+
+
+class LegacyDumb(Dumb):
+    # Mirrors pyproject-fmt <=2.21.2, which re-registers the shared format flags that
+    # build_cli now also defines (tox-dev/toml-fmt#355).
+    def add_format_flags(self, parser: ArgumentGroup) -> None:
+        super().add_format_flags(parser)
+        parser.add_argument("--table-format", choices=["short", "long"], default="short")
+        parser.add_argument("--expand-tables", default=[])
+
+
+def test_legacy_consumer_reregistering_flags_does_not_crash(tmp_path: Path) -> None:
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_text("")
+    # Must not raise argparse.ArgumentError on the duplicate --table-format/--expand-tables.
+    assert run(LegacyDumb(), ["E", str(dumb), "--table-format", "long"]) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1685,7 +1685,7 @@ wheels = [
 
 [[package]]
 name = "toml-fmt-common"
-version = "1.3.3"
+version = "1.3.4"
 source = { editable = "toml-fmt-common" }
 dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
The `_build_cli` alias in 1.3.4 restored the import, but it was not enough: #320 also moved the shared formatting flags (`--table-format`, `--expand-tables`, `--collapse-tables`, `--skip-wrap-for-keys`, …) into `build_cli`. Every released `pyproject-fmt` (≤ 2.21.2) and `tox-toml-fmt` still registers those same flags in its own `add_format_flags`, so `build_cli` adds them and then the consumer adds them again — argparse raises `ArgumentError: argument --table-format: conflicting option string` and every pinned install keeps crashing (#355). 🐛

Give the "formatting behavior" argument group `conflict_handler="resolve"`, as suggested in the issue thread. When a consumer re-registers an identical flag it now overrides ours instead of raising, so old consumers work unchanged and current/unreleased consumers (which rely on `build_cli` providing the flags) are unaffected.

Verified empirically against the published `pyproject-fmt` 2.14.1–2.21.2 and `tox-toml-fmt` 1.8.0–1.9.3 — both run and format correctly with this build of common, not just `--version`. A regression test mirrors a legacy consumer that re-registers the flags. Also resyncs `uv.lock`, which the 1.3.4 release bump left pointing at 1.3.3.