### PR TITLE
🐛 fix(common): keep empty table when sub-table stays expanded

### DIFF
--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -45,6 +45,13 @@ fn ensure_table_exists(tables: &mut Tables, name: &str) {
     }
 }
 
+fn has_live_descendant_table(tables: &Tables, full_name: &str) -> bool {
+    let prefix = format!("{full_name}.");
+    tables.header_to_pos.iter().any(|(name, positions)| {
+        name.starts_with(&prefix) && positions.iter().any(|&pos| !tables.table_set[pos].borrow().is_empty())
+    })
+}
+
 fn filter_entries(table: &mut RefMut<Vec<SyntaxElement>>, entries_to_remove: &HashSet<usize>) {
     let mut new_elements = Vec::new();
     let mut entry_index = 0;
@@ -657,6 +664,9 @@ pub fn collapse_sub_tables(tables: &mut Tables, name: &str) {
 
         let is_empty_table = !sub.iter().any(|child| child.kind() == KEY_VALUE);
         if is_empty_table {
+            if has_live_descendant_table(tables, key) {
+                continue;
+            }
             if main.last().is_some_and(|e| e.kind() != LINE_BREAK) {
                 main.push(make_newline());
             }
@@ -789,6 +799,14 @@ pub fn collapse_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str
 
     if is_array_table {
         collapse_array_of_tables(tables, parent_name, sub_name, &sub_positions, column_width);
+        return;
+    }
+
+    let sub_is_empty = !tables.table_set[*sub_positions.first().unwrap()]
+        .borrow()
+        .iter()
+        .any(|child| child.kind() == KEY_VALUE);
+    if sub_is_empty && has_live_descendant_table(tables, &full_name) {
         return;
     }
 

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -2537,3 +2537,87 @@ fn test_reorder_table_keys_group_markers_respect_order() {
     delta = 3
     "#);
 }
+
+#[test]
+fn test_collapse_sub_table_keeps_empty_parent_with_wide_array_of_tables() {
+    let toml = indoc! {r#"
+        [tool.demo.labels]
+
+        [[tool.demo.labels.file-rules]]
+        any-glob-to-any-file = ["src/managers/apt*", "src/managers/dpkg*", "src/managers/opkg*", "tests/*apt*", "tests/*dpkg*", "tests/*opkg*"]
+    "#};
+    let root_ast = parse(toml);
+    let mut tables = Tables::from_ast(&root_ast);
+
+    apply_table_formatting(&mut tables, |_| true, &["tool.demo"], 120);
+
+    assert!(
+        tables.get("tool.demo").is_none(),
+        "empty parent must not be collapsed to an inline table"
+    );
+    let file_rules = tables.get("tool.demo.labels.file-rules").unwrap();
+    assert!(
+        !file_rules[0].borrow().is_empty(),
+        "wide array of tables must stay expanded"
+    );
+
+    tables.reorder(
+        &root_ast,
+        &["tool.demo.labels", "tool.demo.labels.file-rules"],
+        &[],
+        "\n",
+        "",
+    );
+    let result = format_toml(&root_ast, 120);
+    crate::test_util::assert_valid_toml(&result);
+    insta::assert_snapshot!(result, @r#"
+    [tool.demo.labels]
+    [[tool.demo.labels.file-rules]]
+    any-glob-to-any-file = [
+      "src/managers/apt*",
+      "src/managers/dpkg*",
+      "src/managers/opkg*",
+      "tests/*apt*",
+      "tests/*dpkg*",
+      "tests/*opkg*"
+    ]
+    "#);
+}
+
+#[test]
+fn test_collapse_sub_tables_keeps_empty_table_with_array_of_tables_descendant() {
+    let toml = indoc! {r#"
+        [dependency-groups.docs]
+
+        [[dependency-groups.docs.entries]]
+        name = "sphinx"
+    "#};
+    let root_ast = parse(toml);
+    let mut tables = Tables::from_ast(&root_ast);
+
+    collapse_sub_tables(&mut tables, "dependency-groups");
+
+    let main = tables.get("dependency-groups").unwrap();
+    let main_text = main[0].borrow().iter().map(|e| e.to_string()).collect::<String>();
+    assert!(
+        !main_text.contains("docs ="),
+        "empty table must not be collapsed to an inline table"
+    );
+    assert!(tables.header_to_pos.contains_key("dependency-groups.docs.entries"));
+
+    tables.reorder(
+        &root_ast,
+        &["dependency-groups.docs", "dependency-groups.docs.entries"],
+        &[],
+        "\n",
+        "",
+    );
+    let result = format_toml(&root_ast, 120);
+    crate::test_util::assert_valid_toml(&result);
+    insta::assert_snapshot!(result, @r#"
+    [dependency-groups]
+    [dependency-groups.docs]
+    [[dependency-groups.docs.entries]]
+    name = "sphinx"
+    "#);
+}

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -1037,3 +1037,47 @@ fn test_issue_376_collapse_with_comments_stays_valid() {
     authenticate = "always"
     "#);
 }
+
+#[test]
+fn test_wide_array_of_tables_under_implicit_parent() {
+    let start = indoc! {r#"
+        [[tool.demo.labels.file-rules]]
+        any-glob-to-any-file = ["src/managers/apt*", "src/managers/dpkg*", "src/managers/opkg*", "tests/*apt*", "tests/*dpkg*", "tests/*opkg*"]
+    "#};
+    let result = format_toml(start, &default_settings());
+    assert_valid_toml(&result);
+    insta::assert_snapshot!(result, @r#"
+    [[tool.demo.labels.file-rules]]
+    any-glob-to-any-file = [
+      "src/managers/apt*",
+      "src/managers/dpkg*",
+      "src/managers/opkg*",
+      "tests/*apt*",
+      "tests/*dpkg*",
+      "tests/*opkg*"
+    ]
+    "#);
+}
+
+#[test]
+fn test_wide_array_of_tables_under_explicit_empty_parent() {
+    let start = indoc! {r#"
+        [tool.demo.labels]
+        [[tool.demo.labels.file-rules]]
+        any-glob-to-any-file = ["src/managers/apt*", "src/managers/dpkg*", "src/managers/opkg*", "tests/*apt*", "tests/*dpkg*", "tests/*opkg*"]
+    "#};
+    let result = format_toml(start, &default_settings());
+    assert_valid_toml(&result);
+    insta::assert_snapshot!(result, @r#"
+    [tool.demo.labels]
+    [[tool.demo.labels.file-rules]]
+    any-glob-to-any-file = [
+      "src/managers/apt*",
+      "src/managers/dpkg*",
+      "src/managers/opkg*",
+      "tests/*apt*",
+      "tests/*dpkg*",
+      "tests/*opkg*"
+    ]
+    "#);
+}


### PR DESCRIPTION
`pyproject-fmt` emitted invalid TOML for an array-of-tables under an empty parent. Given `[[tool.demo.labels.file-rules]]` whose entries are wide enough to stay in expanded block form, the formatter wrote `labels = {}` to declare the parent and then re-opened that same parent with `[[tool.demo.labels.file-rules]]`. 🐛 The result failed to parse, since a dotted/array-of-tables header cannot extend a value already set to an inline table. This regressed in `2.16.0`.

The collapse logic turned any empty table into an inline `key = {}`. That is correct for a genuinely empty leaf such as `tool.uv.workspace`, but wrong when the table still owns a descendant table or array-of-tables that remained expanded as its own header. The fix checks for a live (non-cleared) descendant before collapsing and preserves the empty header in that case, so the descendant has a valid table to attach to.

Leaf empty tables keep collapsing to `{}` as before, so only the invalid-output case changes. The reported implicit-parent input also stays valid.

Fixes #384