### PR TITLE
🐛 fix(common): decode line-ending backslash in multiline basic strings

### DIFF
--- a/common/src/create.rs
+++ b/common/src/create.rs
@@ -62,7 +62,8 @@ pub fn make_multiline_string_node(wrapped: &str) -> SyntaxElement {
 /// `text` is inserted verbatim between the delimiters; callers must ensure it does not
 /// contain the `'''` substring.
 pub fn make_multiline_literal_string_node(text: &str) -> SyntaxElement {
-    let expr = format!("a = '''{text}'''");
+    let leading = if text.starts_with(['\n', '\r']) { "\n" } else { "" };
+    let expr = format!("a = '''{leading}{text}'''");
     let root = parse(&expr);
     first_key_value(&root)
         .children_with_tokens()

--- a/common/src/string.rs
+++ b/common/src/string.rs
@@ -133,6 +133,9 @@ fn can_use_multiline_literal_string(s: &str) -> bool {
 
 fn make_multiline_string_preserving_newlines(text: &str) -> String {
     let mut result = String::from("\"\"\"");
+    if text.starts_with(['\n', '\r']) {
+        result.push('\n');
+    }
     result.push_str(text);
     result.push_str("\"\"\"");
     result
@@ -223,7 +226,10 @@ pub fn load_text(value: &str, kind: SyntaxKind) -> String {
         content
     };
 
-    if kind == BASIC_STRING || kind == MULTI_LINE_BASIC_STRING {
+    if kind == MULTI_LINE_BASIC_STRING {
+        tombi_toml_text::parse_basic_string(content, TomlVersion::default(), true)
+            .unwrap_or_else(|_| content.to_string())
+    } else if kind == BASIC_STRING {
         unescape(content).unwrap_or_else(|_| content.to_string())
     } else {
         content.to_string()

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -1092,6 +1092,64 @@ fn test_can_use_multiline_literal_string_rejects_triple_single_quote() {
 }
 
 #[test]
+fn test_issue_388_load_text_multiline_basic_line_ending_backslash() {
+    // A multi-line basic string using a line-ending backslash (trims the newline and the
+    // next line's leading whitespace) must decode to its true value, not the raw escaped text.
+    let token = "\"\"\"\\\necho \"one\"\necho \"two\"\\\n\"\"\"";
+    let result = load_text(token, MULTI_LINE_BASIC_STRING);
+    assert_eq!(result, "echo \"one\"\necho \"two\"");
+}
+
+#[test]
+fn test_issue_388_line_ending_backslash_value_preserved_and_idempotent() {
+    let toml = "[tool.example]\ncmd = \"\"\"\\\necho \"one\"\necho \"two\"\\\n\"\"\"\n";
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[]);
+    let result = root_ast.to_string();
+
+    let parsed: toml::Value = toml::from_str(&result).unwrap();
+    assert_eq!(
+        parsed["tool"]["example"]["cmd"].as_str().unwrap(),
+        "echo \"one\"\necho \"two\""
+    );
+
+    let root_ast2 = parse(&result);
+    wrap_all_long_strings(&root_ast2, 120, "  ", &[]);
+    assert_eq!(result, root_ast2.to_string(), "formatting must be idempotent");
+}
+
+#[test]
+fn test_issue_388_leading_newline_preserved_literal_form() {
+    // Value starts with a newline and contains `"`, so it is emitted as a triple-literal.
+    // The builder must prepend an extra newline so TOML's first-newline trim is harmless.
+    let toml = "v = \"\"\"\n\\necho \"x\" done\"\"\"\n";
+    let original: toml::Value = toml::from_str(toml).unwrap();
+    assert_eq!(original["v"].as_str().unwrap(), "\necho \"x\" done");
+
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[]);
+    let result = root_ast.to_string();
+    assert!(result.contains("'''"), "expected triple-literal output, got: {result}");
+
+    let parsed: toml::Value = toml::from_str(&result).unwrap();
+    assert_eq!(parsed["v"].as_str().unwrap(), "\necho \"x\" done");
+}
+
+#[test]
+fn test_issue_388_leading_newline_preserved_basic_form() {
+    // Value starts with a newline and goes through the basic-preserving builder
+    // (single-line -> multi-line via skip_wrap, literal form unsafe due to the newline).
+    let toml = "[tool.x]\nv = \"\\nhello\"\n";
+    let root_ast = parse(toml);
+    wrap_all_long_strings(&root_ast, 120, "  ", &[String::from("*.v")]);
+    let result = root_ast.to_string();
+    assert!(result.contains("\"\"\""), "expected triple-basic output, got: {result}");
+
+    let parsed: toml::Value = toml::from_str(&result).unwrap();
+    assert_eq!(parsed["tool"]["x"]["v"].as_str().unwrap(), "\nhello");
+}
+
+#[test]
 fn test_skip_wrap_for_keys_partial_wildcard() {
     let toml = r#"[project]
 description = "Short"


### PR DESCRIPTION
A multiline basic string that ends a line with a backslash relies on TOML trimming that newline and the following indentation. When such a string also contained a `"`, the formatter preferred a literal string and rewrote the value into `'''...'''` while keeping the backslash verbatim, so the formatted file parsed to a different string than the input. 🐛 This corrupted multiline shell commands in real configs and first appeared in `2.22.0`.

The root cause sat in `load_text`, which decoded a `MULTI_LINE_BASIC_STRING` through the single-line decoder. A line-ending backslash is invalid there, the decode failed, and the code fell back to the raw escaped text that later landed inside the literal delimiters unchanged. Decoding now goes through tombi's multiline-aware `parse_basic_string`, so the real value is recovered before the string gets re-emitted. The literal and preserved-basic builders also prepend a newline when the value itself starts with one, because TOML drops the first newline after the opening delimiter.

A value that can be represented as a literal string still becomes one, and the result now round-trips. Strings that never used the line-ending backslash keep their previous formatting.

Fixes #388.
