### PR TITLE
🐛 fix(ci): fix PyPI trusted publishing with reusable workflows

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -9,6 +9,11 @@ on:
         required: true
         type: string
         description: "Pre-commit mirror repo (e.g. tox-dev/pyproject-fmt)"
+    outputs:
+      version:
+        value: ${{ jobs.bump.outputs.version }}
+      changelog:
+        value: ${{ jobs.bump.outputs.changelog }}
 
 permissions:
   contents: read
@@ -222,70 +227,6 @@ jobs:
         with:
           name: wheels-sdist
           path: dist
-
-  release:
-    name: 🚀 release
-    runs-on: ubuntu-24.04
-    environment:
-      name: release
-      url: https://pypi.org/project/${{ inputs.package-name }}/${{ needs.bump.outputs.version }}
-    permissions:
-      id-token: write
-      contents: write
-    if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
-    needs: [bump, sdist, linux, macos, windows]
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: true
-      - name: 📥 Download source
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: source
-          path: .
-      - name: 👀 Show changes
-        run: git diff HEAD -u
-      - name: 💾 Commit release
-        run: |
-          git config --global user.name 'Bernat Gabor'
-          git config --global user.email 'gaborbernat@users.noreply.github.com'
-          git commit -am "Release ${PACKAGE} ${VERSION} [skip ci]"
-        env:
-          PACKAGE: ${{ inputs.package-name }}
-          VERSION: ${{ needs.bump.outputs.version }}
-      - name: 📥 Download wheels
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: wheels-*
-          path: dist
-          merge-multiple: "true"
-      - name: 👀 Show wheels
-        run: ls -lth dist
-      - name: 🚀 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          skip-existing: true
-      - name: 📢 Create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          PACKAGE: ${{ inputs.package-name }}
-          VERSION: ${{ needs.bump.outputs.version }}
-          CHANGELOG: ${{ needs.bump.outputs.changelog }}
-        run: |
-          git pull --rebase origin main
-          git tag "${PACKAGE}/${VERSION}"
-          git push
-          git push --tags
-          gh release create "${PACKAGE}/${VERSION}" \
-              --title="${PACKAGE}/${VERSION}" --verify-tag \
-            --notes "${CHANGELOG}"
-      - name: 🔄 Trigger pre-commit mirror sync
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          MIRROR: ${{ inputs.pre-commit-mirror }}
-        run: gh workflow run main.yaml --repo "$MIRROR"
 
   all-pass:
     name: ✅ ${{ inputs.package-name }}-build

--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -41,3 +41,64 @@ jobs:
       contents: write
       id-token: write
       pull-requests: read
+
+  release:
+    name: 🚀 release
+    runs-on: ubuntu-24.04
+    environment:
+      name: release
+      url: https://pypi.org/project/pyproject-fmt/${{ needs.build.outputs.version }}
+    permissions:
+      id-token: write
+      contents: write
+    if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
+    needs: [build]
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: true
+      - name: 📥 Download source
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: source
+          path: .
+      - name: 👀 Show changes
+        run: git diff HEAD -u
+      - name: 💾 Commit release
+        run: |
+          git config --global user.name 'Bernat Gabor'
+          git config --global user.email 'gaborbernat@users.noreply.github.com'
+          git commit -am "Release pyproject-fmt ${VERSION} [skip ci]"
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+      - name: 📥 Download wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: "true"
+      - name: 👀 Show wheels
+        run: ls -lth dist
+      - name: 🚀 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+      - name: 📢 Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          VERSION: ${{ needs.build.outputs.version }}
+          CHANGELOG: ${{ needs.build.outputs.changelog }}
+        run: |
+          git pull --rebase origin main
+          git tag "pyproject-fmt/${VERSION}"
+          git push
+          git push --tags
+          gh release create "pyproject-fmt/${VERSION}" \
+              --title="pyproject-fmt/${VERSION}" --verify-tag \
+            --notes "${CHANGELOG}"
+      - name: 🔄 Trigger pre-commit mirror sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: gh workflow run main.yaml --repo "tox-dev/pyproject-fmt"

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -41,3 +41,64 @@ jobs:
       contents: write
       id-token: write
       pull-requests: read
+
+  release:
+    name: 🚀 release
+    runs-on: ubuntu-24.04
+    environment:
+      name: release
+      url: https://pypi.org/project/tox-toml-fmt/${{ needs.build.outputs.version }}
+    permissions:
+      id-token: write
+      contents: write
+    if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
+    needs: [build]
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          persist-credentials: true
+      - name: 📥 Download source
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: source
+          path: .
+      - name: 👀 Show changes
+        run: git diff HEAD -u
+      - name: 💾 Commit release
+        run: |
+          git config --global user.name 'Bernat Gabor'
+          git config --global user.email 'gaborbernat@users.noreply.github.com'
+          git commit -am "Release tox-toml-fmt ${VERSION} [skip ci]"
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+      - name: 📥 Download wheels
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: "true"
+      - name: 👀 Show wheels
+        run: ls -lth dist
+      - name: 🚀 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true
+      - name: 📢 Create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          VERSION: ${{ needs.build.outputs.version }}
+          CHANGELOG: ${{ needs.build.outputs.changelog }}
+        run: |
+          git pull --rebase origin main
+          git tag "tox-toml-fmt/${VERSION}"
+          git push
+          git push --tags
+          gh release create "tox-toml-fmt/${VERSION}" \
+              --title="tox-toml-fmt/${VERSION}" --verify-tag \
+            --notes "${CHANGELOG}"
+      - name: 🔄 Trigger pre-commit mirror sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: gh workflow run main.yaml --repo "tox-dev/tox-toml-fmt"


### PR DESCRIPTION
PyPI trusted publishing fails when the publish step runs inside a reusable workflow. The OIDC token's Build Config URI reflects the *caller* workflow, but `gh-action-pypi-publish` was running inside `_build.yaml` — so the attestation certificate and the authenticating trusted publisher didn't match, producing a 400 from PyPI.

The `release` job moves out of `_build.yaml` and into each caller workflow (`pyproject_fmt_build.yaml`, `tox_toml_fmt_build.yaml`), mirroring the pattern already used by `toml_fmt_common_build.yaml`. `_build.yaml` now exposes `version` and `changelog` as `workflow_call` outputs. With the publish step in the caller, the OIDC token and attestation certificate both reference the same workflow, and PyPI verification passes. 🔐

`toml_fmt_common_build.yaml` also loses its `release` job and `workflow_dispatch` trigger entirely — `toml-fmt-common` is always vendored into the other packages and no longer published to PyPI independently.

After merging, the `_build.yaml` entry in PyPI's trusted publisher config for `pyproject-fmt` and `tox-toml-fmt` can be removed.