### PR TITLE
✨ feat(pyproject-fmt): drop redundant wheel from setuptools build requires

### DIFF
--- a/common/src/array.rs
+++ b/common/src/array.rs
@@ -383,11 +383,19 @@ pub fn dedupe_strings<K>(array: &SyntaxNode, to_key: K)
 where
     K: Fn(&str) -> String,
 {
+    let mut seen: HashSet<String> = HashSet::new();
+    remove_strings(array, |s| !seen.insert(to_key(s)));
+}
+
+/// Remove string entries from an array for which `predicate` returns true
+pub fn remove_strings<P>(array: &SyntaxNode, mut predicate: P)
+where
+    P: FnMut(&str) -> bool,
+{
     if array.kind() != ARRAY {
         return;
     }
     flatten_array_in_place(array);
-    let mut seen: HashSet<String> = HashSet::new();
     let mut to_insert: Vec<SyntaxElement> = Vec::new();
     let mut skip_until_next_value = false;
     let count = array.children_with_tokens().count();
@@ -395,7 +403,7 @@ where
     for entry in array.children_with_tokens() {
         let kind = entry.kind();
         if is_array_value(kind) {
-            let key = if kind == BASIC_STRING || kind == LITERAL_STRING {
+            let text = if kind == BASIC_STRING || kind == LITERAL_STRING {
                 entry
                     .as_node()
                     .and_then(|n| {
@@ -403,16 +411,15 @@ where
                             .filter_map(|e| e.into_token())
                             .find(|token| token.kind() == kind)
                     })
-                    .map(|token| to_key(&load_text(token.text(), kind)))
+                    .map(|token| load_text(token.text(), kind))
             } else {
                 None
             };
-            if let Some(k) = key {
-                if seen.contains(&k) {
-                    skip_until_next_value = true;
-                    continue;
-                }
-                seen.insert(k);
+            if let Some(value) = text
+                && predicate(&value)
+            {
+                skip_until_next_value = true;
+                continue;
             }
             skip_until_next_value = false;
             to_insert.push(entry);

--- a/common/src/pep508/requirement.rs
+++ b/common/src/pep508/requirement.rs
@@ -122,6 +122,10 @@ impl Requirement {
         self
     }
 
+    pub fn is_name_only(&self) -> bool {
+        self.extras.is_empty() && self.version_or_url.is_none() && self.marker.is_none() && !self.private
+    }
+
     pub fn canonical_name(&self) -> String {
         Regex::new(r"[-_.]+")
             .unwrap()

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -3,8 +3,8 @@ use tombi_syntax::SyntaxKind::{ARRAY, KEY_VALUE, KEY_VALUE_GROUP, KEYS};
 use tombi_syntax::SyntaxNode;
 
 use crate::array::{
-    align_array_comments, dedupe_strings, ensure_all_arrays_multiline, ensure_trailing_comma, sort, sort_strings,
-    transform,
+    align_array_comments, dedupe_strings, ensure_all_arrays_multiline, ensure_trailing_comma, remove_strings, sort,
+    sort_strings, transform,
 };
 use crate::pep508::Requirement;
 use crate::tests::{format_toml, format_toml_str};
@@ -1057,4 +1057,37 @@ fn test_dedupe_on_non_array_is_noop() {
     let value_node = find_first_value(&root_ast);
     dedupe_strings(&value_node, |s| s.to_lowercase());
     insta::assert_snapshot!(root_ast.to_string(), @r#"a = "src""#);
+}
+
+fn remove_strings_helper(start: &str, value: &str) -> String {
+    apply_to_arrays(start, |array| {
+        remove_strings(array, |s| s == value);
+    })
+}
+
+#[test]
+fn test_remove_strings_match() {
+    let start = indoc! {r#"
+    a = ["b", "c", "d"]
+    "#};
+    let res = remove_strings_helper(start, "c");
+    insta::assert_snapshot!(res, @r#"a = [ "b", "d" ]"#);
+}
+
+#[test]
+fn test_remove_strings_no_match() {
+    let start = indoc! {r#"
+    a = ["b", "c"]
+    "#};
+    let res = remove_strings_helper(start, "z");
+    insta::assert_snapshot!(res, @r#"a = [ "b", "c" ]"#);
+}
+
+#[test]
+fn test_remove_strings_last_entry_no_trailing_comma() {
+    let start = indoc! {r#"
+    a = ["b", "c"]
+    "#};
+    let res = remove_strings_helper(start, "c");
+    insta::assert_snapshot!(res, @r#"a = [ "b" ]"#);
 }

--- a/common/src/tests/pep508_tests.rs
+++ b/common/src/tests/pep508_tests.rs
@@ -428,3 +428,37 @@ fn test_invalid_epoch_falls_back() {
     let req = Requirement::new("pkg>=abc!1.0").unwrap().normalize(false);
     assert!(req.to_string().starts_with("pkg>="));
 }
+
+#[test]
+fn test_is_name_only_bare_name() {
+    assert!(Requirement::new("wheel").unwrap().is_name_only());
+}
+
+#[test]
+fn test_is_name_only_version_constraint() {
+    assert!(!Requirement::new("wheel>=0.40").unwrap().is_name_only());
+}
+
+#[test]
+fn test_is_name_only_extras() {
+    assert!(!Requirement::new("wheel[extra]").unwrap().is_name_only());
+}
+
+#[test]
+fn test_is_name_only_marker() {
+    assert!(!Requirement::new("wheel; sys_platform=='win32'").unwrap().is_name_only());
+}
+
+#[test]
+fn test_is_name_only_url() {
+    assert!(
+        !Requirement::new("wheel @ https://example.com/wheel.whl")
+            .unwrap()
+            .is_name_only()
+    );
+}
+
+#[test]
+fn test_is_name_only_private() {
+    assert!(!Requirement::new("wheel; private").unwrap().is_name_only());
+}

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -228,7 +228,8 @@ Beyond general formatting, each table has specific key ordering and value normal
 The :pep:`517` / :pep:`518` table that declares how your project is built. See the
 `packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#build-system-table>`_.
 
-Keys are ordered ``build-backend`` → ``requires`` → ``backend-path``, and ``requires`` is normalized and sorted.
+Keys are ordered ``build-backend`` → ``requires`` → ``backend-path``, and ``requires`` is normalized and sorted. A
+redundant ``wheel`` requirement is removed when the build backend is setuptools.
 
 .. dropdown:: Formatting details
 
@@ -238,6 +239,15 @@ Keys are ordered ``build-backend`` → ``requires`` → ``backend-path``, and ``
 
     - ``requires``: dependencies normalized per :pep:`508` and sorted alphabetically by package name
     - ``backend-path``: entries sorted alphabetically
+
+    **Redundant wheel removal:**
+
+    A bare ``wheel`` entry is removed from ``requires`` when ``build-backend`` is ``setuptools.build_meta`` or
+    ``setuptools.build_meta:__legacy__``: setuptools either injects ``wheel`` dynamically when building (before
+    version 70.1) or bundles its own copy of ``bdist_wheel`` (70.1 and later), so listing it has no effect. The
+    entry is kept when it carries a version constraint, extras, or markers (it then expresses intent the backend's
+    dynamic injection would honor), when ``backend-path`` is set (an in-tree backend may import ``wheel``
+    directly), or when ``setuptools`` itself is missing from ``requires``.
 
     .. code-block:: toml
 
@@ -249,7 +259,7 @@ Keys are ordered ``build-backend`` → ``requires`` → ``backend-path``, and ``
         # After
         [build-system]
         build-backend = "setuptools.build_meta"
-        requires = ["setuptools>=45", "wheel"]
+        requires = ["setuptools>=45"]
 
 ``[project]``
 ~~~~~~~~~~~~~

--- a/pyproject-fmt/rust/src/build_system.rs
+++ b/pyproject-fmt/rust/src/build_system.rs
@@ -1,7 +1,10 @@
-use common::array::{sort_strings, transform};
+use common::array::{remove_strings, sort_strings, transform};
 use common::pep508::Requirement;
+use common::string::{get_string_token, load_text};
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::{lexical_cmp, natural_lexical_cmp};
+use tombi_syntax::SyntaxKind::{BASIC_STRING, LITERAL_STRING};
+use tombi_syntax::SyntaxNode;
 
 pub fn fix(tables: &Tables, keep_full_version: bool) {
     let table_element = tables.get("build-system");
@@ -9,11 +12,34 @@ pub fn fix(tables: &Tables, keep_full_version: bool) {
         return;
     }
     let table = &mut table_element.unwrap().first().unwrap().borrow_mut();
+    let mut backend = String::new();
+    let mut has_backend_path = false;
+    for_entries(table, &mut |key, entry| match key.as_str() {
+        "build-backend" => {
+            if let Some(token) = get_string_token(entry) {
+                backend = load_text(token.text(), entry.kind());
+            }
+        }
+        "backend-path" => {
+            has_backend_path = true;
+        }
+        _ => {}
+    });
+    let drop_wheel = !has_backend_path
+        && matches!(
+            backend.as_str(),
+            "setuptools.build_meta" | "setuptools.build_meta:__legacy__"
+        );
     for_entries(table, &mut |key, entry| match key.as_str() {
         "requires" => {
             transform(entry, &|s| {
                 Requirement::new(s).unwrap().normalize(keep_full_version).to_string()
             });
+            if drop_wheel && requires_has_setuptools(entry) {
+                remove_strings(entry, |s| {
+                    Requirement::new(s).is_ok_and(|r| r.canonical_name() == "wheel" && r.is_name_only())
+                });
+            }
             sort_strings::<String, _, _>(
                 entry,
                 |s| Requirement::new(s.as_str()).unwrap().canonical_name(),
@@ -26,4 +52,15 @@ pub fn fix(tables: &Tables, keep_full_version: bool) {
         _ => {}
     });
     reorder_table_keys(table, &["", "build-backend", "requires", "backend-path"]);
+}
+
+fn requires_has_setuptools(entry: &SyntaxNode) -> bool {
+    entry
+        .descendants()
+        .filter(|n| matches!(n.kind(), BASIC_STRING | LITERAL_STRING))
+        .any(|n| {
+            get_string_token(&n).is_some_and(|token| {
+                Requirement::new(&load_text(token.text(), n.kind())).is_ok_and(|r| r.canonical_name() == "setuptools")
+            })
+        })
 }

--- a/pyproject-fmt/rust/src/tests/build_systems_tests.rs
+++ b/pyproject-fmt/rust/src/tests/build_systems_tests.rs
@@ -117,3 +117,123 @@ fn test_format_build_systems_backend_path_sorting() {
     backend-path = [ "another", "lib", "src" ]
     "#);
 }
+
+#[test]
+fn test_format_build_systems_setuptools_backend_removes_bare_wheel() {
+    let start = indoc! {r#"
+    [build-system]
+    requires = ["setuptools >= 45", "wheel"]
+    build-backend = "setuptools.build_meta"
+    "#};
+    let res = format_build_systems_helper(start, false);
+    insta::assert_snapshot!(res, @r#"
+    [build-system]
+    build-backend = "setuptools.build_meta"
+    requires = [ "setuptools>=45" ]
+    "#);
+}
+
+#[test]
+fn test_format_build_systems_setuptools_legacy_backend_removes_bare_wheel() {
+    let start = indoc! {r#"
+    [build-system]
+    requires = ["setuptools", "wheel"]
+    build-backend = "setuptools.build_meta:__legacy__"
+    "#};
+    let res = format_build_systems_helper(start, false);
+    insta::assert_snapshot!(res, @r#"
+    [build-system]
+    build-backend = "setuptools.build_meta:__legacy__"
+    requires = [ "setuptools" ]
+    "#);
+}
+
+#[test]
+fn test_format_build_systems_setuptools_backend_keeps_constrained_wheel() {
+    let start = indoc! {r#"
+    [build-system]
+    requires = ["setuptools", "wheel>=0.40"]
+    build-backend = "setuptools.build_meta"
+    "#};
+    let res = format_build_systems_helper(start, false);
+    insta::assert_snapshot!(res, @r#"
+    [build-system]
+    build-backend = "setuptools.build_meta"
+    requires = [ "setuptools", "wheel>=0.40" ]
+    "#);
+}
+
+#[test]
+fn test_format_build_systems_setuptools_backend_keeps_wheel_with_marker() {
+    let start = indoc! {r#"
+    [build-system]
+    requires = ["setuptools", "wheel; sys_platform=='win32'"]
+    build-backend = "setuptools.build_meta"
+    "#};
+    let res = format_build_systems_helper(start, false);
+    insta::assert_snapshot!(res, @r#"
+    [build-system]
+    build-backend = "setuptools.build_meta"
+    requires = [ "setuptools", "wheel; sys_platform=='win32'" ]
+    "#);
+}
+
+#[test]
+fn test_format_build_systems_other_backend_keeps_wheel() {
+    let start = indoc! {r#"
+    [build-system]
+    requires = ["hatchling", "wheel"]
+    build-backend = "hatchling.build"
+    "#};
+    let res = format_build_systems_helper(start, false);
+    insta::assert_snapshot!(res, @r#"
+    [build-system]
+    build-backend = "hatchling.build"
+    requires = [ "hatchling", "wheel" ]
+    "#);
+}
+
+#[test]
+fn test_format_build_systems_no_backend_keeps_wheel() {
+    let start = indoc! {r#"
+    [build-system]
+    requires = ["setuptools", "wheel"]
+    "#};
+    let res = format_build_systems_helper(start, false);
+    insta::assert_snapshot!(res, @r#"
+    [build-system]
+    requires = [ "setuptools", "wheel" ]
+    "#);
+}
+
+#[test]
+fn test_format_build_systems_backend_path_keeps_wheel() {
+    let start = indoc! {r#"
+    [build-system]
+    requires = ["setuptools", "wheel"]
+    build-backend = "setuptools.build_meta"
+    backend-path = ["_custom"]
+    "#};
+    let res = format_build_systems_helper(start, false);
+    insta::assert_snapshot!(res, @r#"
+    [build-system]
+    build-backend = "setuptools.build_meta"
+    requires = [ "setuptools", "wheel" ]
+    backend-path = [ "_custom" ]
+    "#);
+}
+
+#[test]
+fn test_format_build_systems_no_setuptools_keeps_wheel() {
+    let start = indoc! {r#"
+    [build-system]
+    requires = ["wheel"]
+    build-backend = "setuptools.build_meta"
+    "#};
+    let res = format_build_systems_helper(start, false);
+    insta::assert_snapshot!(res, @r#"
+    [build-system]
+    build-backend = "setuptools.build_meta"
+    requires = [ "wheel" ]
+    "#);
+}


### PR DESCRIPTION
Projects copying old packaging guides still list `wheel` next to `setuptools` in `build-system.requires`, where it has no effect: setuptools injected `wheel` dynamically before 70.1 and bundles `bdist_wheel` itself since. The setuptools docs advise against listing it and repo-review flags it as `PP003`, which is how our own documentation example carrying the redundant entry got reported in #371. Rather than only fixing the example, the formatter now cleans this up for users. ✨

A bare `wheel` entry is removed from `requires` when `build-backend` is `setuptools.build_meta` or `setuptools.build_meta:__legacy__`. The removal stays conservative: entries carrying version constraints, extras, or markers express intent the backend's dynamic injection honors on older setuptools, so they remain; configurations with `backend-path` are left alone since an in-tree backend may import `wheel` directly, as are ones missing `setuptools` from `requires`. The implementation adds a reusable `remove_strings` array helper to `common` (with `dedupe_strings` now delegating to it) and a `Requirement::is_name_only` predicate.

The formatting reference documents the rule and its rationale, and the `[build-system]` example no longer showcases the anti-pattern.

Fixes #371
