### PR TITLE
uv direct tool install support

### DIFF
--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -1,0 +1,1 @@
+.. comment:: empty readme file so you can uv tool install directly from a github url (normally it is generated at build time)

--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -1,1 +1,1 @@
-.. comment:: empty readme file so you can uv tool install directly from a github url (normally it is generated at build time)
+.. empty readme file so you can uv tool install directly from a github url (normally it is generated at build time)

--- a/tox-toml-fmt/README.rst
+++ b/tox-toml-fmt/README.rst
@@ -1,0 +1,1 @@
+.. comment:: empty readme file so you can uv tool install directly from a github url (normally it is generated at build time)

--- a/tox-toml-fmt/README.rst
+++ b/tox-toml-fmt/README.rst
@@ -1,1 +1,1 @@
-.. comment:: empty readme file so you can uv tool install directly from a github url (normally it is generated at build time)
+.. empty readme file so you can uv tool install directly from a github url (normally it is generated at build time)


### PR DESCRIPTION
I wanted to test the latest updates and ran into the following issue:

```
$ uv tool install git+https://github.com/tox-dev/toml-fmt#subdirectory=pyproject-fmt

error: The build backend returned an error
  Caused by: Call to `build_backend.build_wheel` failed (exit status: 1)

[stdout]
Rust not found, installing into a temporary directory
cargo 1.93.1 (083ac5135 2025-12-15)
Running `maturin pep517 build-wheel -i ~/.cache/uv/builds-v0/.tmpiufjXk/bin/python --compatibility off`

[stderr]
Python reports SOABI: cpython-313-x86_64-linux-gnu
Computed rustc target triple: x86_64-unknown-linux-gnu
Installation directory: ~/.cache/puccinialin
Downloading rustup-init from https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
Downloading rustup-init: 100%|██████████| 20.8M/20.8M [00:00<00:00, 29.4MB/s]
Installing rust to ~/.cache/puccinialin/rustup
warn: It looks like you have an existing rustup settings file at:
warn: ~/.cache/puccinialin/rustup/settings.toml
warn: Rustup will install the default toolchain as specified in the settings file,
warn: instead of the one inferred from the default host triple.
info: profile set to minimal
info: setting default host triple to x86_64-unknown-linux-gnu
info: syncing channel updates for stable-x86_64-unknown-linux-gnu
info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
info: downloading 3 components
info: default toolchain set to stable-x86_64-unknown-linux-gnu
Checking if cargo is installed
info: syncing channel updates for 1.93-x86_64-unknown-linux-gnu
info: latest update on 2026-02-12 for version 1.93.1 (01f6ddf75 2026-02-11)
info: downloading 3 components
    Updating crates.io index
    Updating git repository `https://github.com/tombi-toml/tombi`
 Downloading crates ...
  Downloaded atomic-waker v1.1.2
 <snip>
  Downloaded ring v0.17.14
  Downloaded windows-sys v0.61.2
  Downloaded linux-raw-sys v0.12.1
💥 maturin failed
  Caused by: Failed to read readme specified in pyproject.toml, which should be at ~/.cache/uv/git-v0/checkouts/54cd5372d2591cd9/bff4127/pyproject-fmt/README.rst
  Caused by: failed to open file `~/.cache/uv/git-v0/checkouts/54cd5372d2591cd9/bff4127/pyproject-fmt/README.rst`: No such file or directory (os error 2)
Error: command ['maturin', 'pep517', 'build-wheel', '-i', '~/.cache/uv/builds-v0/.tmpiufjXk/bin/python', '--compatibility', 'off'] returned non-zero exit status 1

hint: This usually indicates a problem with the package or the build environment.
```

It seems like these files are usually generated during the build, however this doesn't appear to occur when installing directly via uv.
There may be a better solution to generate them during the maturin build but this did work to allow me to install and test the updated package.