### PR TITLE
✨ feat(common): keep disabled keys anchored to their table

### DIFF
--- a/common/src/disabled.rs
+++ b/common/src/disabled.rs
@@ -1,0 +1,88 @@
+//! Transparent handling of commented-out (disabled) keys.
+//!
+//! A standalone comment whose body is itself a single valid key-value (for example
+//! `# default = true`) is treated as a temporarily disabled field rather than free
+//! text. It is enabled for the duration of the formatting pass so it is laid out and
+//! ordered together with the table it belongs to, then disabled again on the way out.
+//! This keeps a disabled key anchored to its entry instead of drifting to the next
+//! table, and formats the line the same way the enabled key would be formatted.
+
+use tombi_syntax::SyntaxKind::{ARRAY_OF_TABLE, COMMENT, KEY_VALUE, TABLE};
+
+/// Marker appended to a disabled key's trailing comment so the pass can find the key
+/// again after it has travelled through reordering and re-parsing. Inline trailing
+/// comments stay attached to their key-value, so the marker rides along for free.
+/// It never reaches the formatted output: [`restore_disabled_keys`] strips it.
+pub const MARKER: &str = "__toml_fmt_disabled__";
+
+/// Rewrite a comment body into its enabled key-value form, or `None` when the body is
+/// not a single key-value (prose, a commented table header, multiple keys, ...).
+fn enabled_form(body: &str) -> Option<String> {
+    let parsed = tombi_parser::parse(body);
+    if !parsed.errors.is_empty() {
+        return None;
+    }
+    let root = parsed.syntax_node();
+    let key_values = root.descendants().filter(|n| n.kind() == KEY_VALUE).count();
+    let has_table = root.descendants().any(|n| matches!(n.kind(), TABLE | ARRAY_OF_TABLE));
+    if key_values != 1 || has_table {
+        return None;
+    }
+    let has_trailing_comment = root.descendants_with_tokens().any(|t| t.kind() == COMMENT);
+    Some(if has_trailing_comment {
+        format!("{body} {MARKER}")
+    } else {
+        format!("{body}  # {MARKER}")
+    })
+}
+
+/// Pre-pass: turn each disabled key into a real key-value tagged with [`MARKER`].
+///
+/// Keys that would not fit on a single line within `column_width` are left as plain
+/// comments, since enabling them could reflow the value across several lines and break
+/// the single-line restore.
+pub fn enable_disabled_keys(source: &str, column_width: usize) -> String {
+    let mut out: Vec<String> = Vec::with_capacity(source.lines().count());
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if let Some(rest) = trimmed.strip_prefix('#') {
+            let indent = &line[..line.len() - trimmed.len()];
+            let body = rest.trim_start();
+            if indent.len() + body.len() <= column_width
+                && let Some(enabled) = enabled_form(body)
+            {
+                out.push(format!("{indent}{enabled}"));
+                continue;
+            }
+        }
+        out.push(line.to_string());
+    }
+    join_like(source, out)
+}
+
+/// Post-pass: turn every marker-tagged key-value back into a comment, dropping the
+/// marker. The key kept its surrounding comment (if any), which is restored verbatim.
+pub fn restore_disabled_keys(formatted: &str) -> String {
+    let mut out: Vec<String> = Vec::with_capacity(formatted.lines().count());
+    for line in formatted.lines() {
+        if let Some(idx) = line.find(MARKER) {
+            let before = line[..idx].trim_end();
+            let body = before.strip_suffix('#').map_or(before, str::trim_end);
+            let indent_len = body.len() - body.trim_start().len();
+            let (indent, content) = body.split_at(indent_len);
+            out.push(format!("{indent}# {content}"));
+        } else {
+            out.push(line.to_string());
+        }
+    }
+    join_like(formatted, out)
+}
+
+fn join_like(original: &str, lines: Vec<String>) -> String {
+    let joined = lines.join("\n");
+    if original.ends_with('\n') {
+        format!("{joined}\n")
+    } else {
+        joined
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod array;
 pub mod create;
+pub mod disabled;
 pub mod format_options;
 pub mod pep508;
 pub mod string;

--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -883,6 +883,18 @@ fn collapse_array_of_tables(
     sub_positions: &[usize],
     column_width: usize,
 ) {
+    // A disabled key carries the marker in a trailing comment; collapsing the entry into an
+    // inline table would embed that comment and produce invalid TOML, so keep it expanded.
+    let has_disabled_key = sub_positions.iter().any(|pos| {
+        tables.table_set[*pos]
+            .borrow()
+            .iter()
+            .any(|e| e.to_string().contains(crate::disabled::MARKER))
+    });
+    if has_disabled_key {
+        return;
+    }
+
     let mut all_entries: Vec<Vec<KeyValueWithComments>> = Vec::new();
 
     for pos in sub_positions {

--- a/common/src/tests/disabled_tests.rs
+++ b/common/src/tests/disabled_tests.rs
@@ -1,0 +1,86 @@
+use crate::disabled::{MARKER, enable_disabled_keys, restore_disabled_keys};
+
+#[test]
+fn test_enable_promotes_valid_key() {
+    let out = enable_disabled_keys("# default = true\n", 120);
+    assert_eq!(out, format!("default = true  # {MARKER}\n"));
+}
+
+#[test]
+fn test_enable_preserves_indentation() {
+    let out = enable_disabled_keys("  # x = 1\n", 120);
+    assert_eq!(out, format!("  x = 1  # {MARKER}\n"));
+}
+
+#[test]
+fn test_enable_appends_to_existing_trailing_comment() {
+    let out = enable_disabled_keys("# x = 1  # note\n", 120);
+    assert_eq!(out, format!("x = 1  # note {MARKER}\n"));
+}
+
+#[test]
+fn test_enable_leaves_prose_comment() {
+    let source = "# just a note, not a key\n";
+    assert_eq!(enable_disabled_keys(source, 120), source);
+}
+
+#[test]
+fn test_enable_leaves_commented_table_header() {
+    let source = "# [tool.foo]\n";
+    assert_eq!(enable_disabled_keys(source, 120), source);
+}
+
+#[test]
+fn test_enable_leaves_non_comment_lines() {
+    let source = "enabled = true\n";
+    assert_eq!(enable_disabled_keys(source, 120), source);
+}
+
+#[test]
+fn test_enable_skips_when_line_exceeds_width() {
+    let source = "# x = 1\n";
+    assert_eq!(enable_disabled_keys(source, 3), source);
+}
+
+#[test]
+fn test_enable_without_trailing_newline() {
+    let out = enable_disabled_keys("# x = 1", 120);
+    assert_eq!(out, format!("x = 1  # {MARKER}"));
+}
+
+#[test]
+fn test_restore_marker_only_comment() {
+    let line = format!("default = true  # {MARKER}\n");
+    assert_eq!(restore_disabled_keys(&line), "# default = true\n");
+}
+
+#[test]
+fn test_restore_keeps_original_trailing_comment() {
+    let line = format!("x = 1  # note {MARKER}\n");
+    assert_eq!(restore_disabled_keys(&line), "# x = 1  # note\n");
+}
+
+#[test]
+fn test_restore_preserves_indentation() {
+    let line = format!("  x = 1  # {MARKER}\n");
+    assert_eq!(restore_disabled_keys(&line), "  # x = 1\n");
+}
+
+#[test]
+fn test_restore_leaves_unmarked_lines() {
+    let source = "x = 1  # real comment\n";
+    assert_eq!(restore_disabled_keys(source), source);
+}
+
+#[test]
+fn test_restore_without_trailing_newline() {
+    let line = format!("x = 1  # {MARKER}");
+    assert_eq!(restore_disabled_keys(&line), "# x = 1");
+}
+
+#[test]
+fn test_round_trip_is_identity_for_disabled_key() {
+    let source = "# default = true\n";
+    let enabled = enable_disabled_keys(source, 120);
+    assert_eq!(restore_disabled_keys(&enabled), source);
+}

--- a/common/src/tests/mod.rs
+++ b/common/src/tests/mod.rs
@@ -4,6 +4,7 @@ pub use crate::test_util::format_toml_str;
 
 pub mod array_tests;
 pub mod create_tests;
+pub mod disabled_tests;
 pub mod pep508_tests;
 pub mod string_tests;
 pub mod table_tests;

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -1048,6 +1048,33 @@ fn test_collapse_array_of_tables_skips_when_comments_between_keys() {
 }
 
 #[test]
+fn test_collapse_array_of_tables_skips_when_entry_has_disabled_key() {
+    let toml = format!(
+        indoc! {r#"
+        [project]
+        name = "foo"
+
+        [[project.authors]]
+        name = "Alice"  # {}
+    "#},
+        crate::disabled::MARKER
+    );
+    let root_ast = parse(&toml);
+    let mut tables = Tables::from_ast(&root_ast);
+
+    collapse_sub_table(&mut tables, "project", "authors", 120);
+
+    let authors = tables.get("project.authors").unwrap();
+    assert!(
+        !authors[0].borrow().is_empty(),
+        "entries with a disabled key must stay expanded to keep valid TOML"
+    );
+    let parent = tables.get("project").unwrap();
+    let result = parent[0].borrow().iter().map(|e| e.to_string()).collect::<String>();
+    assert!(!result.contains("authors ="), "table must not be collapsed inline");
+}
+
+#[test]
 fn test_collapse_array_of_tables_no_comments() {
     let toml = indoc! {r#"
         [project]

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -217,6 +217,37 @@ Inline comments within arrays are aligned independently per array, based on that
       "ISC001",  # Another rule
     ]
 
+Disabled Keys
+~~~~~~~~~~~~~
+
+A commented-out line whose body is itself a single valid key-value (for example ``# default = true``) is treated as a
+temporarily *disabled* field rather than free text. The formatter enables it for the duration of the pass, so it is laid
+out and ordered together with the table it belongs to, then comments it out again on the way out. This keeps a disabled
+key anchored to its entry instead of drifting to the next table, and formats the line the same way the enabled key would
+be:
+
+.. code-block:: toml
+
+    # Before
+    [[tool.uv.index]]
+    name = "pypi"
+    authenticate = "never"
+    # default = true
+    # ignore-error-codes = [400,401,403]
+
+    # After
+    [[tool.uv.index]]
+    name = "pypi"
+    authenticate = "never"
+    # default = true
+    # ignore-error-codes = [ 400, 401, 403 ]
+
+Comments that are not a single valid key-value (prose, multi-line blocks, commented-out table headers like
+``# [tool.x]``) are left untouched and follow the usual comment-preservation rules above. The heuristic is purely
+structural, so a prose comment that *happens* to be valid TOML (such as a ``key = value`` example written in
+documentation) is reflowed too; if that matters, phrase the comment so it does not parse as a key-value. Keys that would
+not fit on a single line within ``column_width`` are left as plain comments.
+
 Group Markers
 ~~~~~~~~~~~~~
 

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -157,7 +157,8 @@ fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
 /// Format toml file
 #[must_use]
 pub fn format_toml(content: &str, opt: &Settings) -> String {
-    let root_ast = parse(content);
+    let content = common::disabled::enable_disabled_keys(content, opt.column_width);
+    let root_ast = parse(&content);
     common::string::normalize_key_quotes(&root_ast);
     let mut tables = Tables::from_ast(&root_ast);
     let table_config = TableFormatConfig::from_settings(opt);
@@ -254,7 +255,8 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     } else {
         formatted
     };
-    common::util::limit_blank_lines(&result, 2)
+    let result = common::util::limit_blank_lines(&result, 2);
+    common::disabled::restore_disabled_keys(&result)
 }
 
 fn remove_blank_lines_between_same_group_tables(content: &str, multi_level_prefixes: &[&str]) -> String {

--- a/pyproject-fmt/rust/src/tests/disabled_tests.rs
+++ b/pyproject-fmt/rust/src/tests/disabled_tests.rs
@@ -1,0 +1,96 @@
+use common::disabled::MARKER;
+use indoc::indoc;
+
+use super::assert_valid_toml;
+use crate::{format_toml, Settings};
+
+fn settings() -> Settings {
+    Settings {
+        column_width: 120,
+        indent: 2,
+        keep_full_version: false,
+        max_supported_python: (3, 9),
+        min_supported_python: (3, 9),
+        generate_python_version_classifiers: false,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+    }
+}
+
+fn evaluate(start: &str) -> String {
+    let result = format_toml(start, &settings());
+    assert_valid_toml(&result);
+    assert!(
+        !result.contains(MARKER),
+        "internal marker leaked into output:\n{result}"
+    );
+    result
+}
+
+#[test]
+fn test_disabled_keys_stay_anchored_to_their_entry() {
+    let start = indoc! {r#"
+        [[tool.uv.index]]
+        name = "pypi"
+        url = "https://pypi.org/simple"
+        authenticate = "never"
+        # TODO: once ticket XYZ is complete
+        #  to prioritise those over pypi
+        # default = true
+
+        # These definitions will be used as priority over the ones specified in uv.toml
+
+        [[tool.uv.index]]
+        name = "company-master"
+        url = "https://dl.cloudsmith.io/basic/company/master/python/simple"
+        authenticate = "always"
+        # ignore-error-codes = [400, 401, 403]  # turn on for debugging
+    "#};
+    insta::assert_snapshot!(evaluate(start), @r#"
+    [[tool.uv.index]]
+    name = "pypi"
+    url = "https://pypi.org/simple"
+    authenticate = "never"
+    # TODO: once ticket XYZ is complete
+    #  to prioritise those over pypi
+    # default = true
+
+    # These definitions will be used as priority over the ones specified in uv.toml
+    [[tool.uv.index]]
+    name = "company-master"
+    url = "https://dl.cloudsmith.io/basic/company/master/python/simple"
+    authenticate = "always"
+    # ignore-error-codes = [ 400, 401, 403 ]  # turn on for debugging
+    "#);
+}
+
+#[test]
+fn test_disabled_key_output_is_idempotent() {
+    let start = indoc! {r#"
+        [[tool.uv.index]]
+        name = "pypi"
+        url = "https://pypi.org/simple"
+        # default = true
+    "#};
+    let once = evaluate(start);
+    assert_eq!(evaluate(&once), once, "second pass must be stable");
+}
+
+#[test]
+fn test_prose_comment_is_left_untouched() {
+    let start = indoc! {r#"
+        [project]
+        name = "foo"
+        # this is just a note
+        version = "1.0"
+    "#};
+    let result = evaluate(start);
+    assert!(
+        result.contains("# this is just a note"),
+        "prose comment must survive:\n{result}"
+    );
+}

--- a/pyproject-fmt/rust/src/tests/disabled_tests.rs
+++ b/pyproject-fmt/rust/src/tests/disabled_tests.rs
@@ -39,7 +39,7 @@ fn test_disabled_keys_stay_anchored_to_their_entry() {
         url = "https://pypi.org/simple"
         authenticate = "never"
         # TODO: once ticket XYZ is complete
-        #  to prioritise those over pypi
+        #  to prioritize those over pypi
         # default = true
 
         # These definitions will be used as priority over the ones specified in uv.toml
@@ -56,7 +56,7 @@ fn test_disabled_keys_stay_anchored_to_their_entry() {
     url = "https://pypi.org/simple"
     authenticate = "never"
     # TODO: once ticket XYZ is complete
-    #  to prioritise those over pypi
+    #  to prioritize those over pypi
     # default = true
 
     # These definitions will be used as priority over the ones specified in uv.toml

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -1033,7 +1033,7 @@ fn test_issue_376_collapse_with_comments_stays_valid() {
     [[tool.uv.index]]
     name = "company-master"
     url = "https://dl.cloudsmith.io/x"
-    # ignore-error-codes = [400, 401, 403]
+    # ignore-error-codes = [ 400, 401, 403 ]
     authenticate = "always"
     "#);
 }

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod commitizen_tests;
 mod coverage_tests;
 mod dependency_groups_tests;
 mod deptry_tests;
+mod disabled_tests;
 mod djlint_tests;
 mod docformatter_tests;
 mod global_tests;


### PR DESCRIPTION
Commenting out a key inside a table left the comment as free text, so the formatter's reordering moved it to whichever entry it ended up beside. A disabled `# default = true` at the end of one `[[tool.uv.index]]` came out as a leading comment of the next index, and the surrounding blank lines shifted with it. Issue #376 reports this.

A comment whose body is a single valid key-value now counts as a temporarily disabled field. 🔧 The formatter enables it for the pass so it orders and lays out with its own table, then comments it back out before writing, which also normalizes the line the way the enabled key would look. The tag that has to outlive reordering and re-parsing rides inside the key's trailing comment, and trailing comments already follow their key-value, so the position needs no separate tracking. An array-of-tables entry holding a disabled key stays expanded, since an inline table cannot carry the comment and remain valid TOML.

Prose, multi-line comment blocks, and commented-out headers such as `# [tool.x]` keep their current handling and stay put. ✨ The check is structural, so a prose comment that parses as a key-value gets reflowed as well; the formatting docs spell out that trade-off. A file without disabled keys formats the same as before.