### PR TITLE
🐛 fix(common): reorder and re-comment disabled keys safely

### DIFF
--- a/common/src/disabled.rs
+++ b/common/src/disabled.rs
@@ -1,23 +1,23 @@
-//! Transparent handling of commented-out (disabled) keys.
+//! Commented-out (disabled) keys, kept in step with the table they belong to.
 //!
-//! A standalone comment whose body is itself a single valid key-value (for example
-//! `# default = true`) is treated as a temporarily disabled field rather than free
-//! text. It is enabled for the duration of the formatting pass so it is laid out and
-//! ordered together with the table it belongs to, then disabled again on the way out.
-//! This keeps a disabled key anchored to its entry instead of drifting to the next
-//! table, and formats the line the same way the enabled key would be formatted.
+//! A comment whose body is one valid key-value (`# default = true`) is a disabled field, not
+//! prose. The pass uncomments it so the formatter sorts it with its table, then comments it back;
+//! otherwise it would drift to the next table and never get ordered.
+//!
+//! A value can span several comment lines. `# x = [` alone is invalid, yet `# x = [` / `#   1,` /
+//! `# ]` parses once the run is uncommented together, so enabling works on whole runs. That also
+//! keeps the round-trip stable when the formatter wraps a value across lines.
 
-use tombi_syntax::SyntaxKind::{ARRAY, ARRAY_OF_TABLE, COMMENT, INLINE_TABLE, KEY_VALUE, KEY_VALUE_GROUP, TABLE};
+use tombi_syntax::SyntaxKind::{
+    ARRAY_OF_TABLE, COMMENT, KEY_VALUE, KEY_VALUE_GROUP, KEYS, LINE_BREAK, TABLE, WHITESPACE,
+};
 use tombi_syntax::SyntaxNode;
 
-/// Marker appended to a disabled key's trailing comment so the pass can find the key
-/// again after it has travelled through reordering and re-parsing. Inline trailing
-/// comments stay attached to their key-value, so the marker rides along for free.
-/// It never reaches the formatted output: [`restore_disabled_keys`] strips it.
+/// Tags a disabled key's trailing comment so the pass can find it again after the formatter has
+/// reordered and re-parsed everything. [`restore_disabled_keys`] strips it.
 pub const MARKER: &str = "__toml_fmt_disabled__";
 
-/// Count the top-level key-values, ignoring any nested inside inline tables or arrays of
-/// tables (a `set_env = { A = "1" }` body is one key, not two).
+/// Top-level key-values only; a nested `set_env = { A = "1" }` is one key, not two.
 fn top_level_key_values(root: &SyntaxNode) -> usize {
     root.children()
         .filter(|child| child.kind() == KEY_VALUE_GROUP)
@@ -25,18 +25,9 @@ fn top_level_key_values(root: &SyntaxNode) -> usize {
         .sum()
 }
 
-/// Whether the value holds an array containing an inline table. The formatter always
-/// expands an array of inline tables onto several lines, even when it fits the column
-/// width, so enabling such a key would scatter the [`MARKER`] across lines the line-based
-/// restore cannot re-comment as a whole. Those keys stay verbatim comments instead.
-fn has_array_of_inline_tables(root: &SyntaxNode) -> bool {
-    root.descendants()
-        .filter(|n| n.kind() == ARRAY)
-        .any(|array| array.descendants().any(|n| n.kind() == INLINE_TABLE))
-}
-
-/// Rewrite a comment body into its enabled key-value form, or `None` when the body is
-/// not a single key-value (prose, a commented table header, multiple keys, ...).
+/// Uncomment `body` (one line or several) into a single marker-tagged key-value, or `None` when it
+/// is not exactly one key-value. The marker extends a comment already on the last line so the
+/// value never ends up with two trailing comments.
 fn enabled_form(body: &str) -> Option<String> {
     let parsed = tombi_parser::parse(body);
     if !parsed.errors.is_empty() {
@@ -44,65 +35,142 @@ fn enabled_form(body: &str) -> Option<String> {
     }
     let root = parsed.syntax_node();
     let has_table = root.children().any(|n| matches!(n.kind(), TABLE | ARRAY_OF_TABLE));
-    if top_level_key_values(&root) != 1 || has_table || has_array_of_inline_tables(&root) {
+    if top_level_key_values(&root) != 1 || has_table {
         return None;
     }
-    let has_trailing_comment = root.descendants_with_tokens().any(|t| t.kind() == COMMENT);
-    Some(if has_trailing_comment {
+    let ends_with_comment = root
+        .descendants_with_tokens()
+        .filter(|t| !matches!(t.kind(), WHITESPACE | LINE_BREAK))
+        .last()
+        .is_some_and(|t| t.kind() == COMMENT);
+    Some(if ends_with_comment {
         format!("{body} {MARKER}")
     } else {
         format!("{body}  # {MARKER}")
     })
 }
 
-/// Bracket a formatter pass with disabled-key handling: enable disabled keys in `content`,
-/// run `format`, then restore them. This is the single entry point every formatter uses, so
-/// the two passes always wrap the whole pipeline as a pair.
-pub fn with_disabled_keys(content: &str, column_width: usize, format: impl FnOnce(&str) -> String) -> String {
-    let enabled = enable_disabled_keys(content, column_width);
+/// The one entry point formatters call, so enable and restore always bracket the pass as a pair.
+pub fn with_disabled_keys(content: &str, format: impl FnOnce(&str) -> String) -> String {
+    let enabled = enable_disabled_keys(content);
     restore_disabled_keys(&format(&enabled))
 }
 
-/// Pre-pass: turn each disabled key into a real key-value tagged with [`MARKER`].
-///
-/// Keys that would not fit on a single line within `column_width` are left as plain
-/// comments, since enabling them could reflow the value across several lines and break
-/// the single-line restore.
-pub(crate) fn enable_disabled_keys(source: &str, column_width: usize) -> String {
-    let mut out: Vec<String> = Vec::with_capacity(source.lines().count());
-    for line in source.lines() {
-        let trimmed = line.trim_start();
-        if let Some(rest) = trimmed.strip_prefix('#') {
-            let indent = &line[..line.len() - trimmed.len()];
-            let body = rest.trim_start();
-            if indent.len() + body.len() <= column_width
-                && let Some(enabled) = enabled_form(body)
-            {
+/// Indent before the `#` and the body after it, dropping one space to mirror how
+/// [`comment_disabled_line`] writes a comment back. `None` for a non-comment line.
+fn split_comment(line: &str) -> Option<(&str, &str)> {
+    let trimmed = line.trim_start();
+    let rest = trimmed.strip_prefix('#')?;
+    let indent = &line[..line.len() - trimmed.len()];
+    Some((indent, rest.strip_prefix(' ').unwrap_or(rest)))
+}
+
+fn is_table_header(body: &str) -> bool {
+    tombi_parser::parse(body)
+        .syntax_node()
+        .children()
+        .any(|n| matches!(n.kind(), TABLE | ARRAY_OF_TABLE))
+}
+
+/// Shortest run from `start` that uncomments to one key-value, with its last line index and the
+/// tagged text. A nested table header ends the run, since the keys under it are a separate value.
+fn enable_block(lines: &[&str], start: usize, run_end: usize) -> Option<(usize, String)> {
+    let mut bodies: Vec<&str> = Vec::new();
+    for (end, line) in lines.iter().enumerate().take(run_end).skip(start) {
+        let (_, body) = split_comment(line)?;
+        if end > start && is_table_header(body) {
+            break;
+        }
+        bodies.push(body);
+        if let Some(enabled) = enabled_form(&bodies.join("\n")) {
+            return Some((end, enabled));
+        }
+    }
+    None
+}
+
+/// Uncomment every disabled key-value, tagging each with [`MARKER`]; prose and incomplete fragments
+/// stay commented. A commented table header ends enabling for the rest of its run, since the keys
+/// under it would otherwise leave the table they belong to.
+pub(crate) fn enable_disabled_keys(source: &str) -> String {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+    let mut i = 0;
+    while i < lines.len() {
+        let Some((indent, body)) = split_comment(lines[i]) else {
+            out.push(lines[i].to_string());
+            i += 1;
+            continue;
+        };
+        if is_table_header(body) {
+            out.push(lines[i].to_string());
+            i += 1;
+            while i < lines.len() && split_comment(lines[i]).is_some() {
+                out.push(lines[i].to_string());
+                i += 1;
+            }
+            continue;
+        }
+        let run_end = (i..lines.len())
+            .find(|&k| split_comment(lines[k]).is_none())
+            .unwrap_or(lines.len());
+        match enable_block(&lines, i, run_end) {
+            Some((end, enabled)) => {
                 out.push(format!("{indent}{enabled}"));
-                continue;
+                i = end + 1;
+            }
+            None => {
+                out.push(lines[i].to_string());
+                i += 1;
             }
         }
-        out.push(line.to_string());
     }
     join_like(source, out)
 }
 
-/// Post-pass: turn every marker-tagged key-value back into a comment, dropping the
-/// marker. The key kept its surrounding comment (if any), which is restored verbatim.
+/// Comment every marker-tagged key-value back, dropping the marker. A wrapped value carries the
+/// marker on its last line only, so the whole span gets commented. The span starts at the key, not
+/// the node: the node also owns the leading comments and blank lines before it, which stay put.
 pub(crate) fn restore_disabled_keys(formatted: &str) -> String {
-    let mut out: Vec<String> = Vec::with_capacity(formatted.lines().count());
-    for line in formatted.lines() {
-        if let Some(idx) = line.find(MARKER) {
-            let before = line[..idx].trim_end();
-            let body = before.strip_suffix('#').map_or(before, str::trim_end);
-            let indent_len = body.len() - body.trim_start().len();
-            let (indent, content) = body.split_at(indent_len);
-            out.push(format!("{indent}# {content}"));
-        } else {
-            out.push(line.to_string());
+    if !formatted.contains(MARKER) {
+        return formatted.to_string();
+    }
+    let lines: Vec<&str> = formatted.lines().collect();
+    let mut base_indent: Vec<Option<usize>> = vec![None; lines.len()];
+    let root = tombi_parser::parse(formatted).syntax_node();
+    for kv in root.descendants().filter(|n| n.kind() == KEY_VALUE) {
+        if !kv.to_string().contains(MARKER) {
+            continue;
+        }
+        let keys = kv.children().find(|c| c.kind() == KEYS).expect("a key-value has a key");
+        let start = keys.range().start.line as usize;
+        let end = kv.range().end.line as usize;
+        let first = lines[start];
+        let indent = first.len() - first.trim_start().len();
+        for slot in base_indent.iter_mut().take(end + 1).skip(start) {
+            *slot = Some(indent);
         }
     }
-    join_like(formatted, out)
+    let restored = lines
+        .iter()
+        .zip(base_indent)
+        .map(|(line, indent)| indent.map_or_else(|| (*line).to_string(), |indent| comment_disabled_line(line, indent)))
+        .collect();
+    join_like(formatted, restored)
+}
+
+/// Comment one line of a disabled key-value, stripping the marker if present. `base` is the key's
+/// own indent, so the `#` lands at its column and the value's deeper indentation survives after it.
+fn comment_disabled_line(line: &str, base: usize) -> String {
+    let cleaned = match line.find(MARKER) {
+        Some(idx) => {
+            let before = line[..idx].trim_end();
+            before.strip_suffix('#').map_or(before, str::trim_end)
+        }
+        None => line,
+    };
+    let cut = base.min(cleaned.len());
+    format!("{}# {}", &cleaned[..cut], &cleaned[cut..])
 }
 
 fn join_like(original: &str, lines: Vec<String>) -> String {

--- a/common/src/disabled.rs
+++ b/common/src/disabled.rs
@@ -7,7 +7,7 @@
 //! This keeps a disabled key anchored to its entry instead of drifting to the next
 //! table, and formats the line the same way the enabled key would be formatted.
 
-use tombi_syntax::SyntaxKind::{ARRAY_OF_TABLE, COMMENT, KEY_VALUE, KEY_VALUE_GROUP, TABLE};
+use tombi_syntax::SyntaxKind::{ARRAY, ARRAY_OF_TABLE, COMMENT, INLINE_TABLE, KEY_VALUE, KEY_VALUE_GROUP, TABLE};
 use tombi_syntax::SyntaxNode;
 
 /// Marker appended to a disabled key's trailing comment so the pass can find the key
@@ -25,6 +25,16 @@ fn top_level_key_values(root: &SyntaxNode) -> usize {
         .sum()
 }
 
+/// Whether the value holds an array containing an inline table. The formatter always
+/// expands an array of inline tables onto several lines, even when it fits the column
+/// width, so enabling such a key would scatter the [`MARKER`] across lines the line-based
+/// restore cannot re-comment as a whole. Those keys stay verbatim comments instead.
+fn has_array_of_inline_tables(root: &SyntaxNode) -> bool {
+    root.descendants()
+        .filter(|n| n.kind() == ARRAY)
+        .any(|array| array.descendants().any(|n| n.kind() == INLINE_TABLE))
+}
+
 /// Rewrite a comment body into its enabled key-value form, or `None` when the body is
 /// not a single key-value (prose, a commented table header, multiple keys, ...).
 fn enabled_form(body: &str) -> Option<String> {
@@ -34,7 +44,7 @@ fn enabled_form(body: &str) -> Option<String> {
     }
     let root = parsed.syntax_node();
     let has_table = root.children().any(|n| matches!(n.kind(), TABLE | ARRAY_OF_TABLE));
-    if top_level_key_values(&root) != 1 || has_table {
+    if top_level_key_values(&root) != 1 || has_table || has_array_of_inline_tables(&root) {
         return None;
     }
     let has_trailing_comment = root.descendants_with_tokens().any(|t| t.kind() == COMMENT);

--- a/common/src/tests/disabled_tests.rs
+++ b/common/src/tests/disabled_tests.rs
@@ -105,3 +105,27 @@ fn test_round_trip_is_identity_for_disabled_key() {
     let enabled = enable_disabled_keys(source, 120);
     assert_eq!(restore_disabled_keys(&enabled), source);
 }
+
+#[test]
+fn test_enable_leaves_array_of_inline_tables() {
+    let source =
+        "# metadata.hooks.fancy-pypi-readme.fragments = [ { path = \"README.rst\", start-after = \".. begin\" } ]\n";
+    assert_eq!(enable_disabled_keys(source, 120), source);
+}
+
+#[test]
+fn test_with_disabled_keys_preserves_array_of_inline_tables_comment() {
+    let source = concat!(
+        "[tool.hatch]\n",
+        "# metadata.hooks.fancy-pypi-readme.fragments = [ { path = \"README.rst\", start-after = \".. begin\" } ]\n",
+        "version.source = \"vcs\"\n",
+    );
+    let out = with_disabled_keys(source, 120, |enabled| {
+        assert!(
+            !enabled.contains(MARKER),
+            "the array-of-inline-tables comment is never enabled"
+        );
+        enabled.to_string()
+    });
+    assert_eq!(out, source);
+}

--- a/common/src/tests/disabled_tests.rs
+++ b/common/src/tests/disabled_tests.rs
@@ -2,7 +2,7 @@ use crate::disabled::{MARKER, enable_disabled_keys, restore_disabled_keys, with_
 
 #[test]
 fn test_with_disabled_keys_brackets_the_format_pass() {
-    let out = with_disabled_keys("# x = 1\n", 120, |enabled| {
+    let out = with_disabled_keys("# x = 1\n", |enabled| {
         assert!(enabled.contains(MARKER), "the format pass sees the enabled key");
         enabled.to_string()
     });
@@ -11,80 +11,124 @@ fn test_with_disabled_keys_brackets_the_format_pass() {
 
 #[test]
 fn test_enable_promotes_valid_key() {
-    let out = enable_disabled_keys("# default = true\n", 120);
-    assert_eq!(out, format!("default = true  # {MARKER}\n"));
+    assert_eq!(
+        enable_disabled_keys("# default = true\n"),
+        format!("default = true  # {MARKER}\n")
+    );
 }
 
 #[test]
 fn test_enable_promotes_inline_table_key() {
-    let out = enable_disabled_keys("# set_env = {A = \"1\"}\n", 120);
-    assert_eq!(out, format!("set_env = {{A = \"1\"}}  # {MARKER}\n"));
+    assert_eq!(
+        enable_disabled_keys("# set_env = {A = \"1\"}\n"),
+        format!("set_env = {{A = \"1\"}}  # {MARKER}\n")
+    );
 }
 
 #[test]
 fn test_enable_leaves_two_keys_on_one_line() {
     let source = "# a = 1 b = 2\n";
-    assert_eq!(enable_disabled_keys(source, 120), source);
+    assert_eq!(enable_disabled_keys(source), source);
 }
 
 #[test]
 fn test_enable_preserves_indentation() {
-    let out = enable_disabled_keys("  # x = 1\n", 120);
-    assert_eq!(out, format!("  x = 1  # {MARKER}\n"));
+    assert_eq!(enable_disabled_keys("  # x = 1\n"), format!("  x = 1  # {MARKER}\n"));
 }
 
 #[test]
 fn test_enable_appends_to_existing_trailing_comment() {
-    let out = enable_disabled_keys("# x = 1  # note\n", 120);
-    assert_eq!(out, format!("x = 1  # note {MARKER}\n"));
+    assert_eq!(
+        enable_disabled_keys("# x = 1  # note\n"),
+        format!("x = 1  # note {MARKER}\n")
+    );
 }
 
 #[test]
 fn test_enable_leaves_prose_comment() {
     let source = "# just a note, not a key\n";
-    assert_eq!(enable_disabled_keys(source, 120), source);
+    assert_eq!(enable_disabled_keys(source), source);
 }
 
 #[test]
 fn test_enable_leaves_commented_table_header() {
     let source = "# [tool.foo]\n";
-    assert_eq!(enable_disabled_keys(source, 120), source);
+    assert_eq!(enable_disabled_keys(source), source);
 }
 
 #[test]
 fn test_enable_leaves_non_comment_lines() {
     let source = "enabled = true\n";
-    assert_eq!(enable_disabled_keys(source, 120), source);
-}
-
-#[test]
-fn test_enable_skips_when_line_exceeds_width() {
-    let source = "# x = 1\n";
-    assert_eq!(enable_disabled_keys(source, 3), source);
+    assert_eq!(enable_disabled_keys(source), source);
 }
 
 #[test]
 fn test_enable_without_trailing_newline() {
-    let out = enable_disabled_keys("# x = 1", 120);
-    assert_eq!(out, format!("x = 1  # {MARKER}"));
+    assert_eq!(enable_disabled_keys("# x = 1"), format!("x = 1  # {MARKER}"));
+}
+
+#[test]
+fn test_enable_promotes_multiline_value() {
+    assert_eq!(
+        enable_disabled_keys("# x = [\n#   1,\n# ]\n"),
+        format!("x = [\n  1,\n]  # {MARKER}\n")
+    );
+}
+
+#[test]
+fn test_enable_leaves_incomplete_value() {
+    let source = "# x = [\n# still going\n";
+    assert_eq!(enable_disabled_keys(source), source);
+}
+
+#[test]
+fn test_enable_leaves_empty_comment() {
+    let source = "#\n";
+    assert_eq!(enable_disabled_keys(source), source);
+}
+
+#[test]
+fn test_enable_leaves_value_cut_off_by_table_header() {
+    let source = "# x = [\n# [tool.x]\n";
+    assert_eq!(enable_disabled_keys(source), source);
+}
+
+#[test]
+fn test_enable_promotes_key_next_to_prose() {
+    assert_eq!(
+        enable_disabled_keys("# a note\n# a = 1\n"),
+        format!("# a note\na = 1  # {MARKER}\n")
+    );
+}
+
+#[test]
+fn test_enable_stops_at_commented_table_header() {
+    let source = "# a = 1\n# [tool.foo]\n# b = 2\n";
+    assert_eq!(
+        enable_disabled_keys(source),
+        format!("a = 1  # {MARKER}\n# [tool.foo]\n# b = 2\n")
+    );
 }
 
 #[test]
 fn test_restore_marker_only_comment() {
-    let line = format!("default = true  # {MARKER}\n");
-    assert_eq!(restore_disabled_keys(&line), "# default = true\n");
+    assert_eq!(
+        restore_disabled_keys(&format!("default = true  # {MARKER}\n")),
+        "# default = true\n"
+    );
 }
 
 #[test]
 fn test_restore_keeps_original_trailing_comment() {
-    let line = format!("x = 1  # note {MARKER}\n");
-    assert_eq!(restore_disabled_keys(&line), "# x = 1  # note\n");
+    assert_eq!(
+        restore_disabled_keys(&format!("x = 1  # note {MARKER}\n")),
+        "# x = 1  # note\n"
+    );
 }
 
 #[test]
 fn test_restore_preserves_indentation() {
-    let line = format!("  x = 1  # {MARKER}\n");
-    assert_eq!(restore_disabled_keys(&line), "  # x = 1\n");
+    assert_eq!(restore_disabled_keys(&format!("  x = 1  # {MARKER}\n")), "  # x = 1\n");
 }
 
 #[test]
@@ -95,37 +139,123 @@ fn test_restore_leaves_unmarked_lines() {
 
 #[test]
 fn test_restore_without_trailing_newline() {
-    let line = format!("x = 1  # {MARKER}");
-    assert_eq!(restore_disabled_keys(&line), "# x = 1");
+    assert_eq!(restore_disabled_keys(&format!("x = 1  # {MARKER}")), "# x = 1");
+}
+
+#[test]
+fn test_restore_recomments_value_reflowed_across_lines() {
+    let formatted = concat!(
+        "x = [\n",
+        "  { path = \"README.rst\", start-after = \".. begin\" }\n",
+        "]  # __toml_fmt_disabled__\n",
+    );
+    let restored = restore_disabled_keys(formatted);
+    assert_eq!(
+        restored,
+        concat!(
+            "# x = [\n",
+            "#   { path = \"README.rst\", start-after = \".. begin\" }\n",
+            "# ]\n",
+        )
+    );
+    assert_eq!(
+        restore_disabled_keys(&restored),
+        restored,
+        "an already-disabled block is stable"
+    );
+}
+
+#[test]
+fn test_restore_recomments_value_reflowed_when_indented() {
+    let formatted = concat!("  x = [\n", "    1,\n", "    2\n", "  ]  # __toml_fmt_disabled__\n");
+    assert_eq!(
+        restore_disabled_keys(formatted),
+        concat!("  # x = [\n", "  #   1,\n", "  #   2\n", "  # ]\n")
+    );
+}
+
+#[test]
+fn test_restore_leaves_adjacent_real_key_and_comment_untouched() {
+    let formatted = concat!(
+        "version.source = \"vcs\"\n",
+        "# TODO: keep me\n",
+        "metadata.x = [\n",
+        "  { a = 1 }\n",
+        "]  # __toml_fmt_disabled__\n",
+    );
+    assert_eq!(
+        restore_disabled_keys(formatted),
+        concat!(
+            "version.source = \"vcs\"\n",
+            "# TODO: keep me\n",
+            "# metadata.x = [\n",
+            "#   { a = 1 }\n",
+            "# ]\n",
+        )
+    );
 }
 
 #[test]
 fn test_round_trip_is_identity_for_disabled_key() {
     let source = "# default = true\n";
-    let enabled = enable_disabled_keys(source, 120);
-    assert_eq!(restore_disabled_keys(&enabled), source);
+    assert_eq!(restore_disabled_keys(&enable_disabled_keys(source)), source);
 }
 
+// Guards against another #390: every value shape that fits on one comment line must round-trip
+// unchanged, not just the scalars the feature started with.
 #[test]
-fn test_enable_leaves_array_of_inline_tables() {
-    let source =
-        "# metadata.hooks.fancy-pypi-readme.fragments = [ { path = \"README.rst\", start-after = \".. begin\" } ]\n";
-    assert_eq!(enable_disabled_keys(source, 120), source);
+fn test_disabled_value_constructs_round_trip() {
+    let constructs = [
+        "# n = 1\n",
+        "# f = 1.5\n",
+        "# b = true\n",
+        "# s = \"hello\"\n",
+        "# s = 'C:\\path'\n",
+        "# items = [ \"a\", \"b\" ]\n",
+        "# matrix = [ [ 1, 2 ], [ 3, 4 ] ]\n",
+        "# opts = { deep = true, name = \"x\" }\n",
+        "# rows = [ { a = 1 }, { b = 2 } ]\n",
+        "# tool.x.y = [ { a = 1 } ]\n",
+    ];
+    for source in constructs {
+        let out = with_disabled_keys(source, |enabled| {
+            assert!(enabled.contains(MARKER), "{source:?} is enabled for the pass");
+            crate::test_util::format_toml_str(enabled, 120)
+        });
+        assert_eq!(out, source, "{source:?} restored to its original comment");
+    }
 }
 
+// The bug in #390: a value the formatter wraps must come back as a valid, stable comment block.
 #[test]
-fn test_with_disabled_keys_preserves_array_of_inline_tables_comment() {
-    let source = concat!(
-        "[tool.hatch]\n",
-        "# metadata.hooks.fancy-pypi-readme.fragments = [ { path = \"README.rst\", start-after = \".. begin\" } ]\n",
-        "version.source = \"vcs\"\n",
+fn test_with_disabled_keys_recomments_reflowed_array_block() {
+    let source = "# data = [ \"alpha\", \"beta\", \"gamma\", \"delta\", \"epsilon\", \"zeta\", \"eta\" ]\n";
+    let out = with_disabled_keys(source, |enabled| crate::test_util::format_toml_str(enabled, 30));
+    assert!(
+        out.contains('\n') && out.lines().count() > 1,
+        "the value reflowed across lines"
     );
-    let out = with_disabled_keys(source, 120, |enabled| {
-        assert!(
-            !enabled.contains(MARKER),
-            "the array-of-inline-tables comment is never enabled"
-        );
-        enabled.to_string()
-    });
-    assert_eq!(out, source);
+    assert!(
+        out.lines().all(|line| line.trim_start().starts_with('#')),
+        "every reflowed line stays commented, got:\n{out}"
+    );
+    assert!(!out.contains(MARKER), "the marker never reaches output");
+    let again = with_disabled_keys(&out, |enabled| crate::test_util::format_toml_str(enabled, 30));
+    assert_eq!(again, out, "the reflowed disabled block is stable");
+}
+
+#[test]
+fn test_commented_table_section_stays_commented() {
+    let source = concat!(
+        "[tool.real]\n",
+        "# [tool.disabled]\n",
+        "# key = [\n",
+        "#   1,\n",
+        "# ]\n"
+    );
+    let out = with_disabled_keys(source, |enabled| crate::test_util::format_toml_str(enabled, 120));
+    assert_eq!(
+        out, source,
+        "a commented table header and its keys stay verbatim comments"
+    );
 }

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -157,7 +157,7 @@ fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
 /// Format toml file
 #[must_use]
 pub fn format_toml(content: &str, opt: &Settings) -> String {
-    common::disabled::with_disabled_keys(content, opt.column_width, |content| format_core(content, opt))
+    common::disabled::with_disabled_keys(content, |content| format_core(content, opt))
 }
 
 fn format_core(content: &str, opt: &Settings) -> String {

--- a/pyproject-fmt/rust/src/tests/hatch_tests.rs
+++ b/pyproject-fmt/rust/src/tests/hatch_tests.rs
@@ -292,3 +292,27 @@ fn test_hatch_long_format_matrix_aot() {
     let result = evaluate_long(start);
     assert!(result.contains("[[tool.hatch.envs.default.matrix]]"));
 }
+
+#[test]
+fn test_disabled_keys_reorder_and_stay_valid_comments_issue_390() {
+    let start = indoc::indoc! {r#"
+        [tool.hatch]
+        # TODO: re-activate after https://github.com/pypa/hatch/issues/2252
+        # metadata.hooks.docstring-description = {}
+        # metadata.hooks.fancy-pypi-readme.fragments = [ { path = "README.rst", start-after = ".. begin" } ]
+        version.source = "vcs"
+        version.raw-options = { local_scheme = "no-local-version" }  # be able to publish dev version
+    "#};
+    let result = evaluate_full(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.hatch]
+    version.source = "vcs"
+    version.raw-options = { local_scheme = "no-local-version" }  # be able to publish dev version
+    # TODO: re-activate after https://github.com/pypa/hatch/issues/2252
+    # metadata.hooks.docstring-description = {}
+    # metadata.hooks.fancy-pypi-readme.fragments = [
+    #   { path = "README.rst", start-after = ".. begin" }
+    # ]
+    "#);
+    assert_eq!(evaluate_full(&result), result, "idempotent");
+}

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -117,7 +117,7 @@ fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
 
 #[must_use]
 pub fn format_toml(content: &str, opt: &Settings) -> String {
-    common::disabled::with_disabled_keys(content, opt.column_width, |content| format_core(content, opt))
+    common::disabled::with_disabled_keys(content, |content| format_core(content, opt))
 }
 
 fn format_core(content: &str, opt: &Settings) -> String {


### PR DESCRIPTION
A commented-out key whose value is an array of inline tables, such as `# x = [ { path = "..." } ]`, was rewritten into broken TOML. 🐛 The disabled-key feature enables a commented key so it sorts with its table and comments it back afterwards, but the formatter spreads an array of inline tables across several lines, and the old line-based restore re-commented only the line that carried its marker, leaving the rest live and invalid.

Both passes are rebuilt on one rule: a run of comment lines is uncommented only where the result parses as a complete key-value, even when no single line is valid on its own, since a multi-line array becomes valid once its opening bracket, items, and closing bracket are read together. The value is formatted normally and then every line of that key-value is commented again, with its span found from the key in the parse tree rather than from the marker alone, so neighbouring real keys and comments are never disturbed. Prose, incomplete fragments, and commented table headers together with the keys beneath them stay as comments.

Disabled keys still reorder with their table, and now come back as valid, stable comments for every value shape, whether the formatter keeps them on one line or wraps them across many. 🔁 Because the restore handles a wrapped value, the pass no longer needs a single-line width limit, so that parameter is dropped from `with_disabled_keys`.

Fixes #390.
