### PR TITLE
✨ feat(common): share disabled-key handling across formatters

### DIFF
--- a/common/src/disabled.rs
+++ b/common/src/disabled.rs
@@ -7,13 +7,23 @@
 //! This keeps a disabled key anchored to its entry instead of drifting to the next
 //! table, and formats the line the same way the enabled key would be formatted.
 
-use tombi_syntax::SyntaxKind::{ARRAY_OF_TABLE, COMMENT, KEY_VALUE, TABLE};
+use tombi_syntax::SyntaxKind::{ARRAY_OF_TABLE, COMMENT, KEY_VALUE, KEY_VALUE_GROUP, TABLE};
+use tombi_syntax::SyntaxNode;
 
 /// Marker appended to a disabled key's trailing comment so the pass can find the key
 /// again after it has travelled through reordering and re-parsing. Inline trailing
 /// comments stay attached to their key-value, so the marker rides along for free.
 /// It never reaches the formatted output: [`restore_disabled_keys`] strips it.
 pub const MARKER: &str = "__toml_fmt_disabled__";
+
+/// Count the top-level key-values, ignoring any nested inside inline tables or arrays of
+/// tables (a `set_env = { A = "1" }` body is one key, not two).
+fn top_level_key_values(root: &SyntaxNode) -> usize {
+    root.children()
+        .filter(|child| child.kind() == KEY_VALUE_GROUP)
+        .map(|group| group.children().filter(|kv| kv.kind() == KEY_VALUE).count())
+        .sum()
+}
 
 /// Rewrite a comment body into its enabled key-value form, or `None` when the body is
 /// not a single key-value (prose, a commented table header, multiple keys, ...).
@@ -23,9 +33,8 @@ fn enabled_form(body: &str) -> Option<String> {
         return None;
     }
     let root = parsed.syntax_node();
-    let key_values = root.descendants().filter(|n| n.kind() == KEY_VALUE).count();
-    let has_table = root.descendants().any(|n| matches!(n.kind(), TABLE | ARRAY_OF_TABLE));
-    if key_values != 1 || has_table {
+    let has_table = root.children().any(|n| matches!(n.kind(), TABLE | ARRAY_OF_TABLE));
+    if top_level_key_values(&root) != 1 || has_table {
         return None;
     }
     let has_trailing_comment = root.descendants_with_tokens().any(|t| t.kind() == COMMENT);
@@ -36,12 +45,20 @@ fn enabled_form(body: &str) -> Option<String> {
     })
 }
 
+/// Bracket a formatter pass with disabled-key handling: enable disabled keys in `content`,
+/// run `format`, then restore them. This is the single entry point every formatter uses, so
+/// the two passes always wrap the whole pipeline as a pair.
+pub fn with_disabled_keys(content: &str, column_width: usize, format: impl FnOnce(&str) -> String) -> String {
+    let enabled = enable_disabled_keys(content, column_width);
+    restore_disabled_keys(&format(&enabled))
+}
+
 /// Pre-pass: turn each disabled key into a real key-value tagged with [`MARKER`].
 ///
 /// Keys that would not fit on a single line within `column_width` are left as plain
 /// comments, since enabling them could reflow the value across several lines and break
 /// the single-line restore.
-pub fn enable_disabled_keys(source: &str, column_width: usize) -> String {
+pub(crate) fn enable_disabled_keys(source: &str, column_width: usize) -> String {
     let mut out: Vec<String> = Vec::with_capacity(source.lines().count());
     for line in source.lines() {
         let trimmed = line.trim_start();
@@ -62,7 +79,7 @@ pub fn enable_disabled_keys(source: &str, column_width: usize) -> String {
 
 /// Post-pass: turn every marker-tagged key-value back into a comment, dropping the
 /// marker. The key kept its surrounding comment (if any), which is restored verbatim.
-pub fn restore_disabled_keys(formatted: &str) -> String {
+pub(crate) fn restore_disabled_keys(formatted: &str) -> String {
     let mut out: Vec<String> = Vec::with_capacity(formatted.lines().count());
     for line in formatted.lines() {
         if let Some(idx) = line.find(MARKER) {

--- a/common/src/tests/disabled_tests.rs
+++ b/common/src/tests/disabled_tests.rs
@@ -1,9 +1,30 @@
-use crate::disabled::{MARKER, enable_disabled_keys, restore_disabled_keys};
+use crate::disabled::{MARKER, enable_disabled_keys, restore_disabled_keys, with_disabled_keys};
+
+#[test]
+fn test_with_disabled_keys_brackets_the_format_pass() {
+    let out = with_disabled_keys("# x = 1\n", 120, |enabled| {
+        assert!(enabled.contains(MARKER), "the format pass sees the enabled key");
+        enabled.to_string()
+    });
+    assert_eq!(out, "# x = 1\n");
+}
 
 #[test]
 fn test_enable_promotes_valid_key() {
     let out = enable_disabled_keys("# default = true\n", 120);
     assert_eq!(out, format!("default = true  # {MARKER}\n"));
+}
+
+#[test]
+fn test_enable_promotes_inline_table_key() {
+    let out = enable_disabled_keys("# set_env = {A = \"1\"}\n", 120);
+    assert_eq!(out, format!("set_env = {{A = \"1\"}}  # {MARKER}\n"));
+}
+
+#[test]
+fn test_enable_leaves_two_keys_on_one_line() {
+    let source = "# a = 1 b = 2\n";
+    assert_eq!(enable_disabled_keys(source, 120), source);
 }
 
 #[test]

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -157,8 +157,11 @@ fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
 /// Format toml file
 #[must_use]
 pub fn format_toml(content: &str, opt: &Settings) -> String {
-    let content = common::disabled::enable_disabled_keys(content, opt.column_width);
-    let root_ast = parse(&content);
+    common::disabled::with_disabled_keys(content, opt.column_width, |content| format_core(content, opt))
+}
+
+fn format_core(content: &str, opt: &Settings) -> String {
+    let root_ast = parse(content);
     common::string::normalize_key_quotes(&root_ast);
     let mut tables = Tables::from_ast(&root_ast);
     let table_config = TableFormatConfig::from_settings(opt);
@@ -255,8 +258,7 @@ pub fn format_toml(content: &str, opt: &Settings) -> String {
     } else {
         formatted
     };
-    let result = common::util::limit_blank_lines(&result, 2);
-    common::disabled::restore_disabled_keys(&result)
+    common::util::limit_blank_lines(&result, 2)
 }
 
 fn remove_blank_lines_between_same_group_tables(content: &str, multi_level_prefixes: &[&str]) -> String {

--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -198,6 +198,33 @@ Inline comments within arrays are aligned independently per array, based on that
       "pytest-mock",  # mocking
     ]
 
+Disabled Keys
+~~~~~~~~~~~~~
+
+A commented-out line whose body is itself a single valid key-value (for example ``# set_env = { A = "1" }``) is treated
+as a temporarily *disabled* field rather than free text. The formatter enables it for the duration of the pass, so it is
+laid out and ordered together with the table it belongs to, then comments it out again on the way out. This keeps a
+disabled key anchored to its entry instead of drifting to the next table, and formats the line the same way the enabled
+key would be:
+
+.. code-block:: toml
+
+    # Before
+    [env_run_base]
+    description = "run the tests"
+    # set_env = {A = "1"}
+
+    # After
+    [env_run_base]
+    description = "run the tests"
+    # set_env = { A = "1" }
+
+Comments that are not a single valid key-value (prose, multi-line blocks, commented-out table headers like
+``# [env.docs]``) are left untouched and follow the usual comment-preservation rules above. The heuristic is purely
+structural, so a prose comment that *happens* to be valid TOML is reflowed too; if that matters, phrase the comment so it
+does not parse as a key-value. Keys that would not fit on a single line within ``column_width`` are left as plain
+comments.
+
 Group Markers
 ~~~~~~~~~~~~~
 

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -117,6 +117,10 @@ fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
 
 #[must_use]
 pub fn format_toml(content: &str, opt: &Settings) -> String {
+    common::disabled::with_disabled_keys(content, opt.column_width, |content| format_core(content, opt))
+}
+
+fn format_core(content: &str, opt: &Settings) -> String {
     let root_ast = parse(content);
     common::string::normalize_key_quotes(&root_ast);
     let mut tables = Tables::from_ast(&root_ast);

--- a/tox-toml-fmt/rust/src/tests/disabled_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/disabled_tests.rs
@@ -1,0 +1,63 @@
+use common::disabled::MARKER;
+use indoc::indoc;
+
+use super::assert_valid_toml;
+use crate::{format_toml, Settings};
+
+fn settings() -> Settings {
+    Settings {
+        column_width: 80,
+        indent: 2,
+        table_format: String::from("short"),
+        sub_table_spacing: String::new(),
+        separate_root_table: String::from("\n"),
+        expand_tables: vec![],
+        collapse_tables: vec![],
+        skip_wrap_for_keys: vec![],
+        pin_envs: vec![],
+    }
+}
+
+fn evaluate(start: &str) -> String {
+    let result = format_toml(start, &settings());
+    assert_valid_toml(&result);
+    assert!(
+        !result.contains(MARKER),
+        "internal marker leaked into output:\n{result}"
+    );
+    result
+}
+
+#[test]
+fn test_disabled_key_stays_with_its_env_table() {
+    let start = indoc! {r#"
+        [env_run_base]
+        description = "run the tests"
+        # set_env = {A = "1"}
+
+        [env.type]
+        description = "type check"
+    "#};
+    insta::assert_snapshot!(evaluate(start), @r#"
+    [env_run_base]
+    description = "run the tests"
+    # set_env = { A = "1" }
+
+    [env.type]
+    description = "type check"
+    "#);
+}
+
+#[test]
+fn test_prose_comment_is_left_untouched() {
+    let start = indoc! {r#"
+        [env_run_base]
+        # run under every interpreter
+        description = "run the tests"
+    "#};
+    let result = evaluate(start);
+    assert!(
+        result.contains("# run under every interpreter"),
+        "prose comment must survive:\n{result}"
+    );
+}

--- a/tox-toml-fmt/rust/src/tests/mod.rs
+++ b/tox-toml-fmt/rust/src/tests/mod.rs
@@ -1,5 +1,6 @@
 pub use common::test_util::{assert_valid_toml, format_syntax, parse};
 
+mod disabled_tests;
 mod doc_examples_tests;
 mod global_tests;
 mod main_tests;


### PR DESCRIPTION
The disabled-key handling from #381 lives in `common`, but only `pyproject-fmt` called the passes. A `tox.toml` file therefore still saw a commented-out key drift to the next table when the formatter reordered things, so the feature was only half delivered.

This exposes one `common::disabled::with_disabled_keys` helper that brackets a format pass with the enable and restore steps, and routes both formatters through it. ♻️ Each `format_toml` now wraps a private `format_core`, so the two passes always stay a pair and neither crate repeats the wiring; a future formatter gets the behavior with a single call.

While adding the `tox.toml` case it surfaced a defect in how `common` decides what counts as a disabled key. 🐛 The check counted every descendant key-value, so an inline-table value such as `set_env = { A = "1" }` looked like two keys (the outer one plus the inner `A`) and was skipped. It now counts only top-level key-values, so inline-table and array values are recognized; `pyproject-fmt` shares the fix.

A commented-out `# set_env = { A = "1" }` now stays with its `[env_run_base]` table and is formatted like the live key would be, while prose comments keep their existing handling. Files without disabled keys format the same as before.