### PR TITLE
🔧 chore(ci): drop toml-fmt-common release workflow

### DIFF
--- a/.github/workflows/toml_fmt_common_build.yaml
+++ b/.github/workflows/toml_fmt_common_build.yaml
@@ -1,13 +1,5 @@
 name: 📦 toml-fmt-common
 on:
-  workflow_dispatch:
-    inputs:
-      release:
-        description: "🚀 Release (semver bump)?"
-        required: true
-        default: "no"
-        type: choice
-        options: ["no", patch, minor, major]
   push:
     branches: ["main"]
   pull_request:
@@ -15,14 +7,11 @@ on:
     - cron: "0 8 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ github.event.inputs.release && github.event.inputs.release != 'no' && '-release' || '' }}
-  cancel-in-progress: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
-
-env:
-  dists-artifact-name: python-package-distributions
 
 jobs:
   changes:
@@ -49,9 +38,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.v.outputs.version }}
-      changelog: ${{ steps.v.outputs.changelog }}
     defaults:
       run:
         working-directory: toml-fmt-common
@@ -59,86 +45,14 @@ jobs:
       - name: 📥 Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0
           persist-credentials: false
       - name: 📦 Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
-      - name: 🔖 Bump version
-        if: github.event.inputs.release != 'no' && github.event.inputs.release != null
-        run: uv version --frozen --bump "$RELEASE_TYPE"
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release }}
-      - name: 📝 Generate changelog
-        id: v
-        run: |
-          echo "version=$(uv version)" >> "$GITHUB_OUTPUT"
-          uv run ../tasks/changelog.py toml-fmt-common "${{ github.event.number }}" "${{ github.event.pull_request.base.sha }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🔨 Build package
         run: uv build --python 3.14 --python-preference only-managed --sdist --wheel . --out-dir dist
-      - name: 📤 Store the distribution packages
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: ${{ env.dists-artifact-name }}
-          path: toml-fmt-common/dist/*
-
-  release:
-    name: 🚀 release
-    needs: [build]
-    runs-on: ubuntu-latest
-    environment:
-      name: release
-      url: https://pypi.org/project/toml-fmt-common/${{ needs.build.outputs.version }}
-    permissions:
-      id-token: write
-      contents: write
-    if: github.event.inputs.release != 'no' && github.event.inputs.release != null && github.ref == 'refs/heads/main'
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-          persist-credentials: true
-      - name: 📦 Setup uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0 # zizmor: ignore[cache-poisoning]
-      - name: 🔖 Bump version
-        working-directory: toml-fmt-common
-        run: uv version --frozen --bump "$RELEASE_TYPE"
-        env:
-          RELEASE_TYPE: ${{ github.event.inputs.release }}
-      - name: 💾 Commit release
-        run: |
-          git config --global user.name 'Bernat Gabor'
-          git config --global user.email 'gaborbernat@users.noreply.github.com'
-          git commit -am "Release toml-fmt-common ${VERSION} [skip ci]"
-        env:
-          VERSION: ${{ needs.build.outputs.version }}
-      - name: 📥 Download all the dists
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ env.dists-artifact-name }}
-          path: dist/
-      - name: 🚀 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          attestations: true
-      - name: 📢 Create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          VERSION: ${{ needs.build.outputs.version }}
-          CHANGELOG: ${{ needs.build.outputs.changelog }}
-        run: |
-          git pull --rebase origin main
-          git tag "toml-fmt-common/${VERSION}"
-          git push
-          git push --tags
-          gh release create "toml-fmt-common/${VERSION}" \
-              --title="toml-fmt-common/${VERSION}" --verify-tag \
-            --notes "${CHANGELOG}"
 
   all-pass:
     name: ✅ toml-fmt-common-build


### PR DESCRIPTION
`toml-fmt-common` is now always vendored into `pyproject-fmt` and `tox-toml-fmt` wheels at build time — it's no longer published to PyPI as a standalone package.

The `workflow_dispatch` release trigger, version bump step, changelog generation, artifact upload, and `release` job are all removed from `toml_fmt_common_build.yaml`. The workflow now only runs a build as a sanity check that the package still compiles. Concurrency is simplified to always cancel in-progress runs since there's no longer a release path to protect.