### PR TITLE
✨ feat(build): ship self-contained pyproject-fmt and tox-toml-fmt wheels

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # our in-tree build_backend wraps maturin; silence its missing-backend warning
+  MATURIN_NO_MISSING_BUILD_BACKEND_WARNING: "1"
+
 jobs:
   bump:
     name: 🔖 bump
@@ -105,6 +109,14 @@ jobs:
             -m ${{ inputs.package-name }}/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target ${{ matrix.platform.zig && '--zig' || '' }}
           manylinux: ${{ matrix.platform.manylinux || 'auto' }}
           sccache: true
+      - name: 📦 Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: 📦 Vendor toml-fmt-common into wheels
+        # maturin build (run by maturin-action) skips PEP 517, so vendor via the backend's CLI
+        run: uv run --no-project "$PACKAGE/build_backend.py" dist
+        shell: bash
+        env:
+          PACKAGE: ${{ inputs.package-name }}
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -140,6 +152,14 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: -m ${{ inputs.package-name }}/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter || '3.10' }} ${{ matrix.platform.extra || '' }} --target-dir target
           sccache: true
+      - name: 📦 Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: 📦 Vendor toml-fmt-common into wheels
+        # maturin build (run by maturin-action) skips PEP 517, so vendor via the backend's CLI
+        run: uv run --no-project "$PACKAGE/build_backend.py" dist
+        shell: bash
+        env:
+          PACKAGE: ${{ inputs.package-name }}
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -169,6 +189,14 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: -m ${{ inputs.package-name }}/Cargo.toml --locked --release --out dist --interpreter ${{ matrix.platform.interpreter }} ${{ matrix.platform.extra || '' }} --target-dir target
           sccache: true
+      - name: 📦 Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: 📦 Vendor toml-fmt-common into wheels
+        # maturin build (run by maturin-action) skips PEP 517, so vendor via the backend's CLI
+        run: uv run --no-project "$PACKAGE/build_backend.py" dist
+        shell: bash
+        env:
+          PACKAGE: ${{ inputs.package-name }}
       - name: 📤 Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/pyproject-fmt/build_backend.py
+++ b/pyproject-fmt/build_backend.py
@@ -1,0 +1,129 @@
+"""
+Vendor toml-fmt-common into the wheel, as a PEP 517 backend and as a CLI patcher.
+
+A new toml-fmt-common release must never break an already published consumer
+(tox-dev/toml-fmt#355), so the wheel is made self-contained instead of depending on it.
+
+The CLI entry point exists because CI builds wheels with ``maturin build``, which never
+invokes a PEP 517 backend; the same patch then runs on maturin-action's output.
+"""
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["maturin>=1.13.3"]
+# ///
+
+from __future__ import annotations
+
+from base64 import urlsafe_b64encode
+from hashlib import sha256
+from os import environ
+from pathlib import Path
+from re import findall, search, sub
+from shutil import copy2
+from sys import argv
+from tempfile import mkdtemp
+from typing import TYPE_CHECKING
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import maturin
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    ConfigSettings = Mapping[str, str | list[str]]
+
+# our wrapper backend is intentional; silence maturin's missing-backend warning
+environ.setdefault("MATURIN_NO_MISSING_BUILD_BACKEND_WARNING", "1")
+
+_HERE = Path(__file__).resolve().parent
+_MODULE = _HERE.name.replace("-", "_")
+_COMMON = _HERE.parent / "toml-fmt-common"
+_VENDOR = "toml_fmt_common"
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: ConfigSettings | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    if not (_COMMON / "src" / _VENDOR).is_dir():  # no workspace (e.g. building from sdist)
+        return maturin.build_wheel(wheel_directory, config_settings, metadata_directory)
+    tmp = Path(mkdtemp())
+    name = maturin.build_wheel(str(tmp), config_settings, metadata_directory)
+    vendor_into_wheel(tmp / name)
+    copy2(tmp / name, Path(wheel_directory) / name)
+    return name
+
+
+def build_sdist(sdist_directory: str, config_settings: ConfigSettings | None = None) -> str:
+    return maturin.build_sdist(sdist_directory, config_settings)
+
+
+def build_editable(
+    wheel_directory: str,
+    config_settings: ConfigSettings | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    return maturin.build_editable(wheel_directory, config_settings, metadata_directory)
+
+
+def get_requires_for_build_wheel(config_settings: ConfigSettings | None = None) -> list[str]:
+    return maturin.get_requires_for_build_wheel(config_settings)
+
+
+def get_requires_for_build_sdist(config_settings: ConfigSettings | None = None) -> list[str]:
+    return maturin.get_requires_for_build_sdist(config_settings)
+
+
+def get_requires_for_build_editable(config_settings: ConfigSettings | None = None) -> list[str]:
+    return maturin.get_requires_for_build_editable(config_settings)
+
+
+def main() -> None:
+    target = Path(argv[1])
+    if not (wheels := sorted(target.glob("*.whl")) if target.is_dir() else [target]):
+        print(f"no wheels found in {target}")
+        raise SystemExit(1)
+    for wheel in wheels:
+        vendor_into_wheel(wheel)
+        print(f"vendored toml-fmt-common into {wheel.name}")
+
+
+def vendor_into_wheel(wheel: Path) -> None:
+    common_src = _COMMON / "src" / _VENDOR
+
+    with ZipFile(wheel) as src:
+        names = src.namelist()
+        dist_info = next(n for n in names if n.endswith(".dist-info/METADATA")).split("/")[0]
+        out = {n: src.read(n) for n in names if not n.endswith("/RECORD")}
+
+    if (entry := f"{_MODULE}/__main__.py") in out:
+        out[entry] = sub(rf"\b{_VENDOR}\b", f"{_MODULE}._vendor.{_VENDOR}", out[entry].decode()).encode()
+    meta = f"{dist_info}/METADATA"
+    deps_block = search(r"(?ms)^dependencies = \[(.*?)\]", (_COMMON / "pyproject.toml").read_text())
+    requires = (
+        "".join(f"Requires-Dist: {d}\n" for d in findall(r'"([^"]*)"', deps_block.group(1))) if deps_block else ""
+    )
+    stripped = sub(r"(?m)^Requires-Dist: toml-fmt-common.*\n", "", out[meta].decode())
+    out[meta] = (stripped + requires).encode()
+
+    out[f"{_MODULE}/_vendor/__init__.py"] = b""
+    for file in common_src.rglob("*"):
+        if file.is_file():
+            out[f"{_MODULE}/_vendor/{file.relative_to(common_src.parent).as_posix()}"] = file.read_bytes()
+
+    record = []
+    for name, data in out.items():
+        digest = urlsafe_b64encode(sha256(data).digest()).rstrip(b"=").decode()
+        record.append(f"{name},sha256={digest},{len(data)}")
+    record.append(f"{dist_info}/RECORD,,")
+    out[f"{dist_info}/RECORD"] = ("\n".join(record) + "\n").encode()
+
+    with ZipFile(wheel, "w", ZIP_DEFLATED) as zf:
+        for name, data in out.items():
+            zf.writestr(name, data)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject-fmt/pyproject.toml
+++ b/pyproject-fmt/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
-build-backend = "maturin"
+build-backend = "build_backend"
 requires = [
   "maturin>=1.13.3",
 ]
+backend-path = [ "." ]
 
 [project]
 name = "pyproject-fmt"
@@ -84,6 +85,8 @@ module-name = "pyproject_fmt._lib"
 python-source = "src"
 strip = true
 include = [
+  # ship the in-tree PEP 517 backend in the sdist so wheels can be built from the sdist
+  { path = "build_backend.py", format = "sdist" },
   { path = "rust-toolchain.toml", format = "sdist" },
   { path = "docs/", format = "sdist" },
   { path = "CHANGELOG.md", format = "sdist" },
@@ -103,6 +106,9 @@ show_error_codes = true
 strict = true
 
 [tool.coverage]
+run.omit = [
+  "*/_vendor/*", # vendored toml_fmt_common is covered by its own test suite
+]
 run.parallel = true
 run.plugins = [
   "covdefaults",

--- a/pyproject-fmt/tests/test_main.py
+++ b/pyproject-fmt/tests/test_main.py
@@ -10,8 +10,6 @@ from pyproject_fmt.__main__ import runner as run
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from pytest_mock import MockerFixture
-
 
 @pytest.mark.parametrize(
     "in_place",
@@ -63,11 +61,10 @@ def test_main(
     outcome: str,
     output: str,
     monkeypatch: pytest.MonkeyPatch,
-    mocker: MockerFixture,
     cwd: bool,
     check: bool,
 ) -> None:
-    mocker.patch("toml_fmt_common._color_diff", lambda t: t)
+    monkeypatch.setenv("NO_COLOR", "1")
     if cwd:
         monkeypatch.chdir(tmp_path)
     pyproject_toml = tmp_path / "pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ lint.ignore = [
   "RUF067", # allow code in __init__.py for toml-fmt-common
   "S104",   # Possible binding to all interface
 ]
+lint.per-file-ignores."**/build_backend.py" = [
+  "D103",   # the build-backend hooks are PEP 517 contract, documented at module level
+  "INP001", # is not a namespace
+  "T201",   # the CLI reports what it patched
+]
 lint.per-file-ignores."**/tests/**/*.py" = [
   "D",       # don't care about documentation in tests
   "FBT",     # don't care about booleans as positional arguments in tests

--- a/toml-fmt-common/src/toml_fmt_common/__init__.py
+++ b/toml-fmt-common/src/toml_fmt_common/__init__.py
@@ -395,6 +395,9 @@ def _color_diff(diff: Iterable[str]) -> Iterable[str]:
 
     :param diff: the diff lines
     """
+    if "NO_COLOR" in os.environ:  # https://no-color.org
+        yield from diff
+        return
     for line in diff:
         if line.startswith("+"):
             yield f"{GREEN}{line}{RESET}"

--- a/toml-fmt-common/tests/test_app.py
+++ b/toml-fmt-common/tests/test_app.py
@@ -6,7 +6,18 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from toml_fmt_common import GREEN, RED, RESET, ArgumentGroup, FmtNamespace, TOMLFormatter, _build_cli, build_cli, run
+from toml_fmt_common import (
+    GREEN,
+    RED,
+    RESET,
+    ArgumentGroup,
+    FmtNamespace,
+    TOMLFormatter,
+    _build_cli,
+    _color_diff,
+    build_cli,
+    run,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -84,6 +95,11 @@ def test_dumb_format_with_override(capsys: pytest.CaptureFixture[str], tmp_path:
         " extra = 'B'",
         f"{GREEN}+extras = 'B'{RESET}",
     ]
+
+
+def test_color_diff_disabled_by_no_color(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert list(_color_diff(["+added", "-removed", " context"])) == ["+added", "-removed", " context"]
 
 
 def test_dumb_format_with_override_custom_type(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:

--- a/tox-toml-fmt/build_backend.py
+++ b/tox-toml-fmt/build_backend.py
@@ -1,0 +1,129 @@
+"""
+Vendor toml-fmt-common into the wheel, as a PEP 517 backend and as a CLI patcher.
+
+A new toml-fmt-common release must never break an already published consumer
+(tox-dev/toml-fmt#355), so the wheel is made self-contained instead of depending on it.
+
+The CLI entry point exists because CI builds wheels with ``maturin build``, which never
+invokes a PEP 517 backend; the same patch then runs on maturin-action's output.
+"""
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["maturin>=1.13.3"]
+# ///
+
+from __future__ import annotations
+
+from base64 import urlsafe_b64encode
+from hashlib import sha256
+from os import environ
+from pathlib import Path
+from re import findall, search, sub
+from shutil import copy2
+from sys import argv
+from tempfile import mkdtemp
+from typing import TYPE_CHECKING
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import maturin
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    ConfigSettings = Mapping[str, str | list[str]]
+
+# our wrapper backend is intentional; silence maturin's missing-backend warning
+environ.setdefault("MATURIN_NO_MISSING_BUILD_BACKEND_WARNING", "1")
+
+_HERE = Path(__file__).resolve().parent
+_MODULE = _HERE.name.replace("-", "_")
+_COMMON = _HERE.parent / "toml-fmt-common"
+_VENDOR = "toml_fmt_common"
+
+
+def build_wheel(
+    wheel_directory: str,
+    config_settings: ConfigSettings | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    if not (_COMMON / "src" / _VENDOR).is_dir():  # no workspace (e.g. building from sdist)
+        return maturin.build_wheel(wheel_directory, config_settings, metadata_directory)
+    tmp = Path(mkdtemp())
+    name = maturin.build_wheel(str(tmp), config_settings, metadata_directory)
+    vendor_into_wheel(tmp / name)
+    copy2(tmp / name, Path(wheel_directory) / name)
+    return name
+
+
+def build_sdist(sdist_directory: str, config_settings: ConfigSettings | None = None) -> str:
+    return maturin.build_sdist(sdist_directory, config_settings)
+
+
+def build_editable(
+    wheel_directory: str,
+    config_settings: ConfigSettings | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    return maturin.build_editable(wheel_directory, config_settings, metadata_directory)
+
+
+def get_requires_for_build_wheel(config_settings: ConfigSettings | None = None) -> list[str]:
+    return maturin.get_requires_for_build_wheel(config_settings)
+
+
+def get_requires_for_build_sdist(config_settings: ConfigSettings | None = None) -> list[str]:
+    return maturin.get_requires_for_build_sdist(config_settings)
+
+
+def get_requires_for_build_editable(config_settings: ConfigSettings | None = None) -> list[str]:
+    return maturin.get_requires_for_build_editable(config_settings)
+
+
+def main() -> None:
+    target = Path(argv[1])
+    if not (wheels := sorted(target.glob("*.whl")) if target.is_dir() else [target]):
+        print(f"no wheels found in {target}")
+        raise SystemExit(1)
+    for wheel in wheels:
+        vendor_into_wheel(wheel)
+        print(f"vendored toml-fmt-common into {wheel.name}")
+
+
+def vendor_into_wheel(wheel: Path) -> None:
+    common_src = _COMMON / "src" / _VENDOR
+
+    with ZipFile(wheel) as src:
+        names = src.namelist()
+        dist_info = next(n for n in names if n.endswith(".dist-info/METADATA")).split("/")[0]
+        out = {n: src.read(n) for n in names if not n.endswith("/RECORD")}
+
+    if (entry := f"{_MODULE}/__main__.py") in out:
+        out[entry] = sub(rf"\b{_VENDOR}\b", f"{_MODULE}._vendor.{_VENDOR}", out[entry].decode()).encode()
+    meta = f"{dist_info}/METADATA"
+    deps_block = search(r"(?ms)^dependencies = \[(.*?)\]", (_COMMON / "pyproject.toml").read_text())
+    requires = (
+        "".join(f"Requires-Dist: {d}\n" for d in findall(r'"([^"]*)"', deps_block.group(1))) if deps_block else ""
+    )
+    stripped = sub(r"(?m)^Requires-Dist: toml-fmt-common.*\n", "", out[meta].decode())
+    out[meta] = (stripped + requires).encode()
+
+    out[f"{_MODULE}/_vendor/__init__.py"] = b""
+    for file in common_src.rglob("*"):
+        if file.is_file():
+            out[f"{_MODULE}/_vendor/{file.relative_to(common_src.parent).as_posix()}"] = file.read_bytes()
+
+    record = []
+    for name, data in out.items():
+        digest = urlsafe_b64encode(sha256(data).digest()).rstrip(b"=").decode()
+        record.append(f"{name},sha256={digest},{len(data)}")
+    record.append(f"{dist_info}/RECORD,,")
+    out[f"{dist_info}/RECORD"] = ("\n".join(record) + "\n").encode()
+
+    with ZipFile(wheel, "w", ZIP_DEFLATED) as zf:
+        for name, data in out.items():
+            zf.writestr(name, data)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox-toml-fmt/pyproject.toml
+++ b/tox-toml-fmt/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
-build-backend = "maturin"
+build-backend = "build_backend"
 requires = [
   "maturin>=1.13.3",
 ]
+backend-path = [ "." ]
 
 [project]
 name = "tox-toml-fmt"
@@ -84,6 +85,8 @@ module-name = "tox_toml_fmt._lib"
 python-source = "src"
 strip = true
 include = [
+  # ship the in-tree PEP 517 backend in the sdist so wheels can be built from the sdist
+  { path = "build_backend.py", format = "sdist" },
   { path = "rust-toolchain.toml", format = "sdist" },
   { path = "docs/", format = "sdist" },
   { path = "CHANGELOG.md", format = "sdist" },
@@ -103,6 +106,9 @@ show_error_codes = true
 strict = true
 
 [tool.coverage]
+run.omit = [
+  "*/_vendor/*", # vendored toml_fmt_common is covered by its own test suite
+]
 run.parallel = true
 run.plugins = [
   "covdefaults",

--- a/tox-toml-fmt/tests/test_main.py
+++ b/tox-toml-fmt/tests/test_main.py
@@ -10,8 +10,6 @@ from tox_toml_fmt.__main__ import runner as run
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from pytest_mock import MockerFixture
-
 
 @pytest.mark.parametrize(
     "in_place",
@@ -62,11 +60,10 @@ def test_main(
     outcome: str,
     output: str,
     monkeypatch: pytest.MonkeyPatch,
-    mocker: MockerFixture,
     cwd: bool,
     check: bool,
 ) -> None:
-    mocker.patch("toml_fmt_common._color_diff", lambda t: t)
+    monkeypatch.setenv("NO_COLOR", "1")
     if cwd:
         monkeypatch.chdir(tmp_path)
     pyproject_toml = tmp_path / "tox.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -1685,7 +1685,7 @@ wheels = [
 
 [[package]]
 name = "toml-fmt-common"
-version = "1.3.4"
+version = "1.3.5"
 source = { editable = "toml-fmt-common" }
 dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
A `toml-fmt-common` release can break an already installed `pyproject-fmt` or `tox-toml-fmt` at import time (#355), because both consumers depend on it with an open range and resolve to whatever is latest. 🔧 Pinning the range is a poor trade: it moves the failure to install-time resolution and stops users from picking up common's fixes.

The published wheels become self-contained instead. A small PEP 517 backend wraps `maturin`: once the wheel is built it folds `toml-fmt-common` in under a private `_vendor` package, repoints the lone import, and swaps the `toml-fmt-common` requirement for common's own runtime dependencies, so an installed consumer no longer reaches outside its own wheel. Editable installs and `build_sdist` delegate to `maturin` untouched, which keeps `tox` and local development resolving the live workspace member.

The same module doubles as a CLI, because release wheels are produced by `maturin-action`, and `maturin build` never runs a PEP 517 backend; the build job applies the identical patch to its output. 📦 The backend ships in the sdist too, so a wheel built from an sdist still works, falling back to a plain `toml-fmt-common` dependency when the workspace is absent. Both packages share one byte-identical `build_backend.py` that derives its target from its own directory, and `maturin` is declared via PEP 723 inline metadata so the CI step needs no extra wiring.