### PR TITLE
✨ feat(common): add # Group: markers for scoped reordering

### DIFF
--- a/common/src/array.rs
+++ b/common/src/array.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
@@ -31,7 +30,9 @@ fn unwrap_leading_trivia(result: &mut Vec<SyntaxElement>, elem: SyntaxElement) {
     let children: Vec<_> = node.children_with_tokens().collect();
     let leading_count = children
         .iter()
-        .take_while(|c| matches!(c.kind(), LINE_BREAK | WHITESPACE))
+        .take_while(|c| {
+            matches!(c.kind(), LINE_BREAK | WHITESPACE) || (c.kind() == COMMENT && is_group_marker(&c.to_string()))
+        })
         .count();
     if leading_count == 0 {
         result.push(elem);
@@ -69,6 +70,7 @@ fn flatten_array_in_place(array: &SyntaxNode) {
 
 use crate::create::{make_comma, make_newline, make_whitespace_n};
 use crate::string::{load_text, update_content};
+use crate::util::is_group_marker;
 
 fn is_array_value(kind: SyntaxKind) -> bool {
     !matches!(
@@ -214,6 +216,48 @@ where
     }
 }
 
+/// A run of array values bounded by `# Group:` markers. Values are reordered only within a group;
+/// the marker `header` stays anchored at the group's start and groups keep their original order.
+struct ValueGroup<T> {
+    header: Vec<SyntaxElement>,
+    order_sets: Vec<Vec<SyntaxElement>>,
+    key_to_order_set: HashMap<T, usize>,
+}
+
+impl<T: Clone + Eq + Hash> ValueGroup<T> {
+    fn new(header: Vec<SyntaxElement>) -> Self {
+        Self {
+            header,
+            order_sets: Vec::new(),
+            key_to_order_set: HashMap::new(),
+        }
+    }
+
+    fn add(&mut self, key: T, set: &mut Vec<SyntaxElement>) {
+        if let Some(&existing_idx) = self.key_to_order_set.get(&key) {
+            self.order_sets[existing_idx].append(set);
+        } else {
+            self.key_to_order_set.insert(key, self.order_sets.len());
+            self.order_sets.push(std::mem::take(set));
+        }
+    }
+
+    fn emit<C: Fn(&T, &T) -> Ordering>(mut self, entries: &mut Vec<SyntaxElement>, cmp: &C) {
+        entries.extend(self.header);
+        for set in &mut self.order_sets {
+            let has_comma = set.iter().any(|e| e.kind() == COMMA);
+            if !has_comma && let Some(pos) = set.iter().position(|e| is_array_value(e.kind())) {
+                set.insert(pos + 1, make_comma());
+            }
+        }
+        let mut order: Vec<T> = self.key_to_order_set.keys().cloned().collect();
+        order.sort_by(cmp);
+        for key in order {
+            entries.extend(self.order_sets[self.key_to_order_set[&key]].clone());
+        }
+    }
+}
+
 #[allow(clippy::range_plus_one, clippy::too_many_lines)]
 pub fn sort<T, K, C>(array: &SyntaxNode, to_key: K, cmp: &C)
 where
@@ -233,24 +277,11 @@ where
         == Some(COMMA);
 
     let mut entries = Vec::<SyntaxElement>::new();
-    let mut order_sets = Vec::<Vec<SyntaxElement>>::new();
-    let mut key_to_order_set = HashMap::<T, usize>::new();
-    let current_set = RefCell::new(Vec::<SyntaxElement>::new());
+    let mut groups = vec![ValueGroup::<T>::new(Vec::new())];
+    let mut current_set = Vec::<SyntaxElement>::new();
     let mut current_set_value: Option<T> = None;
     let mut after_bracket_start = false;
-
-    let mut add_to_order_sets = |entry: T| {
-        let mut entry_set_borrow = current_set.borrow_mut();
-        if !entry_set_borrow.is_empty() {
-            if let Some(&existing_idx) = key_to_order_set.get(&entry) {
-                order_sets[existing_idx].extend(entry_set_borrow.clone());
-            } else {
-                key_to_order_set.insert(entry, order_sets.len());
-                order_sets.push(entry_set_borrow.clone());
-            }
-            entry_set_borrow.clear();
-        }
-    };
+    let mut pending_marker = false;
 
     let mut count = 0;
 
@@ -263,26 +294,25 @@ where
             }
             after_bracket_start = false;
         }
-        match &entry.kind() {
+        match entry.kind() {
             BRACKET_START => {
                 entries.push(entry);
                 after_bracket_start = true;
             }
             BRACKET_END => {
                 match current_set_value.take() {
-                    None => {
-                        entries.extend(current_set.borrow_mut().drain(..));
-                    }
-                    Some(val) => {
-                        add_to_order_sets(val);
-                    }
+                    None => entries.append(&mut current_set),
+                    Some(val) => groups.last_mut().unwrap().add(val, &mut current_set),
                 }
                 entries.push(entry);
             }
             LINE_BREAK => {
-                current_set.borrow_mut().push(entry);
-                if current_set_value.is_some() {
-                    add_to_order_sets(current_set_value.take().unwrap());
+                current_set.push(entry);
+                if pending_marker {
+                    groups.push(ValueGroup::new(std::mem::take(&mut current_set)));
+                    pending_marker = false;
+                } else if let Some(val) = current_set_value.take() {
+                    groups.last_mut().unwrap().add(val, &mut current_set);
                 }
             }
             COMMA => {
@@ -290,49 +320,38 @@ where
                     .as_node()
                     .is_some_and(|n| n.children_with_tokens().any(|c| c.kind() == COMMENT));
                 if has_comment {
-                    current_set.borrow_mut().push(entry);
+                    current_set.push(entry);
                 } else {
-                    current_set.borrow_mut().push(make_comma());
+                    current_set.push(make_comma());
                 }
             }
-            kind if is_array_value(*kind) => {
-                match current_set_value.take() {
-                    None => {}
-                    Some(val) => {
-                        add_to_order_sets(val);
-                    }
+            COMMENT if is_group_marker(&entry.to_string()) => {
+                current_set.push(entry);
+                pending_marker = true;
+            }
+            kind if is_array_value(kind) => {
+                if let Some(val) = current_set_value.take() {
+                    groups.last_mut().unwrap().add(val, &mut current_set);
                 }
                 if let Some(value_node) = entry.as_node() {
                     current_set_value = to_key(value_node);
                 }
-
-                current_set.borrow_mut().push(entry);
+                current_set.push(entry);
             }
-            _ => {
-                current_set.borrow_mut().push(entry);
-            }
+            _ => current_set.push(entry),
         }
     }
 
-    let remaining: Vec<SyntaxElement> = current_set.borrow_mut().drain(..).collect();
+    let remaining: Vec<SyntaxElement> = std::mem::take(&mut current_set);
 
     let leading_count = entries
         .iter()
         .take_while(|e| matches!(e.kind(), BRACKET_START | LINE_BREAK))
         .count();
     let trailing_content = entries.split_off(leading_count);
-    let mut order: Vec<T> = key_to_order_set.keys().cloned().collect();
-    order.sort_by(&cmp);
 
-    for set in &mut order_sets {
-        let has_comma = set.iter().any(|e| e.kind() == COMMA);
-        if !has_comma && let Some(pos) = set.iter().position(|e| is_array_value(e.kind())) {
-            set.insert(pos + 1, make_comma());
-        }
-    }
-
-    for key in order {
-        entries.extend(order_sets[key_to_order_set[&key]].clone());
+    for group in groups {
+        group.emit(&mut entries, cmp);
     }
     entries.extend(trailing_content);
     entries.extend(remaining);

--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -69,6 +69,30 @@ fn filter_entries(table: &mut RefMut<Vec<SyntaxElement>>, entries_to_remove: &Ha
     table.splice(0..table_len, new_elements);
 }
 use crate::string::load_text;
+use crate::util::is_group_marker;
+
+fn split_leading_group_marker(kv: &SyntaxElement) -> Option<Vec<SyntaxElement>> {
+    let node = kv.as_node()?;
+    let children: Vec<SyntaxElement> = node.children_with_tokens().collect();
+    let after = group_marker_prefix_len(&children)?;
+    let header = children[..after].to_vec();
+    let mut remaining = vec![make_newline()];
+    remaining.extend_from_slice(&children[after..]);
+    node.splice_children(0..children.len(), remaining);
+    Some(header)
+}
+
+fn emit_key(to_insert: &mut Vec<SyntaxElement>, set: &[SyntaxElement]) {
+    let first_has_leading = set.first().is_some_and(has_leading_newline);
+    if first_has_leading {
+        while to_insert.last().is_some_and(|e| e.kind() == LINE_BREAK) {
+            to_insert.pop();
+        }
+    } else if !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
+        to_insert.push(make_newline());
+    }
+    to_insert.extend(set.iter().cloned());
+}
 
 fn parse(source: &str) -> SyntaxNode {
     tombi_parser::parse(source).syntax_node().clone_for_update()
@@ -235,12 +259,33 @@ impl Tables {
         let sub_breaks = sub_table_spacing.chars().filter(|&c| c == '\n').count() + 1;
         let mut to_insert = Vec::<SyntaxElement>::new();
         let order = calculate_order(&self.header_to_pos, &self.table_set, order, multi_level_prefixes);
+
+        let pos_group = compute_pos_groups(&self.table_set);
+        let mut group_marker: HashMap<usize, Vec<SyntaxElement>> = HashMap::new();
+        for (pos, cell) in self.table_set.iter().enumerate() {
+            if let Some(header) = take_leading_group_marker(&mut cell.borrow_mut()) {
+                group_marker.insert(pos_group[pos], header);
+            }
+        }
+        let group_of_name: HashMap<&String, usize> = self
+            .header_to_pos
+            .iter()
+            .map(|(name, positions)| (name, pos_group[*positions.iter().min().unwrap()]))
+            .collect();
+        let mut emitted_groups = HashSet::<usize>::new();
+
         let mut next = order.clone();
         if !next.is_empty() {
             next.remove(0);
         }
         next.push(String::new());
         for (name, next_name) in zip(order.iter(), next.iter()) {
+            let group = group_of_name[name];
+            if emitted_groups.insert(group)
+                && let Some(header) = group_marker.get(&group)
+            {
+                to_insert.extend(header.iter().cloned());
+            }
             let entries_list = self.get(name).unwrap();
             let num_entries = entries_list.len();
 
@@ -300,6 +345,8 @@ fn calculate_order(
         .map(|(k, v)| (v, k * 2))
         .collect::<HashMap<&&str, usize>>();
 
+    let pos_group = compute_pos_groups(table_set);
+
     let mut header_pos: Vec<(String, usize)> = header_to_pos
         .clone()
         .into_iter()
@@ -316,32 +363,62 @@ fn calculate_order(
             .or_insert(*file_pos);
     }
 
-    header_pos.sort_by(|(k1, _), (k2, _)| {
-        let key1 = get_key(k1, multi_level_prefixes);
-        let key2 = get_key(k2, multi_level_prefixes);
-        let pos1 = key_to_pos.get(&key1.as_str());
-        let pos2 = key_to_pos.get(&key2.as_str());
+    header_pos.sort_by(|(k1, fp1), (k2, fp2)| {
+        pos_group[*fp1].cmp(&pos_group[*fp2]).then_with(|| {
+            let key1 = get_key(k1, multi_level_prefixes);
+            let key2 = get_key(k2, multi_level_prefixes);
+            let pos1 = key_to_pos.get(&key1.as_str());
+            let pos2 = key_to_pos.get(&key2.as_str());
 
-        match (pos1, pos2) {
-            (Some(&p1), Some(&p2)) => {
-                let offset1 = usize::from(key1 != *k1);
-                let offset2 = usize::from(key2 != *k2);
-                (p1 + offset1)
-                    .cmp(&(p2 + offset2))
-                    .then_with(|| k1.to_lowercase().cmp(&k2.to_lowercase()))
+            match (pos1, pos2) {
+                (Some(&p1), Some(&p2)) => {
+                    let offset1 = usize::from(key1 != *k1);
+                    let offset2 = usize::from(key2 != *k2);
+                    (p1 + offset1)
+                        .cmp(&(p2 + offset2))
+                        .then_with(|| k1.to_lowercase().cmp(&k2.to_lowercase()))
+                }
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => {
+                    let base_pos1 = base_key_first_pos.get(&key1).unwrap_or(&usize::MAX);
+                    let base_pos2 = base_key_first_pos.get(&key2).unwrap_or(&usize::MAX);
+                    base_pos1
+                        .cmp(base_pos2)
+                        .then_with(|| k1.to_lowercase().cmp(&k2.to_lowercase()))
+                }
             }
-            (Some(_), None) => std::cmp::Ordering::Less,
-            (None, Some(_)) => std::cmp::Ordering::Greater,
-            (None, None) => {
-                let base_pos1 = base_key_first_pos.get(&key1).unwrap_or(&usize::MAX);
-                let base_pos2 = base_key_first_pos.get(&key2).unwrap_or(&usize::MAX);
-                base_pos1
-                    .cmp(base_pos2)
-                    .then_with(|| k1.to_lowercase().cmp(&k2.to_lowercase()))
-            }
-        }
+        })
     });
     header_pos.into_iter().map(|(k, _)| k).collect()
+}
+
+fn compute_pos_groups(table_set: &[RefCell<Vec<SyntaxElement>>]) -> Vec<usize> {
+    let mut pos_group = vec![0_usize; table_set.len()];
+    let mut group = 0;
+    for (pos, cell) in table_set.iter().enumerate() {
+        if group_marker_prefix_len(&cell.borrow()).is_some() {
+            group += 1;
+        }
+        pos_group[pos] = group;
+    }
+    pos_group
+}
+
+fn group_marker_prefix_len(elements: &[SyntaxElement]) -> Option<usize> {
+    let marker_at = elements
+        .iter()
+        .position(|e| !matches!(e.kind(), LINE_BREAK | WHITESPACE))?;
+    if elements[marker_at].kind() != COMMENT || !is_group_marker(&elements[marker_at].to_string()) {
+        return None;
+    }
+    let trailing_break = usize::from(elements.get(marker_at + 1).is_some_and(|e| e.kind() == LINE_BREAK));
+    Some(marker_at + 1 + trailing_break)
+}
+
+fn take_leading_group_marker(content: &mut Vec<SyntaxElement>) -> Option<Vec<SyntaxElement>> {
+    let after = group_marker_prefix_len(content)?;
+    Some(content.drain(..after).collect())
 }
 
 fn get_key(k: &str, multi_level_prefixes: &[&str]) -> String {
@@ -357,51 +434,62 @@ fn get_key(k: &str, multi_level_prefixes: &[&str]) -> String {
 pub fn reorder_table_keys(table: &mut RefMut<Vec<SyntaxElement>>, order: &[&str]) {
     let (size, mut to_insert) = (table.len(), Vec::<SyntaxElement>::new());
     let (key_to_position, key_set) = load_keys(table);
+
+    let mut headers: Vec<Vec<SyntaxElement>> = vec![Vec::new()];
+    let mut pos_group = vec![0_usize; key_set.len()];
+    let mut current_group = 0;
+    for position in 0..key_set.len() {
+        if let Some(first) = key_set[position].first()
+            && let Some(header) = split_leading_group_marker(first)
+        {
+            headers.push(header);
+            current_group = headers.len() - 1;
+        }
+        pos_group[position] = current_group;
+    }
+
     let mut handled_positions = HashSet::<usize>::new();
-    for current_key in order {
-        let mut matching_keys = key_to_position
-            .iter()
-            .filter(|(checked_key, position)| {
-                !handled_positions.contains(position)
-                    && (current_key == checked_key
-                        || (checked_key.starts_with(current_key)
-                            && checked_key.len() > current_key.len()
-                            && checked_key.chars().nth(current_key.len()).unwrap() == '.'))
-            })
-            .map(|(key, _)| key)
-            .clone()
-            .collect::<Vec<&String>>();
-        matching_keys.sort_by_key(|key| key.to_lowercase());
-        for key in matching_keys {
-            let position = key_to_position[key];
-            let first_has_leading = key_set[position].first().is_some_and(has_leading_newline);
-            if first_has_leading {
-                while to_insert.last().is_some_and(|e| e.kind() == LINE_BREAK) {
-                    to_insert.pop();
-                }
-            } else if !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
+    for (group, header) in headers.iter().enumerate() {
+        if !header.is_empty() {
+            let starts_with_break = header.first().map(SyntaxElement::kind) == Some(LINE_BREAK);
+            if !starts_with_break && !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
                 to_insert.push(make_newline());
             }
-            to_insert.extend(key_set[position].clone());
+            to_insert.extend(header.iter().cloned());
+        }
+        for current_key in order {
+            let mut matching_keys = key_to_position
+                .iter()
+                .filter(|(checked_key, position)| {
+                    !handled_positions.contains(position)
+                        && (current_key == checked_key
+                            || (checked_key.starts_with(current_key)
+                                && checked_key.len() > current_key.len()
+                                && checked_key.chars().nth(current_key.len()).unwrap() == '.'))
+                })
+                .map(|(key, _)| key)
+                .clone()
+                .collect::<Vec<&String>>();
+            matching_keys.sort_by_key(|key| key.to_lowercase());
+            for key in matching_keys {
+                let position = key_to_position[key];
+                if pos_group[position] != group {
+                    continue;
+                }
+                emit_key(&mut to_insert, &key_set[position]);
+                handled_positions.insert(position);
+            }
+        }
+        let mut unhandled: Vec<(String, usize)> = key_to_position
+            .iter()
+            .filter(|(_, position)| !handled_positions.contains(position) && pos_group[**position] == group)
+            .map(|(key, position)| (key.clone(), *position))
+            .collect();
+        unhandled.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+        for (_, position) in unhandled {
+            emit_key(&mut to_insert, &key_set[position]);
             handled_positions.insert(position);
         }
-    }
-    let mut unhandled: Vec<(String, usize)> = key_to_position
-        .iter()
-        .filter(|(_, position)| !handled_positions.contains(position))
-        .map(|(key, position)| (key.clone(), *position))
-        .collect();
-    unhandled.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
-    for (_, position) in unhandled {
-        let first_has_leading = key_set[position].first().is_some_and(has_leading_newline);
-        if first_has_leading {
-            while to_insert.last().is_some_and(|e| e.kind() == LINE_BREAK) {
-                to_insert.pop();
-            }
-        } else if !to_insert.is_empty() && to_insert.last().map(|e| e.kind()) != Some(LINE_BREAK) {
-            to_insert.push(make_newline());
-        }
-        to_insert.extend(key_set[position].clone());
     }
     table.splice(0..size, to_insert);
 }
@@ -692,12 +780,6 @@ pub fn collapse_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str
         _ => return,
     };
 
-    ensure_table_exists(tables, parent_name);
-    let main_positions = tables.header_to_pos[parent_name].clone();
-    if main_positions.len() != 1 {
-        return;
-    }
-
     let first_sub = tables.table_set[*sub_positions.first().unwrap()].borrow();
     // Check for both ARRAY_OF_TABLE node (old structure) and DOUBLE_BRACKET_START (new structure)
     let is_array_table = first_sub
@@ -710,6 +792,11 @@ pub fn collapse_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str
         return;
     }
 
+    ensure_table_exists(tables, parent_name);
+    let main_positions = tables.header_to_pos[parent_name].clone();
+    if main_positions.len() != 1 {
+        return;
+    }
     let mut main = tables.table_set[*main_positions.first().unwrap()].borrow_mut();
     let mut sub = tables.table_set[*sub_positions.first().unwrap()].borrow_mut();
 
@@ -839,23 +926,11 @@ fn collapse_array_of_tables(
     let has_comments_between_keys = all_entries
         .iter()
         .any(|aot_entries| aot_entries.iter().skip(1).any(|entry| !entry.comments.is_empty()));
+    if has_comments_between_keys {
+        return;
+    }
 
-    let array_value = if has_comments_between_keys {
-        let mut parts: Vec<String> = Vec::new();
-        for aot_entries in &all_entries {
-            for entry in aot_entries {
-                for comment in &entry.comments {
-                    parts.push(format!("  {comment}"));
-                }
-                let inline_table = format!("{{ {} = {} }}", entry.key, entry.value);
-                if inline_table.len() > column_width {
-                    return;
-                }
-                parts.push(format!("  {inline_table},"));
-            }
-        }
-        format!("[\n{}\n]", parts.join("\n"))
-    } else {
+    let array_value = {
         let has_leading_comments = all_entries
             .iter()
             .any(|aot_entries| aot_entries.first().is_some_and(|e| !e.comments.is_empty()));
@@ -890,7 +965,11 @@ fn collapse_array_of_tables(
     };
     let entry_text = format!("{sub_name} = {array_value}\n");
 
-    let main_positions = &tables.header_to_pos[parent_name];
+    ensure_table_exists(tables, parent_name);
+    let main_positions = tables.header_to_pos[parent_name].clone();
+    if main_positions.len() != 1 {
+        return;
+    }
     let mut main = tables.table_set[*main_positions.first().unwrap()].borrow_mut();
 
     if main.last().is_some_and(|e| e.kind() != LINE_BREAK) {

--- a/common/src/tests/array_tests.rs
+++ b/common/src/tests/array_tests.rs
@@ -1091,3 +1091,70 @@ fn test_remove_strings_last_entry_no_trailing_comma() {
     let res = remove_strings_helper(start, "c");
     insta::assert_snapshot!(res, @r#"a = [ "b" ]"#);
 }
+
+#[test]
+fn test_sort_group_markers_partition() {
+    let start = indoc! {r#"
+        a = [
+          # Group: web
+          "flask",
+          "django",
+          # Group: net
+          "requests",
+          "aiohttp",
+        ]
+    "#};
+    let res = sort_array_helper(start);
+    insta::assert_snapshot!(res, @r#"
+    a = [
+      # Group: web
+      "django",
+      "flask",
+      # Group: net
+      "aiohttp",
+      "requests",
+    ]
+    "#);
+}
+
+#[test]
+fn test_sort_group_markers_leading_group() {
+    let start = indoc! {r#"
+        a = [
+          "zebra",
+          "apple",
+          # Group: more
+          "yak",
+          "bear",
+        ]
+    "#};
+    let res = sort_array_helper(start);
+    insta::assert_snapshot!(res, @r#"
+    a = [
+      "apple",
+      "zebra",
+      # Group: more
+      "bear",
+      "yak",
+    ]
+    "#);
+}
+
+#[test]
+fn test_sort_non_marker_comment_travels_with_value() {
+    let start = indoc! {r#"
+        a = [
+          # web frameworks
+          "flask",
+          "django",
+        ]
+    "#};
+    let res = sort_array_helper(start);
+    insta::assert_snapshot!(res, @r#"
+    a = [
+      "django",
+      # web frameworks
+      "flask",
+    ]
+    "#);
+}

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -1018,7 +1018,7 @@ fn test_collapse_array_of_tables_preserves_comments() {
 }
 
 #[test]
-fn test_collapse_array_of_tables_preserves_multiple_comments_per_entry() {
+fn test_collapse_array_of_tables_skips_when_comments_between_keys() {
     let toml = indoc! {r#"
         [tool.cibuildwheel]
         name = "foo"
@@ -1036,21 +1036,15 @@ fn test_collapse_array_of_tables_preserves_multiple_comments_per_entry() {
 
     collapse_sub_table(&mut tables, "tool.cibuildwheel", "overrides", 120);
 
+    let overrides = tables.get("tool.cibuildwheel.overrides").unwrap();
+    assert!(
+        !overrides[0].borrow().is_empty(),
+        "entries with comments between keys must stay expanded to keep valid TOML"
+    );
     let parent = tables.get("tool.cibuildwheel").unwrap();
     let parent_table = parent[0].borrow();
     let result = parent_table.iter().map(|e| e.to_string()).collect::<String>();
-    insta::assert_snapshot!(result, @r#"
-    [tool.cibuildwheel]
-    name = "foo"
-    overrides = [
-      # iOS environment comment
-      # yeah
-      { select = "*_iphoneos" },
-      # s
-      # oh yeah
-      { pure = "ss" },
-    ]
-    "#);
+    assert!(!result.contains("overrides ="), "table must not be collapsed inline");
 }
 
 #[test]
@@ -2384,5 +2378,135 @@ fn test_reorder_inline_table_keys_unknown_keys_appended() {
     insta::assert_snapshot!(result, @r#"
     [section]
     val = { replace = "env", name = "X", extra = true }
+    "#);
+}
+
+fn reorder_keys_render(start: &str, table_name: &str, order: &[&str]) -> String {
+    let root_ast = parse(start);
+    let tables = Tables::from_ast(&root_ast);
+    let refs = tables.get(table_name).unwrap();
+    reorder_table_keys(&mut refs[0].borrow_mut(), order);
+    refs[0].borrow().iter().map(|e| e.to_string()).collect::<String>()
+}
+
+#[test]
+fn test_reorder_table_keys_group_markers_partition() {
+    let start = indoc! {r#"
+        [tool.x]
+        # Group: a
+        zebra = 1
+        apple = 2
+        # Group: b
+        yak = 3
+        bear = 4
+    "#};
+    let res = reorder_keys_render(start, "tool.x", &[""]);
+    insta::assert_snapshot!(res, @r#"
+    [tool.x]
+    # Group: a
+    apple = 2
+    zebra = 1
+    # Group: b
+    bear = 4
+    yak = 3
+    "#);
+}
+
+#[test]
+fn test_reorder_table_keys_no_markers_unchanged() {
+    let start = indoc! {r#"
+        [tool.x]
+        zebra = 1
+        apple = 2
+    "#};
+    let res = reorder_keys_render(start, "tool.x", &[""]);
+    insta::assert_snapshot!(res, @r#"
+    [tool.x]
+    apple = 2
+    zebra = 1
+    "#);
+}
+
+#[test]
+fn test_reorder_sections_group_markers_block_cross_group() {
+    let start = indoc! {r#"
+        # Group: one
+        [tool.zzz]
+        a = 1
+
+        [tool.aaa]
+        b = 2
+
+        # Group: two
+        [tool.yyy]
+        c = 3
+
+        [tool.bbb]
+        d = 4
+    "#};
+    let root_ast = parse(start);
+    let tables = Tables::from_ast(&root_ast);
+    tables.reorder(&root_ast, &[], &[], "\n", "");
+    insta::assert_snapshot!(format_toml(&root_ast, 120), @r#"
+    # Group: one
+    [tool.aaa]
+    b = 2
+
+    [tool.zzz]
+    a = 1
+
+    # Group: two
+    [tool.bbb]
+    d = 4
+
+    [tool.yyy]
+    c = 3
+    "#);
+}
+
+#[test]
+fn test_collapse_array_of_tables_skips_multi_position_parent() {
+    let toml = indoc! {r#"
+        [[project]]
+        name = "a"
+
+        [[project]]
+        name = "b"
+
+        [[project.foo]]
+        x = 1
+    "#};
+    let root_ast = parse(toml);
+    let mut tables = Tables::from_ast(&root_ast);
+
+    collapse_sub_table(&mut tables, "project", "foo", 120);
+
+    let foo = tables.get("project.foo").unwrap();
+    assert!(
+        !foo[0].borrow().is_empty(),
+        "must not collapse into a parent with multiple positions"
+    );
+}
+
+#[test]
+fn test_reorder_table_keys_group_markers_respect_order() {
+    let start = indoc! {r#"
+        [tool.x]
+        # Group: a
+        beta = 1
+        alpha = 2
+        # Group: b
+        delta = 3
+        charlie = 4
+    "#};
+    let res = reorder_keys_render(start, "tool.x", &["alpha", "charlie"]);
+    insta::assert_snapshot!(res, @r#"
+    [tool.x]
+    # Group: a
+    alpha = 2
+    beta = 1
+    # Group: b
+    charlie = 4
+    delta = 3
     "#);
 }

--- a/common/src/tests/util_tests.rs
+++ b/common/src/tests/util_tests.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use tombi_syntax::SyntaxKind::{BASIC_STRING, KEY_VALUE, KEYS};
 
-use crate::util::{find_first, iter, limit_blank_lines};
+use crate::util::{find_first, is_group_marker, iter, limit_blank_lines};
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
     tombi_parser::parse(source).syntax_node().clone_for_update()
@@ -125,4 +125,23 @@ fn test_limit_blank_lines_zero_max() {
     let expected = "line1\nline2\n";
     let result = limit_blank_lines(input, 0);
     assert_eq!(result, expected);
+}
+
+#[test]
+fn test_is_group_marker() {
+    for (text, expected) in [
+        ("# Group: web", true),
+        ("#Group:web", true),
+        ("#   Group:   web", true),
+        ("# group: web", true),
+        ("# GROUP: web", true),
+        ("   # Group: x", true),
+        ("# web frameworks", false),
+        ("# Group of things", false),
+        ("Group: web", false),
+        ("", false),
+        ("#", false),
+    ] {
+        assert_eq!(is_group_marker(text), expected, "{text:?}");
+    }
 }

--- a/common/src/util.rs
+++ b/common/src/util.rs
@@ -45,6 +45,15 @@ where
     None
 }
 
+pub fn is_group_marker(comment_text: &str) -> bool {
+    comment_text
+        .trim_start()
+        .strip_prefix('#')
+        .map(str::trim_start)
+        .and_then(|rest| rest.get(..6))
+        .is_some_and(|head| head.eq_ignore_ascii_case("group:"))
+}
+
 pub fn limit_blank_lines(content: &str, max_blank_lines: usize) -> String {
     let lines: Vec<&str> = content.lines().collect();
     let mut result = Vec::new();

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -217,6 +217,44 @@ Inline comments within arrays are aligned independently per array, based on that
       "ISC001",  # Another rule
     ]
 
+Group Markers
+~~~~~~~~~~~~~
+
+By default the formatter reorders each array, table, and section list as a single unit, so any entry can move to its
+sorted position. Mark a boundary with a standalone comment that starts with ``# Group:``: the formatter then sorts within
+each group, holds the groups in their original order, and keeps the marker at the top of its group. Reach for this when
+related entries belong together but should still be sorted.
+
+Files without a ``# Group:`` marker format the same as before, so the feature stays opt-in. Case does not matter, so
+``# group:`` works too. Only standalone comment lines count; the formatter ignores inline trailing comments.
+
+The formatter sorts the entries inside each group:
+
+.. code-block:: toml
+
+    # Before
+    dependencies = [
+      # Group: web
+      "flask",
+      "django",
+      # Group: db
+      "sqlalchemy",
+      "psycopg2",
+    ]
+
+    # After
+    dependencies = [
+      # Group: web
+      "django",
+      "flask",
+      # Group: db
+      "psycopg2",
+      "sqlalchemy",
+    ]
+
+A ``# Group:`` marker works the same way before a key in a table or before a ``[tool.*]`` header: the formatter sorts the
+keys or sections up to the next marker, and never moves them across the boundary.
+
 Table-Specific Handling
 -----------------------
 

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -1001,3 +1001,39 @@ fn test_issue_202_preserve_inline_comment_after_array() {
     lint.per-file-ignores."docs/**/*.py" = [ "INP001" ]  # No __init__.py in docs
     "#);
 }
+
+#[test]
+fn test_issue_376_collapse_with_comments_stays_valid() {
+    let start = indoc! {r#"
+        [[tool.uv.index]]
+        name = "pypi"
+        url = "https://pypi.org/simple"
+        # TODO: uncomment once ready
+        # default = true
+        authenticate = "never"
+
+        [[tool.uv.index]]
+        name = "company-master"
+        url = "https://dl.cloudsmith.io/x"
+        # ignore-error-codes = [400, 401, 403]
+        authenticate = "always"
+    "#};
+    let mut settings = default_settings();
+    settings.collapse_tables = vec![String::from("tool.uv.index")];
+    let result = format_toml(start, &settings);
+    assert_valid_toml(&result);
+    insta::assert_snapshot!(result, @r#"
+    [[tool.uv.index]]
+    name = "pypi"
+    url = "https://pypi.org/simple"
+    # TODO: uncomment once ready
+    # default = true
+    authenticate = "never"
+
+    [[tool.uv.index]]
+    name = "company-master"
+    url = "https://dl.cloudsmith.io/x"
+    # ignore-error-codes = [400, 401, 403]
+    authenticate = "always"
+    "#);
+}

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -2335,3 +2335,34 @@ fn test_project_classifiers_with_invalid_classifier() {
     ]
     "#);
 }
+
+#[test]
+fn test_project_dependencies_group_markers() {
+    let start = indoc! {r#"
+        [project]
+        name = "x"
+        version = "1"
+        dependencies = [
+          # Group: web
+          "flask",
+          "django",
+          # Group: db
+          "sqlalchemy",
+          "psycopg2",
+        ]
+    "#};
+    let result = evaluate_project(start, false, (3, 9), false);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "x"
+    version = "1"
+    dependencies = [
+      # Group: web
+      "django",
+      "flask",
+      # Group: db
+      "psycopg2",
+      "sqlalchemy",
+    ]
+    "#);
+}

--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -198,6 +198,39 @@ Inline comments within arrays are aligned independently per array, based on that
       "pytest-mock",  # mocking
     ]
 
+Group Markers
+~~~~~~~~~~~~~
+
+By default the formatter reorders each array and table as a single unit, so any entry can move to its sorted position.
+Mark a boundary with a standalone comment that starts with ``# Group:``: the formatter then sorts within each group,
+holds the groups in their original order, and keeps the marker at the top of its group. Reach for this when related
+entries belong together but should still be sorted.
+
+Files without a ``# Group:`` marker format the same as before, so the feature stays opt-in. Case does not matter, so
+``# group:`` works too. Only standalone comment lines count; the formatter ignores inline trailing comments.
+
+.. code-block:: toml
+
+    # Before
+    deps = [
+      # Group: runtime
+      "requests",
+      "click",
+      # Group: testing
+      "pytest-cov",
+      "pytest",
+    ]
+
+    # After
+    deps = [
+      # Group: runtime
+      "click",
+      "requests",
+      # Group: testing
+      "pytest",
+      "pytest-cov",
+    ]
+
 Table-Specific Handling
 -----------------------
 


### PR DESCRIPTION
Reordering treated each array, table, and tool-section list as one flat unit, so sorting was free to interleave entries across what a user considered separate sections, dragging standalone comments along with whichever value they ended up beside. People who structure a `dependencies` list or a set of `[tool.*]` sections into logical blocks had no way to keep those blocks intact while still sorting inside them. This addresses #376.

A standalone comment that starts with `# Group:` now marks a boundary. ✨ The formatter sorts only within each group, keeps the groups in their original order, and anchors the marker at the top of its group. The same marker works in three places: array elements, table keys, and tool-section ordering. Matching ignores case, and only standalone comment lines count, so inline trailing comments keep traveling with their value as before. A file without any marker formats exactly as it did, so the behavior is opt-in.

While wiring this up I also fixed a related defect in array-of-tables collapsing. 🐛 When an entry carried comments between its keys, the collapse split each key into its own inline table, which produced invalid TOML and left behind a spurious empty parent table. Such tables now stay expanded so the output remains valid.

Behavior is unchanged for any file that has no `# Group:` markers and no comment-laden array-of-tables, so existing formatted files stay stable.