### PR TITLE
📝 docs: keep comments to why only and de-slop docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ benefits all of them. Four packages make up the workspace:
 
 - `common/`: pure Rust library with the TOML parsing, syntax tree manipulation, and formatting utilities. No Python
   bindings; every formatter here builds on it.
-- `toml-fmt-common/`: pure Python library with the CLI utilities, argument parsing, and diff output shared by the
-  Python formatters.
+- `toml-fmt-common/`: pure Python library with the CLI utilities, argument parsing, and diff output shared by the Python
+  formatters.
 - `pyproject-fmt/`: Python package with Rust internals (via PyO3) that formats `pyproject.toml` per PEP 621 and
   community conventions, covering project metadata, dependencies, classifiers, and tool sections.
 - `tox-toml-fmt/`: Python package, also Rust-backed, that formats the `tox.toml` files used by tox.
@@ -94,8 +94,8 @@ tox run -e type
 
 #### Working on `pyproject-fmt/` or `tox-toml-fmt/` (Python packages with Rust internals)
 
-The Rust layer holds the formatting logic; the Python layer is the CLI and higher-level API. Modify the Rust code
-first, then confirm the Python tests still pass.
+The Rust layer holds the formatting logic; the Python layer is the CLI and higher-level API. Modify the Rust code first,
+then confirm the Python tests still pass.
 
 For Rust layer development:
 
@@ -372,8 +372,8 @@ Some code may not reach 100% coverage, and this is acceptable:
 
 ### Writing Good Assertions
 
-Assert the complete expected output instead of checking for a substring. A full assertion catches subtle structural
-bugs a substring check slides past.
+Assert the complete expected output instead of checking for a substring. A full assertion catches subtle structural bugs
+a substring check slides past.
 
 Good assertion style uses exact equality checks:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,16 @@
 
 ## Project Layout
 
-This repository is a Cargo workspace containing multiple Rust crates and Python packages that share common TOML
-formatting infrastructure. The project follows a layered architecture where low-level TOML manipulation code is shared
-across multiple high-level formatter tools.
+This Cargo workspace shares low-level TOML manipulation code across several formatter tools, so a fix in one place
+benefits all of them. Four packages make up the workspace:
 
-The workspace is organized into four main packages. At the foundation is `common/`, a pure Rust library that provides
-all the core TOML parsing, syntax tree manipulation, and formatting utilities. This crate contains no Python bindings
-and serves as the shared infrastructure for all formatters in this repository. Alongside it is `toml-fmt-common/`, a
-pure Python package providing CLI utilities, argument parsing, and diff output shared by all Python formatter tools. On
-top of these, we have `pyproject-fmt/`, which is a Python package (with Rust internals via PyO3) that formats
-`pyproject.toml` files according to PEP 621 and community standards. It handles project metadata, dependencies,
-classifiers, and tool-specific configuration sections. Similarly, `tox-toml-fmt/` is another Python package (also with
-Rust internals) that formats `tox.toml` files used by the tox test automation tool.
+- `common/`: pure Rust library with the TOML parsing, syntax tree manipulation, and formatting utilities. No Python
+  bindings; every formatter here builds on it.
+- `toml-fmt-common/`: pure Python library with the CLI utilities, argument parsing, and diff output shared by the
+  Python formatters.
+- `pyproject-fmt/`: Python package with Rust internals (via PyO3) that formats `pyproject.toml` per PEP 621 and
+  community conventions, covering project metadata, dependencies, classifiers, and tool sections.
+- `tox-toml-fmt/`: Python package, also Rust-backed, that formats the `tox.toml` files used by tox.
 
 ```
 toml-fmt/                       # Workspace root
@@ -54,14 +52,12 @@ toml-fmt/                       # Workspace root
 
 ### Development Commands by Package
 
-When working on this codebase, you'll use different commands depending on which layer you're modifying. The commands are
-organized by the package they apply to, with clear separation between Rust and Python tooling.
+Which commands you run depends on the layer you touch. They split along Rust versus Python tooling.
 
 #### Working on `common/` (Rust library)
 
-The common library contains all the low-level TOML manipulation code. When you modify this package, you're changing
-shared infrastructure that affects both pyproject-fmt and tox-toml-fmt. Since this is pure Rust with no Python bindings,
-all development happens through Cargo commands.
+Changes here ripple into both pyproject-fmt and tox-toml-fmt, since they share this code. It is pure Rust, so use Cargo
+for everything.
 
 ```bash
 # Run all tests in common
@@ -82,8 +78,7 @@ cargo clippy -p common
 
 #### Working on `toml-fmt-common/` (Python library)
 
-The toml-fmt-common package is a pure Python library providing CLI utilities shared by all formatter tools. Since it has
-no Rust code, development is straightforward Python testing with tox.
+This package has no Rust code, so development is Python testing with tox.
 
 ```bash
 # Set up development environment
@@ -99,9 +94,8 @@ tox run -e type
 
 #### Working on `pyproject-fmt/` or `tox-toml-fmt/` (Python packages with Rust internals)
 
-These packages have both Rust and Python layers. The Rust layer handles all the actual formatting logic, while the
-Python layer provides the CLI interface and higher-level API. When developing these packages, you'll typically modify
-Rust code first, then ensure the Python tests still pass.
+The Rust layer holds the formatting logic; the Python layer is the CLI and higher-level API. Modify the Rust code
+first, then confirm the Python tests still pass.
 
 For Rust layer development:
 
@@ -120,9 +114,8 @@ cargo fmt -p pyproject-fmt
 cargo clippy -p pyproject-fmt
 ```
 
-For Python layer development and integration testing, you use tox to manage the development environment and run tests.
-The build process compiles the Rust code and creates Python bindings via PyO3, which can take a minute or two on the
-first build. After that, cargo caches compiled artifacts and rebuilds are much faster.
+For the Python layer and integration testing, tox manages the environment and runs tests. The first build compiles the
+Rust code and generates PyO3 bindings, which takes a minute or two; later rebuilds reuse cargo's cached artifacts.
 
 ```bash
 # Set up development environment for pyproject-fmt
@@ -143,8 +136,8 @@ tox run -e 3.13
 
 #### Working across the entire workspace
 
-Sometimes you need to run commands across all packages at once. This is especially useful for CI-like validation before
-committing or when you've modified common code that affects multiple packages.
+Run commands across all packages for CI-like validation before committing, or after changing common code that several
+packages depend on.
 
 **Important:** The CI runs tests with `--no-default-features` to disable the PyO3 `extension-module` feature, which
 allows tests to link against Python. Always use this flag when running workspace-wide tests locally to match CI
@@ -166,16 +159,15 @@ cargo clippy --workspace
 
 ## Architecture Overview
 
-This project uses tombi for TOML parsing and syntax tree manipulation. Tombi is built on the rg_tree library, which
-provides a lossless syntax tree implementation designed for incremental parsing and efficient tree modifications.
+This project parses and manipulates TOML with tombi, which builds on rg_tree, a lossless syntax tree built for
+incremental parsing and in-place tree edits.
 
 ## Understanding Tombi/rg_tree
 
 ### Syntax Tree Architecture
 
-Tombi uses rg_tree for its AST representation, which provides a mutable syntax tree where nodes can be modified in
-place. When you parse TOML with tombi, you get an immutable syntax tree. To modify it, you call `clone_for_update()`
-which creates a mutable version that supports structural changes.
+Parsing TOML with tombi gives you an immutable syntax tree. To modify it, call `clone_for_update()` for a mutable
+version that supports structural changes.
 
 ```mermaid
 graph TD
@@ -187,10 +179,8 @@ graph TD
 
 ### Mutation Model
 
-When you parse TOML, you get an immutable syntax tree. To modify it, you call `clone_for_update()` which creates a
-mutable version. From there, you can use methods like `splice_children()` for batch updates, `insert_child()` to add
-nodes, or manipulate the tree structure directly. The tree maintains parent-child relationships automatically during
-modifications.
+On the mutable tree, use `splice_children()` for batch updates, `insert_child()` to add nodes, or edit the structure
+directly. The tree keeps parent-child relationships in sync as you go.
 
 ```rust
 let syntax = tombi_parser::parse(toml_str)
@@ -208,11 +198,11 @@ LITERAL_STRING (`'hello'`), LINE_BREAK (`\n`), COMMA (`,`), and WHITESPACE. Comp
 key-value pair), VALUE (the right side of an assignment), ARRAY (an array of values), TABLE (a `[section]` header), and
 ARRAY_TABLE (`[[section]]` header).
 
-An important difference from other parsers is how comments are represented. In tombi, inline comments attached to array
-elements are children of COMMA nodes. A COMMA node can contain three children: a COMMA token, a WHITESPACE token, and a
-COMMENT token. This structure is important when manipulating arrays with comments.
+Tombi represents comments differently from most parsers: an inline comment attached to an array element is a child of
+the COMMA node. A COMMA node can hold three children: a COMMA token, a WHITESPACE token, and a COMMENT token. Watch for
+this when manipulating arrays with comments.
 
-Here's an example showing the structure for a simple TOML entry:
+The structure of a simple TOML entry:
 
 ```toml
 name = "value"
@@ -232,7 +222,7 @@ ROOT
       └─ BASIC_STRING (node)
 ```
 
-For arrays with inline comments, the structure is more complex:
+An array with inline comments nests deeper:
 
 ```toml
 deps = [
@@ -265,26 +255,23 @@ ROOT
 
 ### Why Parse-and-Extract for Node Creation
 
-In `common/src/create.rs`, we use a "parse-and-extract" pattern. When we need to create a BASIC_STRING node, we format a
-complete TOML expression like `a = "text"`, parse it, navigate to the KEY_VALUE node, find the VALUE child, and extract
-the BASIC_STRING node from within it. While this involves parsing overhead, we chose this approach for several important
-reasons.
+`common/src/create.rs` uses a "parse-and-extract" pattern. To create a BASIC_STRING node, it formats a complete TOML
+expression like `a = "text"`, parses it, navigates to the KEY_VALUE node, finds the VALUE child, and extracts the
+BASIC_STRING node from within. Three reasons justify the parsing overhead:
 
-First, we'd need to reimplement all TOML escaping rules (quote escaping, backslash escaping, newline escaping, unicode
-sequences `\uXXXX` and `\UXXXXXXXX`, and line continuations) that tombi's parser already handles correctly. Second,
-parse-and-extract guarantees we always create valid TOML syntax because we're using the actual parser. Finally,
-performance is not a concern here because node creation is a small fraction of total formatting time.
+- Building nodes by hand means reimplementing every TOML escaping rule (quote, backslash, and newline escaping, the
+  unicode sequences `\uXXXX` and `\UXXXXXXXX`, line continuations) that tombi's parser already gets right.
+- Going through the real parser guarantees the output is valid TOML.
+- Node creation is a tiny fraction of total formatting time, so the extra parse costs nothing that matters.
 
-The trade-off is clear: we accept slightly slower node creation in exchange for guaranteed correctness, simpler code,
-and better maintainability.
+The trade is slightly slower node creation for guaranteed correctness and simpler code.
 
 ## Formatting Style
 
 ### Comment Alignment
 
-The formatters implement per-array comment alignment for inline comments. Unlike global alignment where all comments
-across the entire file align to the same column, comments are aligned independently within each array based on that
-array's longest value. This produces cleaner, more readable formatting.
+Inline comments align per array, each to that array's longest value, rather than to one shared column across the whole
+file. Keeping alignment local means an outlier in one array does not push every other comment across the file.
 
 For example, this input:
 
@@ -301,23 +288,21 @@ lint.per-file-ignores."tests/**/*.py" = [
 ]
 ```
 
-Will be formatted with each array aligning independently. The `lint.ignore` array aligns based on "ISC001" (its longest
-value), while `per-file-ignores` aligns based on "S101". This alignment happens after tombi's primary formatter runs, by
-modifying the WHITESPACE children within COMMA nodes that contain COMMENT children.
+aligns each array on its own. `lint.ignore` aligns to "ISC001" (its longest value), `per-file-ignores` to "S101".
+Alignment runs after tombi's primary formatter, editing the WHITESPACE children of COMMA nodes that contain a COMMENT
+child.
 
 ### Comment Preservation During Sorting
 
-When arrays contain comments (either inline or standalone), sorting is automatically skipped to preserve the comments in
-their original positions. This ensures that explanatory comments stay with their associated values. The
-`common/src/array.rs::sort()` function checks for comments before sorting and returns early if any are found.
+When an array contains comments (inline or standalone), sorting is skipped so the comments keep their positions and stay
+with the values they explain. `common/src/array.rs::sort()` checks for comments first and returns early if it finds any.
 
 ## Testing Guidelines
 
 ### Unit Tests and Parameterization
 
-Each module has corresponding tests in the `src/tests/` directory following a consistent naming pattern. We use the
-`rstest` crate for parameterized tests, which allows us to test multiple cases with different inputs using a single test
-function. This reduces code duplication and makes it easy to add new test cases.
+Each module has matching tests in `src/tests/` under a consistent naming pattern. The `rstest` crate drives
+parameterized tests, so one test function covers many input cases and adding a case is a single line.
 
 ```rust
 #[rstest]
@@ -330,14 +315,13 @@ fn test_load_text(#[case] input: &str, #[case] kind: SyntaxKind, #[case] expecte
 
 ### Coverage Goals and Measurement
 
-We require **98% line coverage for Rust code** and **100% coverage for Python code**. Additionally, **diff coverage must
-be 100% per test suite** — changes to `common/src/` must be fully covered by the common test suite alone, and changes to
-`tox-toml-fmt/rust/src/` must be fully covered by the tox-toml-fmt test suite alone. Use per-package coverage checks to
-verify: `cargo llvm-cov -p common --summary-only` or `cargo llvm-cov -p tox-toml-fmt --summary-only`.
+We require **98% line coverage for Rust code** and **100% coverage for Python code**. Diff coverage must also be **100%
+per test suite**: changes to `common/src/` must be fully covered by the common test suite alone, and changes to
+`tox-toml-fmt/rust/src/` by the tox-toml-fmt test suite alone. Verify with a per-package check:
+`cargo llvm-cov -p common --summary-only` or `cargo llvm-cov -p tox-toml-fmt --summary-only`.
 
-To generate an HTML coverage report for Rust code, run `tox r -e coverage` from the repository root. This generates lcov
-output and opens an HTML report in your browser. For a quick summary, use
-`cargo llvm-cov --workspace --no-default-features --summary-only`.
+For an HTML coverage report, run `tox r -e coverage` from the repository root; it writes lcov output and opens the
+report in your browser. For a quick summary, use `cargo llvm-cov --workspace --no-default-features --summary-only`.
 
 #### Testing PyO3 Code from Rust
 
@@ -367,8 +351,8 @@ Run these tests with: `cargo test --no-default-features`
 
 #### LLVM Coverage Artifacts
 
-LLVM coverage reports closing braces of multi-branch conditionals as separate lines. These often show as uncovered even
-when all code paths are tested. For example:
+LLVM reports the closing brace of a multi-branch conditional as its own line, often flagged uncovered even when every
+path is tested. For example:
 
 ```rust
 if condition {
@@ -376,8 +360,8 @@ if condition {
 }                        // reported as uncovered by LLVM
 ```
 
-This is a known limitation of LLVM's coverage instrumentation. We do not expect these closing brace lines to be covered
-and they should not block merging code that otherwise meets the 98% threshold.
+This is a known limitation of LLVM's coverage instrumentation. These closing-brace lines need not be covered and should
+not block merging code that otherwise meets the 98% threshold.
 
 #### Acceptable Coverage Gaps
 
@@ -388,8 +372,8 @@ Some code may not reach 100% coverage, and this is acceptable:
 
 ### Writing Good Assertions
 
-Write assertions that verify the complete expected output rather than just checking for the presence of substrings. Full
-assertions make tests more robust and catch subtle bugs that partial assertions might miss.
+Assert the complete expected output instead of checking for a substring. A full assertion catches subtle structural
+bugs a substring check slides past.
 
 Good assertion style uses exact equality checks:
 
@@ -405,8 +389,8 @@ assert!(result.contains("dependencies"));  // Too vague - doesn't verify structu
 
 ### Snapshot Testing with Insta
 
-For input/output comparison tests (where you verify formatter output against expected results), use the `insta` crate
-instead of inline expected strings. This makes test maintenance significantly easier when formatter behavior changes.
+For input/output comparison tests that check formatter output against expected results, use the `insta` crate rather
+than inline expected strings, so a behavior change updates expectations in one command instead of by hand.
 
 Traditional approach (avoid):
 
@@ -430,9 +414,8 @@ fn test_format(#[case] input: &str) {
 }
 ```
 
-The `@""` syntax creates an **inline snapshot** where the expected value is stored directly in the test file. This is
-preferred over file-based snapshots because it keeps the expected output next to the test input, making tests easier to
-read and review.
+The `@""` syntax stores the expected value as an **inline snapshot** in the test file itself. Keeping output next to
+input beats file-based snapshots for reading and reviewing tests.
 
 Snapshot testing workflow:
 
@@ -448,8 +431,8 @@ When formatter behavior changes (like switching parsers), you can update all tes
 
 ### Iterating Over Table Entries
 
-When you need to process entries in a TOML table, use the `Tables` abstraction from `common::table`. This handles the
-complexity of navigating the syntax tree and finding entries within a specific table section.
+To process entries in a TOML table, use the `Tables` abstraction from `common::table`. It navigates the syntax tree and
+finds the entries within a given table section for you.
 
 ```rust
 use common::table::Tables;
@@ -464,9 +447,8 @@ for entry in tables.get("project") {
 
 ### Modifying String Values
 
-To transform string values in TOML (like normalizing dependency versions or fixing URLs), use the `update_content`
-function from `common::string`. This handles all the complexity of finding string nodes, applying your transformation,
-and updating the tree.
+To transform string values in TOML (normalizing dependency versions, fixing URLs), use `update_content` from
+`common::string`. It finds the string node, applies your transformation, and updates the tree.
 
 ```rust
 use common::string::update_content;
@@ -478,9 +460,9 @@ update_content(value_node, |text| {
 
 ### Reordering Inline Table Keys
 
-When a formatter needs to enforce a consistent key order within inline tables, use the `InlineTableSchema` and
-`reorder_inline_table_keys` from `common::table`. Each schema specifies a discriminator key (used to identify which
-schema applies) and the desired key order. Keys not listed in the schema are appended at the end.
+To enforce a consistent key order within inline tables, use `InlineTableSchema` and `reorder_inline_table_keys` from
+`common::table`. Each schema names a discriminator key (which selects the schema) and the desired key order; keys not
+listed are appended at the end.
 
 ```rust
 use common::table::{reorder_inline_table_keys, InlineTableSchema};
@@ -497,8 +479,8 @@ reorder_inline_table_keys(&root_ast, SCHEMAS);
 
 ### Creating New Nodes
 
-When you need to create new syntax nodes, use the functions in `common::create`. These use the parse-and-extract pattern
-to guarantee valid TOML syntax.
+To create new syntax nodes, use the functions in `common::create`. They use the parse-and-extract pattern to guarantee
+valid TOML syntax.
 
 ```rust
 use common::create::{make_string_node, make_entry_of_string};
@@ -509,13 +491,11 @@ let new_entry = make_entry_of_string(&"key".to_string(), &"value".to_string());
 
 ## Development Workflow
 
-The typical development workflow starts with making changes in the Rust code, then running the test suite with
-`cargo test`. Check coverage using `cargo llvm-cov report` to ensure your changes are well-tested. Format your code with
-`cargo fmt` and run the linter with `cargo clippy` to catch common issues.
+Change the Rust code, then run the test suite with `cargo test`. Check coverage with `cargo llvm-cov report`. Format
+with `cargo fmt` and lint with `cargo clippy`.
 
-For testing the Python bindings, first set up the development environment by running `tox run -e dev` in the
-`pyproject-fmt` directory. Then run the Python test suite using `tox run -e 3.13` or whichever Python version you're
-targeting. This ensures both the Rust and Python layers work correctly together.
+To test the Python bindings, set up the environment with `tox run -e dev` in the `pyproject-fmt` directory, then run the
+Python suite with `tox run -e 3.13` (or your target Python version) to exercise the Rust and Python layers together.
 
-When you're ready to commit, make sure all tests pass in both Rust and Python, coverage meets the threshold, and the
-code is formatted and lint-free.
+Before committing, confirm all Rust and Python tests pass, coverage meets the threshold, and the code is formatted and
+lint-free.

--- a/common/src/array.rs
+++ b/common/src/array.rs
@@ -216,8 +216,7 @@ where
     }
 }
 
-/// A run of array values bounded by `# Group:` markers. Values are reordered only within a group;
-/// the marker `header` stays anchored at the group's start and groups keep their original order.
+/// Sorting reorders values only within a group; group `header`s and the relative order of groups stay put.
 struct ValueGroup<T> {
     header: Vec<SyntaxElement>,
     order_sets: Vec<Vec<SyntaxElement>>,
@@ -397,7 +396,6 @@ where
     );
 }
 
-/// Remove duplicate string entries from an array (case-insensitive comparison)
 pub fn dedupe_strings<K>(array: &SyntaxNode, to_key: K)
 where
     K: Fn(&str) -> String,
@@ -406,7 +404,6 @@ where
     remove_strings(array, |s| !seen.insert(to_key(s)));
 }
 
-/// Remove string entries from an array for which `predicate` returns true
 pub fn remove_strings<P>(array: &SyntaxNode, mut predicate: P)
 where
     P: FnMut(&str) -> bool,

--- a/common/src/create.rs
+++ b/common/src/create.rs
@@ -1,12 +1,5 @@
-//! Syntax node creation utilities using the parse-and-extract pattern.
-//!
-//! This module provides functions to create TOML syntax nodes by parsing valid TOML
-//! and extracting the desired elements. While this approach involves parsing overhead,
-//! it ensures:
-//!
-//! 1. **Correctness**: All created nodes are guaranteed to be valid TOML syntax
-//! 2. **Proper escaping**: The parser handles all TOML escape sequences correctly
-//! 3. **Simplicity**: Straightforward code that's easy to understand and maintain
+//! Parsing each snippet costs more than hand-building nodes, but buys valid syntax and correct escape
+//! handling for free, since the parser owns those rules.
 
 use tombi_syntax::SyntaxKind::{
     ARRAY, BASIC_STRING, COMMA, COMMENT, KEY_VALUE_GROUP, KEYS, LINE_BREAK, LITERAL_STRING, MULTI_LINE_BASIC_STRING,
@@ -57,10 +50,7 @@ pub fn make_multiline_string_node(wrapped: &str) -> SyntaxElement {
         .expect("KEY_VALUE contains MULTI_LINE_BASIC_STRING")
 }
 
-/// Create a MULTI_LINE_LITERAL_STRING (`'''...'''`) syntax element by parsing valid TOML.
-///
-/// `text` is inserted verbatim between the delimiters; callers must ensure it does not
-/// contain the `'''` substring.
+/// `text` is inserted verbatim between the `'''` delimiters; callers must ensure it does not contain `'''`.
 pub fn make_multiline_literal_string_node(text: &str) -> SyntaxElement {
     let leading = if text.starts_with(['\n', '\r']) { "\n" } else { "" };
     let expr = format!("a = '''{leading}{text}'''");
@@ -71,10 +61,6 @@ pub fn make_multiline_literal_string_node(text: &str) -> SyntaxElement {
         .expect("KEY_VALUE contains MULTI_LINE_LITERAL_STRING")
 }
 
-/// Create a BASIC_STRING (basic/double-quoted) syntax element by parsing valid TOML.
-///
-/// This function ensures proper TOML escaping by using the escape function
-/// to handle backslash escaping, quote escaping, and control characters.
 pub fn make_string_node(text: &str) -> SyntaxElement {
     let escaped = escape(text);
     let expr = format!("a = \"{escaped}\"");
@@ -85,10 +71,7 @@ pub fn make_string_node(text: &str) -> SyntaxElement {
         .expect("KEY_VALUE contains BASIC_STRING")
 }
 
-/// Create a LITERAL_STRING (literal/single-quoted) syntax element by parsing valid TOML.
-///
-/// Use this when content contains backslashes that would need escaping in a basic string.
-/// Content must not contain single quotes (there's no way to escape them in literal strings).
+/// `text` must not contain a single quote, which literal strings cannot escape.
 pub fn make_literal_string_node(text: &str) -> SyntaxElement {
     let expr = format!("a = '{text}'");
     let root = parse(&expr);
@@ -98,10 +81,7 @@ pub fn make_literal_string_node(text: &str) -> SyntaxElement {
         .expect("KEY_VALUE contains LITERAL_STRING")
 }
 
-/// Create LINE_BREAK tokens for a blank line (two newlines).
-///
-/// Used for adding vertical spacing between sections in TOML files.
-/// Returns two LINE_BREAK elements since tombi represents each newline separately.
+/// Returns two LINE_BREAK elements: tombi models each newline as its own token.
 pub fn make_empty_newline() -> Vec<SyntaxElement> {
     parse("\n\n")
         .children_with_tokens()
@@ -109,7 +89,6 @@ pub fn make_empty_newline() -> Vec<SyntaxElement> {
         .collect()
 }
 
-/// Create a single LINE_BREAK token.
 pub fn make_newline() -> SyntaxElement {
     parse("\n")
         .children_with_tokens()
@@ -128,7 +107,6 @@ pub fn make_comment(text: &str) -> SyntaxElement {
     unreachable!("parsed comment TOML contains COMMENT")
 }
 
-/// Create a COMMA token for use in arrays.
 pub fn make_comma() -> SyntaxElement {
     let root = parse("a=[1,2]");
     let array_node = first_key_value(&root)
@@ -138,7 +116,6 @@ pub fn make_comma() -> SyntaxElement {
     find_in_array(array_node.as_node().unwrap(), COMMA).expect("ARRAY contains COMMA")
 }
 
-/// Create a WHITESPACE token with a custom number of spaces.
 pub fn make_whitespace_n(count: usize) -> SyntaxElement {
     let spaces = " ".repeat(count.max(1));
     let sample = format!("a=[1,{}2]", spaces);
@@ -150,9 +127,6 @@ pub fn make_whitespace_n(count: usize) -> SyntaxElement {
     find_in_array(array_node.as_node().unwrap(), WHITESPACE).expect("ARRAY contains WHITESPACE")
 }
 
-/// Create a KEYS node with the given text.
-///
-/// Supports dotted keys like `"foo.bar"`.
 pub fn make_key(text: &str) -> SyntaxElement {
     let root = parse(format!("{text}=1").as_str());
     first_key_value(&root)
@@ -201,13 +175,11 @@ pub fn make_entry_with_array_of_inline_tables(key: &str, inline_tables: &[String
     SyntaxElement::Node(first_key_value(&root))
 }
 
-/// Create an array of tables entry (e.g., `[[project.authors]]`)
 pub fn make_table_array_entry(key: &str) -> Vec<SyntaxElement> {
     let txt = format!("[[{key}]]\n");
     parse(txt.as_str()).children_with_tokens().collect()
 }
 
-/// Create a table array with entries (e.g., `[[project.authors]]\nname = "John"\nemail = "john@example.com"`)
 pub fn make_table_array_with_entries(key: &str, entries: &[(String, String)]) -> Vec<SyntaxElement> {
     let entries_str = entries
         .iter()

--- a/common/src/disabled.rs
+++ b/common/src/disabled.rs
@@ -1,20 +1,18 @@
-//! Commented-out (disabled) keys, kept in step with the table they belong to.
+//! A comment whose body is one valid key-value (`# default = true`) is a disabled field rather than prose. The pass
+//! uncomments it so the formatter sorts it with its table, then comments it back; otherwise it would drift to the next
+//! table and never get ordered.
 //!
-//! A comment whose body is one valid key-value (`# default = true`) is a disabled field, not
-//! prose. The pass uncomments it so the formatter sorts it with its table, then comments it back;
-//! otherwise it would drift to the next table and never get ordered.
-//!
-//! A value can span several comment lines. `# x = [` alone is invalid, yet `# x = [` / `#   1,` /
-//! `# ]` parses once the run is uncommented together, so enabling works on whole runs. That also
-//! keeps the round-trip stable when the formatter wraps a value across lines.
+//! A value can span several comment lines. `# x = [` alone is invalid, yet `# x = [` / `#   1,` / `# ]` parses once the
+//! run is uncommented together, so enabling works on whole runs. That also keeps the round-trip stable when the
+//! formatter wraps a value across lines.
 
 use tombi_syntax::SyntaxKind::{
     ARRAY_OF_TABLE, COMMENT, KEY_VALUE, KEY_VALUE_GROUP, KEYS, LINE_BREAK, TABLE, WHITESPACE,
 };
 use tombi_syntax::SyntaxNode;
 
-/// Tags a disabled key's trailing comment so the pass can find it again after the formatter has
-/// reordered and re-parsed everything. [`restore_disabled_keys`] strips it.
+/// Tags a disabled key's trailing comment so the pass can find it again after the formatter has reordered and
+/// re-parsed everything. [`restore_disabled_keys`] strips it.
 pub const MARKER: &str = "__toml_fmt_disabled__";
 
 /// Top-level key-values only; a nested `set_env = { A = "1" }` is one key, not two.
@@ -25,9 +23,8 @@ fn top_level_key_values(root: &SyntaxNode) -> usize {
         .sum()
 }
 
-/// Uncomment `body` (one line or several) into a single marker-tagged key-value, or `None` when it
-/// is not exactly one key-value. The marker extends a comment already on the last line so the
-/// value never ends up with two trailing comments.
+/// `None` unless `body` is exactly one key-value. The marker extends a comment already on the last line, so the value
+/// never ends up with two trailing comments.
 fn enabled_form(body: &str) -> Option<String> {
     let parsed = tombi_parser::parse(body);
     if !parsed.errors.is_empty() {
@@ -56,8 +53,7 @@ pub fn with_disabled_keys(content: &str, format: impl FnOnce(&str) -> String) ->
     restore_disabled_keys(&format(&enabled))
 }
 
-/// Indent before the `#` and the body after it, dropping one space to mirror how
-/// [`comment_disabled_line`] writes a comment back. `None` for a non-comment line.
+/// Drops one space after `#` to mirror how [`comment_disabled_line`] writes it back, keeping the round-trip stable.
 fn split_comment(line: &str) -> Option<(&str, &str)> {
     let trimmed = line.trim_start();
     let rest = trimmed.strip_prefix('#')?;
@@ -72,8 +68,7 @@ fn is_table_header(body: &str) -> bool {
         .any(|n| matches!(n.kind(), TABLE | ARRAY_OF_TABLE))
 }
 
-/// Shortest run from `start` that uncomments to one key-value, with its last line index and the
-/// tagged text. A nested table header ends the run, since the keys under it are a separate value.
+/// A nested table header ends the run, since the keys under it are a separate value.
 fn enable_block(lines: &[&str], start: usize, run_end: usize) -> Option<(usize, String)> {
     let mut bodies: Vec<&str> = Vec::new();
     for (end, line) in lines.iter().enumerate().take(run_end).skip(start) {
@@ -89,9 +84,8 @@ fn enable_block(lines: &[&str], start: usize, run_end: usize) -> Option<(usize, 
     None
 }
 
-/// Uncomment every disabled key-value, tagging each with [`MARKER`]; prose and incomplete fragments
-/// stay commented. A commented table header ends enabling for the rest of its run, since the keys
-/// under it would otherwise leave the table they belong to.
+/// A commented table header ends enabling for the rest of its run, since the keys under it would otherwise leave
+/// the table they belong to.
 pub(crate) fn enable_disabled_keys(source: &str) -> String {
     let lines: Vec<&str> = source.lines().collect();
     let mut out: Vec<String> = Vec::with_capacity(lines.len());
@@ -128,9 +122,8 @@ pub(crate) fn enable_disabled_keys(source: &str) -> String {
     join_like(source, out)
 }
 
-/// Comment every marker-tagged key-value back, dropping the marker. A wrapped value carries the
-/// marker on its last line only, so the whole span gets commented. The span starts at the key, not
-/// the node: the node also owns the leading comments and blank lines before it, which stay put.
+/// A wrapped value carries the marker on its last line only, so the whole span gets commented. The span starts at
+/// the key rather than the node, which also owns the leading comments and blank lines before it that stay put.
 pub(crate) fn restore_disabled_keys(formatted: &str) -> String {
     if !formatted.contains(MARKER) {
         return formatted.to_string();
@@ -159,8 +152,7 @@ pub(crate) fn restore_disabled_keys(formatted: &str) -> String {
     join_like(formatted, restored)
 }
 
-/// Comment one line of a disabled key-value, stripping the marker if present. `base` is the key's
-/// own indent, so the `#` lands at its column and the value's deeper indentation survives after it.
+/// `base` is the key's own indent, so the `#` lands at its column and the value's deeper indentation survives.
 fn comment_disabled_line(line: &str, base: usize) -> String {
     let cleaned = match line.find(MARKER) {
         Some(idx) => {

--- a/common/src/pep508/requirement.rs
+++ b/common/src/pep508/requirement.rs
@@ -21,7 +21,7 @@ pub struct Requirement {
 
 impl Requirement {
     pub fn new(raw: &str) -> Result<Self, String> {
-        // Check for ; private suffix (PEP 794)
+        // PEP 794 `; private` suffix.
         let (raw_without_private, private) = if let Some(idx) = raw.rfind(';') {
             let suffix = raw[idx + 1..].trim();
             if suffix.eq_ignore_ascii_case("private") {
@@ -33,21 +33,18 @@ impl Requirement {
             (raw, false)
         };
 
-        // Extract the marker (find ';' separator)
         let (raw_req, marker_start) = if let Some(idx) = raw_without_private.find(';') {
             (&raw_without_private[..idx], Some(idx + 1))
         } else {
             (raw_without_private, None)
         };
 
-        // Extract URL from remaining (find "@" separator)
         let (req_part, url_start) = if let Some(idx) = raw_req.find("@") {
             (&raw_req[..idx], Some(idx + 1))
         } else {
             (raw_req, None)
         };
 
-        // Split extras (inside [...]) and extract name
         let (name, extras) = if let Some(start) = req_part.find('[') {
             let end = req_part.find(']').ok_or("Unclosed extras bracket")?;
             let name = &req_part[..start];
@@ -57,13 +54,11 @@ impl Requirement {
                 .collect();
             (name, extras)
         } else {
-            // No extras, but need to find where version specifiers start
             let name_end = req_part.find(|c: char| "=!<>~(".contains(c)).unwrap_or(req_part.len());
             let name = &req_part[..name_end];
             (name, vec![])
         };
 
-        // Parse version specifiers into Vec<VersionOp>
         let version_or_url = if let Some(url_idx) = url_start {
             let url = &raw_req[url_idx..];
             Some(VersionOrUrl::Url(url.trim().to_string()))
@@ -105,7 +100,7 @@ impl Requirement {
         self.name = self.canonical_name();
         if !keep_full_version && let Some(VersionOrUrl::Versions(ref mut specs)) = self.version_or_url {
             for version_op in specs.iter_mut() {
-                // Only strip trailing .0 if there are no pre, post, dev, or local segments
+                // Trailing `.0` is only redundant without pre/post/dev/local segments.
                 if version_op.op != Operator::Compatible
                     && !version_op.version.has_wildcard
                     && version_op.version.pre.is_none()

--- a/common/src/pep508/version_op.rs
+++ b/common/src/pep508/version_op.rs
@@ -15,7 +15,7 @@ impl VersionOp {
         let spec = spec.trim();
         let (op, remaining) = Operator::new(spec)?;
         let version_str = remaining.trim();
-        // No need to handle .*, Version::new will do it
+        // Version::new parses the `.*` wildcard itself.
         let version = Version::new(version_str);
         Ok(Self { op, version })
     }

--- a/common/src/pep508/version_op/version.rs
+++ b/common/src/pep508/version_op/version.rs
@@ -18,7 +18,6 @@ impl Version {
             input = &input[..input.len() - 2];
         }
 
-        // Parse epoch (e.g., "1!" from "1!2.0.0")
         let epoch = if let Some(idx) = input.find('!') {
             if let Ok(epoch) = input[..idx].parse() {
                 input = &input[idx + 1..];
@@ -30,7 +29,6 @@ impl Version {
             None
         };
 
-        // Parse local version (e.g., "+local" from "1.0.0+local")
         let local = if let Some(idx) = input.find('+') {
             let local = Some(input[idx + 1..].to_ascii_lowercase());
             input = &input[..idx];
@@ -39,13 +37,11 @@ impl Version {
             None
         };
 
-        // Parse pre/post/dev releases
         let mut main = input;
         let mut pre = None;
         let mut post = None;
         let mut dev = None;
 
-        // Parse dev release (e.g., ".dev3" or "dev3")
         if let Some(idx) = main.to_ascii_lowercase().rfind("dev") {
             let (before, after) = main.split_at(idx);
             let after = &after[3..];
@@ -54,7 +50,6 @@ impl Version {
             main = Self::trim_separators_end(before);
         }
 
-        // Parse post release (e.g., ".post2" or "post2")
         if let Some(idx) = main.to_ascii_lowercase().rfind("post") {
             let (before, after) = main.split_at(idx);
             let after = &after[4..];
@@ -63,8 +58,7 @@ impl Version {
             main = Self::trim_separators_end(before);
         }
 
-        // Parse pre-release (e.g., "a1", "beta2", "rc3")
-        // Labels checked longest first to avoid partial matches (e.g. "rc" before "c")
+        // Labels are checked longest first so a shorter one is not matched inside a longer one ("rc" before "c").
         let pre_labels = ["preview", "alpha", "beta", "pre", "rc", "a", "b", "c"];
         for label in &pre_labels {
             if let Some(idx) = main.to_ascii_lowercase().rfind(label) {
@@ -77,7 +71,6 @@ impl Version {
             }
         }
 
-        // Parse release numbers (e.g., "1.2.3" -> [1, 2, 3])
         let release: Vec<u64> = main.split('.').filter_map(|x| x.parse().ok()).collect();
 
         Self {
@@ -107,14 +100,12 @@ impl std::fmt::Display for Version {
         if let Some(epoch) = self.epoch {
             write!(f, "{}!", epoch)?;
         }
-        // Release segment
         for (i, part) in self.release.iter().enumerate() {
             if i > 0 {
                 write!(f, ".")?;
             }
             write!(f, "{}", part)?;
         }
-        // Pre-release
         if let Some((ref pre_l, pre_n)) = self.pre {
             f.write_str(match pre_l.as_str() {
                 "alpha" | "a" => "a",
@@ -128,7 +119,6 @@ impl std::fmt::Display for Version {
                 f.write_str("0")?;
             }
         }
-        // Post-release
         if let Some((ref _post_l, post_n)) = self.post {
             f.write_str(".post")?;
             if let Some(n) = post_n {
@@ -137,7 +127,6 @@ impl std::fmt::Display for Version {
                 f.write_str("0")?;
             }
         }
-        // Dev-release
         if let Some((_, dev_n)) = self.dev {
             f.write_str(".dev")?;
             if let Some(n) = dev_n {
@@ -146,12 +135,10 @@ impl std::fmt::Display for Version {
                 f.write_str("0")?;
             }
         }
-        // Local
         if let Some(ref local) = self.local {
             f.write_str("+")?;
             f.write_str(&local.replace(['-', '_'], "."))?;
         }
-        // Append .*, if this version had a wildcard
         if self.has_wildcard {
             f.write_str(".*")?;
         }

--- a/common/src/string.rs
+++ b/common/src/string.rs
@@ -124,9 +124,7 @@ fn can_use_literal_string(s: &str) -> bool {
     !s.contains('\'') && !s.chars().any(|c| c.is_control() && c != '\t')
 }
 
-/// Triple-literal `'''...'''` strings preserve everything verbatim except they must not
-/// contain the closing delimiter `'''`. Newlines, tabs, and CR are explicitly allowed
-/// (they are the whole reason to use a multi-line form).
+/// Allows `\n\r\t` (the point of a multi-line form) but not `'''`, which a literal string cannot represent.
 fn can_use_multiline_literal_string(s: &str) -> bool {
     !s.contains("'''") && !s.chars().any(|c| c.is_control() && c != '\n' && c != '\r' && c != '\t')
 }
@@ -407,10 +405,8 @@ fn wrap_string_node_if_needed(
         .any(|pattern| matches_pattern(&key_path, pattern));
 
     let has_newlines = text.contains('\n');
-    // A multi-line literal source like `'''(\n  \.eggs\n  | \.git\n)'''` cannot be
-    // re-emitted as triple-basic without escaping every `\`. Preserve the literal form
-    // whenever it is still valid: the source was literal and the text has no `'''`
-    // (or no `'` for single-line) and no disallowed control chars.
+    // A literal source like `'''(\n  \.eggs\n  | \.git\n)'''` would need every `\` escaped to become triple-basic,
+    // so keep the literal form while it stays valid.
     let literal_safe = if is_multiline {
         can_use_multiline_literal_string(&text)
     } else {

--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -212,7 +212,7 @@ impl Tables {
 
                 let comments_for_new_table: Vec<SyntaxElement> = borrow.drain(comments_start..).collect();
 
-                // Strip trailing LINE_BREAKs - they represent spacing between tables, not table content
+                // Trailing LINE_BREAKs are inter-table spacing; keep them out of table content.
                 while let Some(last) = borrow.last() {
                     if last.kind() == LINE_BREAK {
                         borrow.pop();
@@ -319,7 +319,6 @@ impl Tables {
                             }
                         }
                     } else {
-                        // Not the last entry - add blank line before next entry of same table
                         add.extend(make_empty_newline());
                     }
 
@@ -330,10 +329,8 @@ impl Tables {
 
         root_ast.splice_children(0..root_ast.children_with_tokens().count(), to_insert);
 
-        // Re-parse to rebuild proper TABLE wrapper nodes and parent chain. from_ast decomposes
-        // TABLE nodes into flat children for manipulation, but splice_children puts them back
-        // without TABLE wrappers. Re-parsing reconstructs the correct tree structure so parent
-        // traversal works.
+        // from_ast flattened TABLE nodes into bare children, and splice_children put them back without TABLE wrappers.
+        // Re-parse to rebuild the wrappers and parent chain that later traversal needs.
         let reparsed = parse(&root_ast.to_string());
         let new_children: Vec<SyntaxElement> = reparsed.children_with_tokens().collect();
         root_ast.splice_children(0..root_ast.children_with_tokens().count(), new_children);
@@ -652,7 +649,7 @@ pub fn collapse_sub_tables(tables: &mut Tables, name: &str) {
         }
         let mut sub = tables.table_set[*sub_positions.first().unwrap()].borrow_mut();
 
-        // Check for both ARRAY_OF_TABLE node (old structure) and DOUBLE_BRACKET_START (new structure)
+        // Array-of-tables shows up as ARRAY_OF_TABLE (old parse) or DOUBLE_BRACKET_START (new parse).
         let is_array_table = sub
             .iter()
             .any(|child| child.kind() == ARRAY_OF_TABLE || child.kind() == DOUBLE_BRACKET_START);
@@ -791,7 +788,7 @@ pub fn collapse_sub_table(tables: &mut Tables, parent_name: &str, sub_name: &str
     };
 
     let first_sub = tables.table_set[*sub_positions.first().unwrap()].borrow();
-    // Check for both ARRAY_OF_TABLE node (old structure) and DOUBLE_BRACKET_START (new structure)
+    // Array-of-tables shows up as ARRAY_OF_TABLE (old parse) or DOUBLE_BRACKET_START (new parse).
     let is_array_table = first_sub
         .iter()
         .any(|child| child.kind() == ARRAY_OF_TABLE || child.kind() == DOUBLE_BRACKET_START);
@@ -901,8 +898,8 @@ fn collapse_array_of_tables(
     sub_positions: &[usize],
     column_width: usize,
 ) {
-    // A disabled key carries the marker in a trailing comment; collapsing the entry into an
-    // inline table would embed that comment and produce invalid TOML, so keep it expanded.
+    // A disabled key carries the marker in a trailing comment; collapsing the entry into an inline table would embed
+    // that comment and produce invalid TOML, so keep it expanded.
     let has_disabled_key = sub_positions.iter().any(|pos| {
         tables.table_set[*pos]
             .borrow()

--- a/common/src/tests/disabled_tests.rs
+++ b/common/src/tests/disabled_tests.rs
@@ -201,8 +201,8 @@ fn test_round_trip_is_identity_for_disabled_key() {
     assert_eq!(restore_disabled_keys(&enable_disabled_keys(source)), source);
 }
 
-// Guards against another #390: every value shape that fits on one comment line must round-trip
-// unchanged, not just the scalars the feature started with.
+// Guards against another #390: every value shape that fits on one comment line must round-trip unchanged, beyond
+// the scalars the feature started with.
 #[test]
 fn test_disabled_value_constructs_round_trip() {
     let constructs = [

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -983,8 +983,8 @@ value = "Another very long string in a different section that should also be ski
 
 #[test]
 fn test_multiline_literal_with_backslashes_preserved() {
-    // Regression: triple-literal strings containing `\.` (etc.) used to be converted to
-    // triple-basic, producing invalid TOML because `\.` is not a valid basic-string escape.
+    // Regression: triple-literal strings containing `\.` (etc.) used to be converted to triple-basic, producing
+    // invalid TOML because `\.` is not a valid basic-string escape.
     let toml = "[tool.black]\nexclude = '''\n(\n  \\.eggs\n  | \\.git\n)\n'''\n";
     let root_ast = parse(toml);
     wrap_all_long_strings(&root_ast, 120, "  ", &[]);
@@ -1002,12 +1002,10 @@ fn test_multiline_literal_with_backslashes_preserved() {
 
 #[test]
 fn test_multiline_literal_with_triple_single_quote_falls_back_to_basic() {
-    // If the literal cannot be represented (contains `'''`), fall back to basic.
     let toml = "[t]\nv = '''line1\n\\.something\nlast'''\n";
     let root_ast = parse(toml);
     wrap_all_long_strings(&root_ast, 120, "  ", &[]);
     let result = root_ast.to_string();
-    // Even after fallback the output must be valid TOML.
     assert!(
         toml::from_str::<toml::Value>(&result).is_ok(),
         "output should be valid TOML, got: {result}"
@@ -1016,8 +1014,7 @@ fn test_multiline_literal_with_triple_single_quote_falls_back_to_basic() {
 
 #[test]
 fn test_multiline_basic_with_quotes_converts_to_literal() {
-    // A multi-line basic string whose body contains `"` should switch to the literal
-    // form so the quotes do not need escaping.
+    // A multi-line basic string whose body contains `"` switches to the literal form so the quotes need no escaping.
     let toml = "[t]\nv = \"\"\"line1\nhas \\\"quote\\\"\nlast\"\"\"\n";
     let root_ast = parse(toml);
     wrap_all_long_strings(&root_ast, 120, "  ", &[]);
@@ -1031,9 +1028,8 @@ fn test_multiline_basic_with_quotes_converts_to_literal() {
 
 #[test]
 fn test_multiline_basic_with_tab_and_cr_stays_basic() {
-    // Cover the `\r` / `\t` short-circuit arms of the control-char check by including
-    // both characters in the source — each one passes the `c != '\n'` and `c != '\r'`
-    // and `c != '\t'` checks differently as the iterator walks the body.
+    // Exercise the `\r` and `\t` arms of the control-char check; each clears a different one of the `c != '\n'`,
+    // `c != '\r'`, `c != '\t'` guards as the body is walked.
     let toml = "[t]\nv = \"\"\"abc\\tdef\\rghi\nmulti\"\"\"\n";
     let root_ast = parse(toml);
     wrap_all_long_strings(&root_ast, 120, "  ", &[]);
@@ -1046,9 +1042,8 @@ fn test_multiline_basic_with_tab_and_cr_stays_basic() {
 
 #[test]
 fn test_multiline_basic_with_backspace_blocks_literal_form() {
-    // Cover the `chars().any(control)` branch of `can_use_multiline_literal_string`:
-    // a multi-line basic string carrying a backspace escape can never become literal
-    // because backspace is a disallowed control character.
+    // Cover the `chars().any(control)` branch of `can_use_multiline_literal_string`: a multi-line basic string
+    // carrying a backspace escape can never become literal because backspace is a disallowed control character.
     let toml = "[t]\nv = \"\"\"abc\\bdef\nmulti\"\"\"\n";
     let root_ast = parse(toml);
     wrap_all_long_strings(&root_ast, 120, "  ", &[]);
@@ -1061,9 +1056,8 @@ fn test_multiline_basic_with_backspace_blocks_literal_form() {
 
 #[test]
 fn test_single_to_multiline_basic_with_skip_wrap_falls_back_to_basic() {
-    // Drive the `else` branch in the `if use_literal` arm of `preserve_newlines`:
-    // a single-line basic string with embedded newlines and skip_wrap forces
-    // single_to_multiline=true, preserve_newlines=true, use_literal=false.
+    // Drive the `else` branch in the `if use_literal` arm of `preserve_newlines`: a single-line basic string
+    // with embedded newlines and skip_wrap forces single_to_multiline=true, preserve_newlines=true, use_literal=false.
     let toml = "[tool.x]\nv = \"line one\\nline two\\nline three\"\n";
     let root_ast = parse(toml);
     wrap_all_long_strings(&root_ast, 120, "  ", &[String::from("*.v")]);
@@ -1077,9 +1071,9 @@ fn test_single_to_multiline_basic_with_skip_wrap_falls_back_to_basic() {
 
 #[test]
 fn test_can_use_multiline_literal_string_rejects_triple_single_quote() {
-    // Drive the `s.contains("'''")` short-circuit branch: a basic string carrying a
-    // quote (so `use_literal` would normally fire) plus `'''` in the body must stay
-    // basic because the literal form cannot represent the closing delimiter.
+    // Drive the `s.contains("'''")` short-circuit branch: a basic string carrying a quote (so `use_literal`
+    // would normally fire) plus `'''` in the body must stay basic because the literal form cannot represent the
+    // closing delimiter.
     let toml = "[t]\nv = \"\"\"\\\"abc '''inside''' xyz\nmulti\"\"\"\n";
     let root_ast = parse(toml);
     wrap_all_long_strings(&root_ast, 120, "  ", &[]);

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -715,7 +715,6 @@ fn test_comments_before_table_header_stay_with_that_table() {
     tables.reorder(&root_ast, &["build-system", "project"], &[], "\n", "");
 
     let res = format_toml(&root_ast, 120);
-    // The comment should stay with [build-system], not [project]
     assert!(res.starts_with("# comment for build-system\n[build-system]"));
 }
 
@@ -735,7 +734,6 @@ fn test_multiple_comments_before_table_header() {
     tables.reorder(&root_ast, &["build-system", "project"], &[], "\n", "");
 
     let res = format_toml(&root_ast, 120);
-    // Both comments should stay with [build-system]
     assert!(res.contains("# first comment\n# second comment\n[build-system]"));
 }
 
@@ -754,7 +752,6 @@ fn test_comment_with_blank_line_before_table_header() {
     tables.reorder(&root_ast, &["build-system", "project"], &[], "\n", "");
 
     let res = format_toml(&root_ast, 120);
-    // Comment should stay with [build-system] even with blank line before it
     assert!(res.starts_with("# comment for build-system\n[build-system]"));
 }
 
@@ -799,7 +796,6 @@ fn test_expand_sub_tables_creates_sub_table() {
 
     expand_sub_tables(&mut tables, "project");
 
-    // Verify the sub-table was created
     assert!(tables.header_to_pos.contains_key("project.urls"));
 }
 
@@ -815,7 +811,6 @@ fn test_expand_sub_tables_removes_dotted_keys_from_parent() {
 
     expand_sub_tables(&mut tables, "project");
 
-    // Verify the dotted key is removed from parent
     let main = tables.get("project").unwrap();
     let table = main[0].borrow();
     let txt = table.iter().map(|e| e.to_string()).collect::<String>();
@@ -836,7 +831,6 @@ fn test_expand_sub_tables_multiple_groups() {
 
     expand_sub_tables(&mut tables, "project");
 
-    // Verify both sub-tables were created
     assert!(tables.header_to_pos.contains_key("project.urls"));
     assert!(tables.header_to_pos.contains_key("project.scripts"));
 }
@@ -854,7 +848,6 @@ fn test_expand_sub_tables_no_dotted_keys() {
     let initial_count = tables.header_to_pos.len();
     expand_sub_tables(&mut tables, "project");
 
-    // No new tables should be created
     assert_eq!(tables.header_to_pos.len(), initial_count);
 }
 
@@ -867,7 +860,7 @@ fn test_expand_sub_tables_non_existent_table() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
 
-    // Should not panic when expanding non-existent table
+    // Expanding a missing table must be a no-op; this test would panic otherwise.
     expand_sub_tables(&mut tables, "nonexistent");
 }
 
@@ -883,7 +876,6 @@ fn test_expand_and_collapse_are_inverses() {
     let root_ast = parse(toml);
     let mut tables = Tables::from_ast(&root_ast);
 
-    // Collapse should work
     collapse_sub_tables(&mut tables, "project");
     let main = tables.get("project").unwrap();
     let table = main[0].borrow();

--- a/pyproject-fmt/docs/configuration.rst
+++ b/pyproject-fmt/docs/configuration.rst
@@ -50,12 +50,12 @@ If not set they will default to values from the CLI.
 Shared configuration file
 -------------------------
 
-You can place formatting settings in a standalone ``pyproject-fmt.toml`` file instead of (or in addition to) the
-``[tool.pyproject-fmt]`` table. This is useful for monorepos or when you want to share the same configuration across
-multiple projects without duplicating it in each ``pyproject.toml``.
+Place formatting settings in a standalone ``pyproject-fmt.toml`` file instead of (or alongside) the
+``[tool.pyproject-fmt]`` table. In a monorepo this shares one configuration across projects without repeating it in
+every ``pyproject.toml``.
 
-The formatter searches for ``pyproject-fmt.toml`` starting from the directory of the file being formatted and walking up
-to the filesystem root. The first match wins. You can also pass an explicit path via ``--config``:
+The formatter searches for ``pyproject-fmt.toml`` from the directory of the file being formatted up to the filesystem
+root, and the first match wins. Pass an explicit path via ``--config``:
 
 .. code-block:: bash
 
@@ -102,10 +102,9 @@ Table formatting
 
     Table formatting options are available in version 2.12.0 and later.
 
-You can control how sub-tables are formatted in your ``pyproject.toml`` file. There are two formatting styles:
+Control how sub-tables are formatted with two styles:
 
-**Short format (collapsed)** - The default behavior where sub-tables are collapsed into dotted keys. Use this for a
-compact representation:
+**Short format (collapsed)** - The default, where sub-tables collapse into dotted keys. Use it for a compact layout:
 
 .. code-block:: toml
 
@@ -150,15 +149,13 @@ option takes a string of ``\n`` characters where each ``\n`` adds one blank line
 Configuration priority
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The formatting behavior is determined by a priority system that allows you to set a global default while overriding
-specific tables:
+A priority system sets a global default while letting you override specific tables:
 
-1. **collapse_tables** - Highest priority, forces specific tables to be collapsed regardless of other settings
-2. **expand_tables** - Medium priority, forces specific tables to be expanded
-3. **table_format** - Lowest priority, sets the default behavior for all tables not explicitly configured
+1. **collapse_tables** - Highest priority, forces specific tables to collapse regardless of other settings
+2. **expand_tables** - Medium priority, forces specific tables to expand
+3. **table_format** - Lowest priority, sets the default for all tables not configured above
 
-This three-tier approach lets you fine-tune formatting for specific tables while maintaining a consistent default.
-For example:
+Set a broad default, then carve out exceptions per table. For example:
 
 .. code-block:: toml
 
@@ -241,9 +238,8 @@ readability and TOML 1.0.0 compatibility (inline tables cannot span multiple lin
 String wrapping
 ---------------
 
-By default, the formatter wraps long strings that exceed the column width using line continuations. However, some strings such as regex patterns should not be wrapped because wrapping can break their functionality.
-
-You can configure which keys should skip string wrapping using the ``skip_wrap_for_keys`` option:
+By default the formatter wraps strings past the column width using line continuations. Some strings, regex patterns
+especially, break when wrapped, so exclude their keys with ``skip_wrap_for_keys``:
 
 .. code-block:: toml
 

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1,20 +1,16 @@
 Formatting Rules
 ================
 
-``pyproject-fmt`` is an opinionated formatter, much like `black <https://github.com/psf/black>`_ is for Python code.
-The tool intentionally provides minimal configuration options because the goal is to establish a single standard format
-that all ``pyproject.toml`` files follow.
+``pyproject-fmt`` is an opinionated formatter, much like `black <https://github.com/psf/black>`_ is for Python code. It
+keeps configuration minimal so every ``pyproject.toml`` lands on one standard format. That buys you:
 
-**Benefits of this approach:**
+- less time configuring tools
+- smaller diffs when committing changes
+- code reviews where formatting never comes up
 
-- Less time configuring tools
-- Smaller diffs when committing changes
-- Easier code reviews since formatting is never a question
-
-While a few key options exist (``column_width``, ``indent``, ``table_format``, ``sub_table_spacing``,
-``separate_root_table``), the tool does not expose dozens of toggles. You get what the maintainers have chosen to be the
-right balance of readability, consistency, and usability. The ``column_width`` setting controls when arrays are split
-into multiple lines and when string values are wrapped using line continuations.
+A few options exist (``column_width``, ``indent``, ``table_format``, ``sub_table_spacing``, ``separate_root_table``),
+but there are no dozens of toggles. ``column_width`` controls when arrays split across lines and when string values
+wrap with line continuations.
 
 General Formatting
 ------------------
@@ -1039,7 +1035,7 @@ separation, skip patterns, and import edits; name lists are sorted, while sequen
 ``[tool.pylint.*]``
 ~~~~~~~~~~~~~~~~~~~
 
-`Pylint <https://pylint.readthedocs.io/en/stable/>`_ is a comprehensive static analyzer and linter for Python. See
+`Pylint <https://pylint.readthedocs.io/en/stable/>`_ is a static analyzer and linter for Python. See
 its `configuration reference <https://pylint.readthedocs.io/en/stable/user_guide/configuration/index.html>`_.
 
 Sub-tables follow Pylint's checker-group order; all rule, name, and path lists are sorted by leaf key name

--- a/pyproject-fmt/docs/index.rst
+++ b/pyproject-fmt/docs/index.rst
@@ -7,9 +7,8 @@ Apply a consistent format to your ``pyproject.toml`` file with comment support. 
 
 Philosophy
 ----------
-This tool aims to be an *opinionated formatter*, with similar objectives to `black <https://github.com/psf/black>`_.
-This means it deliberately does not support a wide variety of configuration settings. In return, you get consistency,
-predictability, and smaller diffs.
+This is an *opinionated formatter*, with the same objectives as `black <https://github.com/psf/black>`_: it offers few
+configuration settings on purpose. In return you get consistency, predictability, and smaller diffs.
 
 Use
 ---
@@ -17,10 +16,9 @@ Use
 Via ``CLI``
 ~~~~~~~~~~~
 
-:pypi:`pyproject-fmt` is a CLI tool that needs a Python interpreter (version 3.10 or higher) to run. We recommend
-either :pypi:`pipx` or :pypi:`uv` to install pyproject-fmt into an isolated environment. This has the added benefit that
-later you will be able to upgrade pyproject-fmt without affecting other parts of the system. We provide a method for
-``pip`` too here, but we discourage that path if you can:
+:pypi:`pyproject-fmt` is a CLI tool that needs Python 3.10 or higher to run. Install it into an isolated environment
+with :pypi:`pipx` or :pypi:`uv`; that way you can upgrade pyproject-fmt later without disturbing the rest of your
+system. A ``pip`` path follows for completeness, though we discourage it:
 
 .. tab:: uv
 
@@ -46,10 +44,9 @@ later you will be able to upgrade pyproject-fmt without affecting other parts of
         python -m pip install --user pyproject-fmt
         pyproject-fmt --help
 
-    You can install it within the global Python interpreter itself (perhaps as a user package via the
-    ``--user`` flag). Be cautious if you are using a Python installation that is managed by your operating system or
-    another package manager. ``pip`` might not coordinate with those tools, and may leave your system in an inconsistent
-    state. Note, if you go down this path you need to ensure pip is new enough per the subsections below
+    You can install it into the global Python interpreter (as a user package via the ``--user`` flag). Take care if
+    your Python is managed by the operating system or another package manager: ``pip`` may not coordinate with those
+    tools and can leave your system inconsistent. On this path, make sure pip is new enough per the subsections below.
 
 
 Via ``pre-commit`` hook
@@ -69,7 +66,7 @@ See :gh:`pre-commit/pre-commit` for instructions, sample ``.pre-commit-config.ya
 Via Python
 ~~~~~~~~~~
 
-You can use ``pyproject-fmt`` as a Python module to format TOML content programmatically.
+Call ``pyproject-fmt`` as a Python module to format TOML from your own code.
 
 .. code-block:: python
 

--- a/pyproject-fmt/rust/src/bandit.rs
+++ b/pyproject-fmt/rust/src/bandit.rs
@@ -2,7 +2,6 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// Group: scope (exclude_dirs, targets) → plugins (tests, skips) → plugin sub-tables.
 const KEY_ORDER: &[&str] = &[
     "",
     "exclude_dirs",

--- a/pyproject-fmt/rust/src/black.rs
+++ b/pyproject-fmt/rust/src/black.rs
@@ -2,7 +2,6 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// Group: meta → length → targets → include/exclude → behavior flags → output.
 const KEY_ORDER: &[&str] = &[
     "",
     "required-version",

--- a/pyproject-fmt/rust/src/bumpversion.rs
+++ b/pyproject-fmt/rust/src/bumpversion.rs
@@ -1,6 +1,5 @@
 use common::table::{reorder_table_keys, Tables};
 
-// Group: identity → format → tag → commit → behavior → [[files]]/[[parts]] (AoT, last).
 const KEY_ORDER: &[&str] = &[
     "",
     "current_version",

--- a/pyproject-fmt/rust/src/cibuildwheel.rs
+++ b/pyproject-fmt/rust/src/cibuildwheel.rs
@@ -4,32 +4,27 @@ use lexical_sort::natural_lexical_cmp;
 
 const KEY_ORDER: &[&str] = &[
     "",
-    // Selection
     "build",
     "skip",
     "test-skip",
     "archs",
     "enable",
     "free-threaded-support",
-    // Build configuration
     "build-frontend",
     "build-verbosity",
     "config-settings",
     "dependency-versions",
     "environment",
     "environment-pass",
-    // Build phases
     "before-all",
     "before-build",
     "repair-wheel-command",
-    // Test phases
     "before-test",
     "test-command",
     "test-requires",
     "test-extras",
     "test-groups",
     "test-sources",
-    // Platform images
     "manylinux-x86_64-image",
     "manylinux-i686-image",
     "manylinux-aarch64-image",
@@ -45,16 +40,13 @@ const KEY_ORDER: &[&str] = &[
     "musllinux-ppc64le-image",
     "musllinux-s390x-image",
     "musllinux-armv7l-image",
-    // Engine
     "container-engine",
-    // Per-platform sub-tables (collapsed)
     "linux",
     "macos",
     "windows",
     "android",
     "ios",
     "pyodide",
-    // Overrides last
     "overrides",
 ];
 
@@ -63,7 +55,7 @@ const SORT_ARRAYS: &[&str] = &["enable", "test-extras", "test-groups"];
 
 pub fn fix(tables: &mut Tables) {
     fix_one(tables, "tool.cibuildwheel");
-    // Per-platform tables follow the same order when not collapsed into the parent.
+    // Per-platform tables reuse KEY_ORDER for when they stay expanded instead of collapsing into the parent.
     for plat in ["linux", "macos", "windows", "android", "ios", "pyodide"] {
         fix_one(tables, &format!("tool.cibuildwheel.{plat}"));
     }
@@ -94,7 +86,7 @@ fn fix_overrides_aot(tables: &mut Tables) {
                 sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
             }
         });
-        // `select` always first (required), then the regular cibuildwheel keys.
+        // `select` leads because cibuildwheel requires it on every override entry.
         let mut order: Vec<&str> = vec!["", "select"];
         order.extend(KEY_ORDER.iter().filter(|k| !k.is_empty() && **k != "overrides"));
         reorder_table_keys(table, &order);

--- a/pyproject-fmt/rust/src/codespell.rs
+++ b/pyproject-fmt/rust/src/codespell.rs
@@ -4,7 +4,6 @@ use lexical_sort::natural_lexical_cmp;
 
 const KEY_ORDER: &[&str] = &[
     "",
-    // Dictionaries
     "builtin",
     "dictionary",
     "ignore-words",
@@ -12,7 +11,6 @@ const KEY_ORDER: &[&str] = &[
     "ignore-regex",
     "ignore-multiline-regex",
     "exclude-file",
-    // Scope
     "skip",
     "uri-ignore-words-list",
     "check-filenames",
@@ -20,7 +18,6 @@ const KEY_ORDER: &[&str] = &[
     "hidden",
     "regex",
     "user-input",
-    // Fix behavior
     "write-changes",
     "interactive",
     "enable-colors",

--- a/pyproject-fmt/rust/src/commitizen.rs
+++ b/pyproject-fmt/rust/src/commitizen.rs
@@ -4,30 +4,25 @@ use lexical_sort::natural_lexical_cmp;
 
 const KEY_ORDER: &[&str] = &[
     "",
-    // Rule selection
     "name",
     "version_type",
     "schema",
     "schema_pattern",
     "allowed_prefixes",
-    // Version source
     "version",
     "version_scheme",
     "version_provider",
     "version_files",
-    // Bump behavior
     "bump_message",
     "always_signoff",
     "retry_after_failure",
     "encoding",
     "major_version_zero",
-    // Tag / sign
     "tag_format",
     "annotated_tag",
     "annotated_tag_message",
     "gpg_sign",
     "use_shortcuts",
-    // Changelog
     "changelog_file",
     "changelog_format",
     "changelog_incremental",
@@ -38,12 +33,9 @@ const KEY_ORDER: &[&str] = &[
     "extras",
     "extra_files",
     "template",
-    // Hooks
     "pre_bump_hooks",
     "post_bump_hooks",
-    // Customization
     "customize",
-    // Commit
     "discover_secret",
 ];
 

--- a/pyproject-fmt/rust/src/coverage.rs
+++ b/pyproject-fmt/rust/src/coverage.rs
@@ -2,67 +2,49 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
+// Order mirrors coverage.py's configuration sections (run, paths, report, html, json, lcov, xml).
 const KEY_ORDER: &[&str] = &[
     "",
-    // === Run phase (data collection) ===
     "run",
-    // Source selection (what to measure)
     "run.source",
     "run.source_pkgs",
     "run.source_dirs",
-    // File filtering (include/omit together)
     "run.include",
     "run.omit",
-    // Measurement options
     "run.branch",
     "run.cover_pylib",
     "run.timid",
-    // Execution context
     "run.command_line",
     "run.concurrency",
     "run.context",
     "run.dynamic_context",
-    // Data management
     "run.data_file",
     "run.parallel",
     "run.relative_files",
-    // Plugins and extensions
     "run.plugins",
-    // Debugging
     "run.debug",
     "run.debug_file",
     "run.disable_warnings",
-    // Other
     "run.core",
     "run.patch",
     "run.sigterm",
-    // === Paths (path mapping) ===
     "paths",
-    // === Report phase (general reporting) ===
     "report",
-    // Coverage threshold
     "report.fail_under",
     "report.precision",
-    // File filtering (include/omit together)
     "report.include",
     "report.omit",
     "report.include_namespace_packages",
-    // Line exclusion (exclude patterns together)
     "report.exclude_lines",
     "report.exclude_also",
-    // Partial branch handling (partial together)
     "report.partial_branches",
     "report.partial_also",
-    // Output control (skip together)
     "report.skip_covered",
     "report.skip_empty",
     "report.show_missing",
-    // Formatting
     "report.format",
     "report.sort",
-    // Error handling
     "report.ignore_errors",
-    // === HTML output ===
     "html",
     "html.directory",
     "html.title",
@@ -70,16 +52,13 @@ const KEY_ORDER: &[&str] = &[
     "html.show_contexts",
     "html.skip_covered",
     "html.skip_empty",
-    // === JSON output ===
     "json",
     "json.output",
     "json.pretty_print",
     "json.show_contexts",
-    // === LCOV output ===
     "lcov",
     "lcov.output",
     "lcov.line_checksums",
-    // === XML output ===
     "xml",
     "xml.output",
     "xml.package_depth",
@@ -91,7 +70,6 @@ pub fn fix(tables: &mut Tables) {
     };
     let table = &mut table_elements.first().unwrap().borrow_mut();
     for_entries(table, &mut |key, entry| match key.as_str() {
-        // Run phase arrays
         "run.source"
         | "run.source_pkgs"
         | "run.source_dirs"
@@ -101,7 +79,6 @@ pub fn fix(tables: &mut Tables) {
         | "run.plugins"
         | "run.debug"
         | "run.disable_warnings"
-        // Report phase arrays
         | "report.include"
         | "report.omit"
         | "report.exclude_lines"

--- a/pyproject-fmt/rust/src/deptry.rs
+++ b/pyproject-fmt/rust/src/deptry.rs
@@ -2,7 +2,6 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// Group: scope/exclude → ignore rules → per-rule ignores → behavior → mapping.
 const KEY_ORDER: &[&str] = &[
     "",
     "exclude",

--- a/pyproject-fmt/rust/src/djlint.rs
+++ b/pyproject-fmt/rust/src/djlint.rs
@@ -4,14 +4,12 @@ use lexical_sort::natural_lexical_cmp;
 
 const KEY_ORDER: &[&str] = &[
     "",
-    // Profile / scope
     "profile",
     "extension",
     "include",
     "exclude",
     "extend_exclude",
     "use_gitignore",
-    // Formatting
     "indent",
     "indent_css",
     "indent_js",
@@ -32,7 +30,6 @@ const KEY_ORDER: &[&str] = &[
     "format_js",
     "custom_blocks",
     "custom_html",
-    // Linting
     "lint",
     "reformat",
     "statistics",
@@ -41,7 +38,6 @@ const KEY_ORDER: &[&str] = &[
     "ignore_blocks",
     "ignore",
     "per_file_ignores",
-    // Output
     "quiet",
 ];
 

--- a/pyproject-fmt/rust/src/docformatter.rs
+++ b/pyproject-fmt/rust/src/docformatter.rs
@@ -1,6 +1,5 @@
 use common::table::{reorder_table_keys, Tables};
 
-// Group: behavior → format width → wrap → other.
 const KEY_ORDER: &[&str] = &[
     "",
     "in-place",

--- a/pyproject-fmt/rust/src/global.rs
+++ b/pyproject-fmt/rust/src/global.rs
@@ -9,7 +9,6 @@ pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables, root_table_spacing
             "build-system",
             "project",
             "dependency-groups",
-            // Build backends
             "tool.poetry",
             "tool.poetry-dynamic-versioning",
             "tool.pdm",
@@ -26,10 +25,8 @@ pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables, root_table_spacing
             "tool.py-build-cmake",
             "tool.sphinx-theme-builder",
             "tool.uv",
-            // Builders
             "tool.cibuildwheel",
             "tool.nuitka",
-            // Formatters and linters
             "tool.autopep8",
             "tool.black",
             "tool.yapf",
@@ -54,22 +51,18 @@ pub fn reorder_tables(root_ast: &SyntaxNode, tables: &Tables, root_table_spacing
             "tool.pyproject-fmt",
             "tool.typos",
             "tool.bandit",
-            // Type checking
             "tool.mypy",
             "tool.pyrefly",
             "tool.pyright",
             "tool.ty",
             "tool.django-stubs",
-            // Testing
             "tool.pytest",
             "tool.pytest_env",
             "tool.pytest-enabler",
             "tool.coverage",
-            // Runners
             "tool.doit",
             "tool.spin",
             "tool.tox",
-            // Releasers/bumpers
             "tool.bumpversion",
             "tool.commitizen",
             "tool.jupyter-releaser",

--- a/pyproject-fmt/rust/src/hatch.rs
+++ b/pyproject-fmt/rust/src/hatch.rs
@@ -3,12 +3,10 @@ use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 use tombi_syntax::SyntaxElement;
 
-// Config lives in sub-tables, so KEY_ORDER works on the collapsed parent's dotted keys
-// (version.source, build.exclude, envs.default.dependencies). Order within each group
-// follows the hatch reference (https://hatch.pypa.io).
+// Config lives in sub-tables, so KEY_ORDER targets the collapsed parent's dotted keys (version.source,
+// build.exclude, envs.default.dependencies); group order follows the hatch reference (https://hatch.pypa.io).
 const KEY_ORDER: &[&str] = &[
     "",
-    // === Version ===
     "version.source",
     "version.path",
     "version.pattern",
@@ -18,12 +16,10 @@ const KEY_ORDER: &[&str] = &[
     "version.fallback-version",
     "version.raw-options",
     "version",
-    // === Metadata ===
     "metadata.allow-direct-references",
     "metadata.allow-ambiguous-features",
     "metadata.hooks",
     "metadata",
-    // === Build ===
     "build.dev-mode-dirs",
     "build.dev-mode-exact",
     "build.directory",
@@ -58,19 +54,16 @@ const KEY_ORDER: &[&str] = &[
     "build.targets.custom",
     "build.targets",
     "build",
-    // === Publish ===
     "publish.index.disable",
     "publish.index.repos",
     "publish.index",
     "publish",
-    // === Workspace ===
     "workspace.members",
     "workspace.exclude",
     "workspace",
-    // `envs` intentionally NOT here — per-env entries are inserted dynamically by
-    // build_key_order with each environment's full inner key list, then a bare `envs`
-    // catch-all is appended last so any envs.* not in the canonical inner-key list still
-    // ends up in the envs block.
+    // `envs` intentionally NOT here: build_key_order inserts per-env entries dynamically with each environment's
+    // full inner key list, then appends a bare `envs` catch-all last so any envs.* outside the canonical inner-key
+    // list still lands in the envs block.
 ];
 
 const SORT_ARRAYS_EXACT: &[&str] = &[
@@ -118,8 +111,6 @@ fn fix_root(tables: &mut Tables) {
     reorder_table_keys(table, &refs);
 }
 
-/// Build a per-input KEY_ORDER that interpolates per-env entries so each environment
-/// keeps a consistent inner order (`type` → `python` → `dependencies` → `scripts` → …).
 fn build_key_order(table: &[SyntaxElement]) -> Vec<String> {
     let mut order: Vec<String> = KEY_ORDER.iter().map(|s| (*s).to_string()).collect();
     for env in collect_dynamic_segments(table, "envs") {
@@ -154,7 +145,6 @@ fn build_key_order(table: &[SyntaxElement]) -> Vec<String> {
         }
         order.push(p);
     }
-    // Bare catch-all for any envs.* keys not in the canonical inner-key list.
     order.push(String::from("envs"));
     order
 }
@@ -182,8 +172,7 @@ fn collect_dynamic_segments(table: &[SyntaxElement], prefix: &str) -> Vec<String
 }
 
 fn is_dynamic_sort_array(key: &str) -> bool {
-    // envs.<n>.dependencies, .extra-dependencies, .features, .pre-install-commands,
-    // .post-install-commands, .platforms — sortable (set semantics in hatch).
+    // These per-env arrays carry set semantics in hatch, so they sort.
     let Some(rest) = key.strip_prefix("envs.") else {
         return false;
     };
@@ -204,7 +193,6 @@ fn is_dynamic_sort_array(key: &str) -> bool {
 }
 
 fn fix_env_tables(tables: &mut Tables) {
-    // Expanded form: [tool.hatch.envs.<name>] as own table — reorder keys, sort arrays.
     let env_names = collect_header_segments(tables, "tool.hatch.envs.");
     for env in env_names {
         let key = format!("tool.hatch.envs.{env}");
@@ -258,7 +246,6 @@ fn fix_env_tables(tables: &mut Tables) {
                 ],
             );
         }
-        // scripts and env-vars sub-tables: alphabetize keys
         for sub in ["scripts", "env-vars"] {
             let k = format!("tool.hatch.envs.{env}.{sub}");
             if let Some(elements) = tables.get(&k) {
@@ -270,8 +257,7 @@ fn fix_env_tables(tables: &mut Tables) {
 }
 
 fn fix_overrides_aot(tables: &mut Tables) {
-    // [[tool.hatch.envs.<n>.matrix]] and overrides.* are AoT — preserve order, but reorder
-    // inner keys.
+    // matrix and overrides.* are AoT, so keep entry order and only reorder inner keys.
     for env in collect_header_segments(tables, "tool.hatch.envs.") {
         let matrix_key = format!("tool.hatch.envs.{env}.matrix");
         if let Some(entries) = tables.get(&matrix_key) {

--- a/pyproject-fmt/rust/src/interrogate.rs
+++ b/pyproject-fmt/rust/src/interrogate.rs
@@ -2,7 +2,6 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// Group: threshold → ignore flags → exclude → output.
 const KEY_ORDER: &[&str] = &[
     "",
     "fail-under",

--- a/pyproject-fmt/rust/src/isort.rs
+++ b/pyproject-fmt/rust/src/isort.rs
@@ -2,18 +2,16 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// profile leads since it sets defaults everything else overrides. sections, force_to_top,
-// and import_heading_* keep their input order, which drives output section sequencing.
+// profile leads since it sets defaults everything else overrides; sections, force_to_top, and import_heading_* keep
+// their input order, which drives output section sequencing.
 const KEY_ORDER: &[&str] = &[
     "",
-    // Defaults / global
     "profile",
     "py_version",
     "atomic",
     "color_output",
     "quiet",
     "verbose",
-    // Output style
     "line_length",
     "wrap_length",
     "indent",
@@ -51,7 +49,6 @@ const KEY_ORDER: &[&str] = &[
     "float_to_top",
     "honor_noqa",
     "old_finders",
-    // Known sources
     "sections",
     "default_section",
     "no_lines_before",
@@ -63,11 +60,9 @@ const KEY_ORDER: &[&str] = &[
     "known_other",
     "namespace_packages",
     "known_pattern",
-    // Forced separation
     "forced_separate",
     "treat_comments_as_code",
     "treat_all_comments_as_code",
-    // Skip / include
     "src_paths",
     "skip",
     "skip_glob",
@@ -76,28 +71,23 @@ const KEY_ORDER: &[&str] = &[
     "skip_gitignore",
     "supported_extensions",
     "blocked_extensions",
-    // Imports add/remove/required
     "add_imports",
     "remove_imports",
     "required_imports",
     "append_only",
     "dedup_headings",
-    // Section heading comments
     "section_comments",
     "import_heading_future",
     "import_heading_stdlib",
     "import_heading_thirdparty",
     "import_heading_firstparty",
     "import_heading_localfolder",
-    // Constants / variables
     "constants",
     "variables",
-    // Format / virtual envs / overrides
     "format_error",
     "format_success",
     "virtual_env",
     "conda_env",
-    // Output / cache
     "filter_files",
     "show_diff",
     "show_files",
@@ -106,8 +96,8 @@ const KEY_ORDER: &[&str] = &[
     "verbose_output",
 ];
 
-// Set-semantics arrays only; order-sensitive keys (sections, force_to_top, *_imports,
-// no_lines_before) are excluded because they define section sequencing.
+// Set-semantics arrays only; order-sensitive keys (sections, force_to_top, *_imports, no_lines_before) are excluded
+// because they define section sequencing.
 const SORT_ARRAYS: &[&str] = &[
     "known_standard_library",
     "extra_standard_library",

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -103,7 +103,6 @@ impl Settings {
     }
 }
 
-/// Configuration for table formatting behavior.
 pub struct TableFormatConfig {
     pub default_collapse: bool,
     pub expand_tables: HashSet<String>,
@@ -154,7 +153,6 @@ fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
     py.detach(|| format_toml(content, opt))
 }
 
-/// Format toml file
 #[must_use]
 pub fn format_toml(content: &str, opt: &Settings) -> String {
     common::disabled::with_disabled_keys(content, |content| format_core(content, opt))
@@ -229,12 +227,9 @@ fn format_core(content: &str, opt: &Settings) -> String {
     ty::fix(&mut tables);
     coverage::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
-    // Inline-table reordering runs AFTER reorder_tables so that AoT entries collapsed
-    // to inline arrays of inline tables (e.g. [[tool.poetry.source]] → source = [{...}])
-    // are visible in root_ast as INLINE_TABLE descendants.
+    // Must follow reorder_tables: only then have AoT entries collapsed to inline arrays of inline tables
+    // (e.g. [[tool.poetry.source]] → source = [{...}]) and become INLINE_TABLE descendants of root_ast.
     poetry::reorder_inline_tables(&root_ast);
-    // mypy needs to walk the AST after AoT entries (`[[tool.mypy.overrides]]`) collapse
-    // into inline-array form via reorder_tables.
     mypy::reorder_inline_tables(&root_ast);
     setuptools::reorder_inline_tables(&root_ast);
     tox::reorder_inline_tables(&root_ast);
@@ -266,13 +261,11 @@ fn remove_blank_lines_between_same_group_tables(content: &str, multi_level_prefi
     let mut result = Vec::new();
 
     for i in 0..lines.len() {
-        // Check if this is a blank line between two table headers in the same group
         if lines[i].is_empty() && i > 0 && i + 1 < lines.len() {
             let trimmed_next = lines[i + 1].trim();
             let next_is_table = trimmed_next.starts_with('[');
 
             if next_is_table {
-                // Look backwards to find the previous table header
                 let mut prev_table_name = None;
                 for j in (0..i).rev() {
                     if let Some(name) = extract_any_table_name(lines[j]) {
@@ -288,7 +281,6 @@ fn remove_blank_lines_between_same_group_tables(content: &str, multi_level_prefi
                     let next_key = get_table_key(&next, multi_level_prefixes);
 
                     if prev_key == next_key {
-                        // Same group - skip this blank line
                         continue;
                     }
                 }
@@ -299,7 +291,6 @@ fn remove_blank_lines_between_same_group_tables(content: &str, multi_level_prefi
     }
 
     let mut output = result.join("\n");
-    // Preserve trailing newline if original content had one
     if content.ends_with('\n') && !output.ends_with('\n') {
         output.push('\n');
     }

--- a/pyproject-fmt/rust/src/maturin.rs
+++ b/pyproject-fmt/rust/src/maturin.rs
@@ -4,13 +4,11 @@ use lexical_sort::natural_lexical_cmp;
 
 const KEY_ORDER: &[&str] = &[
     "",
-    // Module identity
     "module-name",
     "bindings",
     "python-source",
     "python-packages",
     "python-bin-path",
-    // Source layout
     "src",
     "manifest-path",
     "include",
@@ -18,7 +16,6 @@ const KEY_ORDER: &[&str] = &[
     "sdist-include",
     "sdist-generator",
     "data",
-    // Cargo
     "features",
     "no-default-features",
     "all-features",
@@ -28,7 +25,6 @@ const KEY_ORDER: &[&str] = &[
     "profile",
     "target",
     "target-dir",
-    // Compatibility / strip
     "compatibility",
     "auditwheel",
     "skip-auditwheel",
@@ -37,7 +33,6 @@ const KEY_ORDER: &[&str] = &[
     "locked",
     "offline",
     "zig",
-    // Behavior
     "use-cross",
 ];
 

--- a/pyproject-fmt/rust/src/mypy.rs
+++ b/pyproject-fmt/rust/src/mypy.rs
@@ -7,7 +7,6 @@ use tombi_syntax::SyntaxNode;
 // Grouped to match the section structure of the official mypy config reference.
 const KEY_ORDER: &[&str] = &[
     "",
-    // 1. Import discovery
     "mypy_path",
     "files",
     "modules",
@@ -23,29 +22,24 @@ const KEY_ORDER: &[&str] = &[
     "python_executable",
     "no_site_packages",
     "no_silence_site_packages",
-    // 2. Platform configuration
     "python_version",
     "platform",
     "always_true",
     "always_false",
-    // 3. Disallow dynamic typing
     "disallow_any_unimported",
     "disallow_any_expr",
     "disallow_any_decorated",
     "disallow_any_explicit",
     "disallow_any_generics",
     "disallow_subclassing_any",
-    // 4. Untyped definitions and calls
     "disallow_untyped_calls",
     "untyped_calls_exclude",
     "disallow_untyped_defs",
     "disallow_incomplete_defs",
     "check_untyped_defs",
     "disallow_untyped_decorators",
-    // 5. None and Optional handling
     "implicit_optional",
     "strict_optional",
-    // 6. Configuring warnings
     "warn_redundant_casts",
     "warn_unused_ignores",
     "warn_no_return",
@@ -53,9 +47,7 @@ const KEY_ORDER: &[&str] = &[
     "warn_unreachable",
     "deprecated_calls_exclude",
     "report_deprecated_as_note",
-    // 7. Suppressing errors
     "ignore_errors",
-    // 8. Miscellaneous strictness flags (strict meta-flag last)
     "allow_untyped_globals",
     "allow_redefinition",
     "allow_redefinition_new",
@@ -70,7 +62,6 @@ const KEY_ORDER: &[&str] = &[
     "strict_equality_for_none",
     "strict_bytes",
     "strict",
-    // 9. Configuring error messages
     "show_error_context",
     "show_column_numbers",
     "show_error_end",
@@ -80,14 +71,12 @@ const KEY_ORDER: &[&str] = &[
     "color_output",
     "error_summary",
     "show_absolute_path",
-    // 10. Incremental mode
     "incremental",
     "cache_dir",
     "sqlite_cache",
     "cache_fine_grained",
     "skip_version_check",
     "skip_cache_mtime_checks",
-    // 11. Advanced options
     "plugins",
     "pdb",
     "show_traceback",
@@ -96,7 +85,6 @@ const KEY_ORDER: &[&str] = &[
     "custom_typeshed_dir",
     "warn_incomplete_stub",
     "native_parser",
-    // 12. Report generation
     "any_exprs_report",
     "cobertura_xml_report",
     "html_report",
@@ -107,53 +95,43 @@ const KEY_ORDER: &[&str] = &[
     "xml_report",
     "xslt_html_report",
     "xslt_txt_report",
-    // 13. Miscellaneous
     "junit_xml",
     "junit_format",
     "scripts_are_modules",
     "warn_unused_configs",
     "verbosity",
-    // 14. Overrides (AoT or inline-array of inline tables) — always last
     "overrides",
 ];
 
-// module is required, so it leads; the rest mirror the parent groupings, restricted to
-// the per-module-overridable subset.
+// module is required, so it leads; the rest mirror the parent groupings, restricted to the per-module-overridable
+// subset.
 const OVERRIDES_KEY_ORDER: &[&str] = &[
     "",
     "module",
-    // Import behavior
     "ignore_missing_imports",
     "follow_untyped_imports",
     "follow_imports",
     "follow_imports_for_stubs",
-    // Platform truthy/falsy markers
     "always_true",
     "always_false",
-    // Disallow dynamic typing
     "disallow_any_unimported",
     "disallow_any_expr",
     "disallow_any_decorated",
     "disallow_any_explicit",
     "disallow_any_generics",
     "disallow_subclassing_any",
-    // Untyped defs and calls
     "disallow_untyped_calls",
     "disallow_untyped_defs",
     "disallow_incomplete_defs",
     "check_untyped_defs",
     "disallow_untyped_decorators",
-    // None and Optional
     "implicit_optional",
     "strict_optional",
-    // Warnings
     "warn_unused_ignores",
     "warn_no_return",
     "warn_return_any",
     "warn_unreachable",
-    // Suppression
     "ignore_errors",
-    // Misc strictness
     "allow_untyped_globals",
     "allow_redefinition",
     "allow_redefinition_old",
@@ -226,10 +204,9 @@ fn fix_expanded_overrides(tables: &mut Tables) {
     }
 }
 
-// Discriminator chosen to avoid collisions: `disable_error_code` and `enable_error_code`
-// are mypy-specific in pyproject.toml; `module` alone would risk matching unrelated
-// inline tables. Several discriminators map to the same OVERRIDES_KEY_ORDER so an entry
-// with only `module` + `ignore_missing_imports` (for example) is still recognized.
+// Discriminators avoid collisions: `disable_error_code` and `enable_error_code` are mypy-specific in pyproject.toml,
+// while `module` alone could match unrelated inline tables. Several discriminators map to the same OVERRIDES_KEY_ORDER,
+// so an entry with only `module` + `ignore_missing_imports` is still recognized.
 pub const INLINE_TABLE_SCHEMAS: &[InlineTableSchema] = &[
     InlineTableSchema {
         discriminator: "disable_error_code",
@@ -270,10 +247,9 @@ pub fn reorder_inline_tables(root_ast: &SyntaxNode) {
     sort_arrays_inside_overrides(root_ast);
 }
 
-/// When `[[tool.mypy.overrides]]` is collapsed into `overrides = [ {...}, {...} ]`, the
-/// arrays inside each inline entry (e.g. `disable_error_code = ["x", "y"]`) live inside
-/// values, not table entries — `for_entries` on the parent table won't see them. Walk the
-/// AST under the `overrides` key and sort the known array-of-string fields in-place.
+/// When `[[tool.mypy.overrides]]` collapses into `overrides = [ {...}, {...} ]`, the arrays inside each inline entry
+/// (e.g. `disable_error_code = ["x", "y"]`) live inside values, so `for_entries` on the parent table misses them.
+/// Walk the AST under the `overrides` key and sort the known array-of-string fields in place.
 fn sort_arrays_inside_overrides(root_ast: &SyntaxNode) {
     for kv in root_ast.descendants().filter(|n| n.kind() == KEY_VALUE) {
         let Some(keys) = kv.children().find(|c| c.kind() == KEYS) else {
@@ -281,8 +257,7 @@ fn sort_arrays_inside_overrides(root_ast: &SyntaxNode) {
         };
         let key_text = keys.text().to_string();
         let key_trim = key_text.trim();
-        // Match either `overrides = [...]` (within `[tool.mypy]`) or
-        // `mypy.overrides = [...]` (when collapsed under tool).
+        // Match `overrides = [...]` (within `[tool.mypy]`) or `mypy.overrides = [...]` (when collapsed under tool).
         if !(key_trim == "overrides" || key_trim.ends_with(".overrides")) {
             continue;
         }
@@ -290,8 +265,8 @@ fn sort_arrays_inside_overrides(root_ast: &SyntaxNode) {
             continue;
         };
         for inline in array.descendants().filter(|n| n.kind() == INLINE_TABLE) {
-            // INLINE_TABLE children are wrapped in KEY_VALUE_WITH_COMMA_GROUP — use
-            // descendants() to reach KEY_VALUE nodes regardless of nesting depth.
+            // INLINE_TABLE children sit inside KEY_VALUE_WITH_COMMA_GROUP, so descendants() reaches KEY_VALUE nodes
+            // at any nesting depth.
             for inner_kv in inline.descendants().filter(|n| n.kind() == KEY_VALUE) {
                 let Some(inner_keys) = inner_kv.children().find(|c| c.kind() == KEYS) else {
                     continue;

--- a/pyproject-fmt/rust/src/pdm.rs
+++ b/pyproject-fmt/rust/src/pdm.rs
@@ -5,17 +5,14 @@ use lexical_sort::natural_lexical_cmp;
 // Sub-tables collapse to dotted keys (version.source, build.includes, etc.).
 const KEY_ORDER: &[&str] = &[
     "",
-    // Distribution / project mode
     "distribution",
     "package-type",
     "plugins",
-    // Resolution
     "resolution.respect-source-order",
     "resolution.allow-prereleases",
     "resolution.excludes",
     "resolution.overrides",
     "resolution",
-    // Version (collapsed sub-table)
     "version.source",
     "version.path",
     "version.getter",
@@ -26,7 +23,6 @@ const KEY_ORDER: &[&str] = &[
     "version.fallback_version",
     "version.version_format",
     "version",
-    // Build (collapsed sub-table)
     "build.includes",
     "build.excludes",
     "build.source-includes",
@@ -36,20 +32,15 @@ const KEY_ORDER: &[&str] = &[
     "build.custom-hook",
     "build.editable-backend",
     "build",
-    // Scripts
     "scripts",
-    // Sources (legacy non-AoT form)
     "source",
-    // Dev / dependency groups
     "dev-dependencies",
-    // Publish
     "publish.repository",
     "publish.username",
     "publish.password",
     "publish.ca_certs",
     "publish.verify_ssl",
     "publish",
-    // Options
     "options.install",
     "options.lock",
     "options.update",

--- a/pyproject-fmt/rust/src/poetry.rs
+++ b/pyproject-fmt/rust/src/poetry.rs
@@ -3,35 +3,29 @@ use common::table::{for_entries, reorder_inline_table_keys, reorder_table_keys, 
 use lexical_sort::natural_lexical_cmp;
 use tombi_syntax::SyntaxNode;
 
-// Sub-table prefixes are appended dynamically because some (group.<name>.*) need
-// per-instance entries to control inner key order.
+// Sub-table prefixes are appended dynamically because some (group.<name>.*) need per-instance entries to control
+// inner key order.
 const TOP_LEVEL_ORDER: &[&str] = &[
     "",
-    // Identity
     "name",
     "version",
     "description",
     "package-mode",
-    // License & authorship
     "license",
     "authors",
     "maintainers",
-    // Documentation
     "readme",
     "homepage",
     "repository",
     "documentation",
-    // Discovery
     "keywords",
     "classifiers",
-    // Packaging contents
     "packages",
     "include",
     "exclude",
 ];
 
-// Order for [[tool.poetry.source]] entries (AoT, kept as separate tables). Deprecated
-// keys (default, secondary) are placed last so we don't promote them above current keys.
+// Deprecated source keys (default, secondary) sort last so reordering never promotes them above current keys.
 const SOURCE_KEY_ORDER: &[&str] = &[
     "",
     "name",
@@ -43,14 +37,12 @@ const SOURCE_KEY_ORDER: &[&str] = &[
     "secondary",
 ];
 
-// Order for [tool.poetry.build] when expanded as its own table.
 const BUILD_KEY_ORDER: &[&str] = &["", "script", "generate-setup-file"];
 
-// Order for [tool.poetry.group.<name>] when expanded.
 const GROUP_KEY_ORDER: &[&str] = &["", "optional", "include-groups", "dependencies"];
 
-// Within [tool.poetry.dependencies] (and the per-group equivalents), "python" is the
-// interpreter constraint and conventionally comes first; everything else is sorted.
+// Within [tool.poetry.dependencies] (and the per-group equivalents), `python` is the interpreter constraint and
+// conventionally leads; everything else sorts.
 const DEPENDENCIES_KEY_ORDER: &[&str] = &["", "python"];
 
 pub fn fix(tables: &mut Tables) {
@@ -59,10 +51,9 @@ pub fn fix(tables: &mut Tables) {
     fix_source(tables);
 }
 
-// Inline-table key order for things that get collapsed to inline form. Discriminators are
-// chosen to be Poetry-specific (priority/links/indexed/secondary only appear on sources;
-// git/path/file only on dependencies), to avoid colliding with inline tables in other
-// `[tool.*]` sections that happen to share generic keys like `name` or `url`.
+// Inline-table key order for specs collapsed to inline form. Discriminators are Poetry-specific
+// (priority/links/indexed/secondary appear only on sources; git/path/file only on dependencies) to avoid colliding
+// with inline tables in other `[tool.*]` sections that share generic keys like `name` or `url`.
 const SOURCE_INLINE_KEYS: &[&str] = &["name", "url", "priority", "links", "indexed", "default", "secondary"];
 
 const GIT_DEP_INLINE_KEYS: &[&str] = &[
@@ -199,7 +190,6 @@ fn is_sort_value_array(key: &str) -> bool {
     false
 }
 
-/// Matches `<pkg>.extras` where `<pkg>` has no further dots.
 fn is_dep_extras(s: &str) -> bool {
     let Some((_pkg, tail)) = split_first_segment(s) else {
         return false;
@@ -214,19 +204,16 @@ fn split_first_segment(s: &str) -> Option<(&str, &str)> {
 fn build_root_key_order(table: &[tombi_syntax::SyntaxElement]) -> Vec<String> {
     let mut order: Vec<String> = TOP_LEVEL_ORDER.iter().map(|s| (*s).to_string()).collect();
 
-    // `build` may appear as a scalar (build = "build.py"), an inline-table key, or via
-    // dotted sub-keys (build.script, build.generate-setup-file). The "build" prefix
-    // entry catches all those.
+    // `build` may appear as a scalar (build = "build.py"), an inline-table key, or via dotted sub-keys
+    // (build.script, build.generate-setup-file); the `build` prefix entry catches every form.
     order.push(String::from("build.script"));
     order.push(String::from("build.generate-setup-file"));
     order.push(String::from("build"));
 
-    // Dependencies: python first, then alphabetized.
     order.push(String::from("dependencies.python"));
     order.push(String::from("dependencies"));
     order.push(String::from("dev-dependencies"));
 
-    // Per-group ordering: optional, include-groups, dependencies (python first inside).
     let group_names = collect_dotted_segment(table, "group");
     for group in &group_names {
         order.push(format!("group.{group}.optional"));
@@ -248,7 +235,6 @@ fn build_root_key_order(table: &[tombi_syntax::SyntaxElement]) -> Vec<String> {
     order
 }
 
-/// Distinct first segments following a dotted prefix (prefix "group" → ["dev", "test"]).
 fn collect_dotted_segment(table: &[tombi_syntax::SyntaxElement], prefix: &str) -> Vec<String> {
     use tombi_syntax::SyntaxKind::{KEYS, KEY_VALUE};
     let prefix_dot = format!("{prefix}.");
@@ -278,8 +264,7 @@ fn unquote(s: &str) -> &str {
 }
 
 fn fix_expanded_sub_tables(tables: &mut Tables) {
-    // When the user runs with `table_format = "long"` (no collapse), sub-tables remain
-    // as their own headers. Apply per-table normalization in that case.
+    // In `table_format = "long"` mode sub-tables stay as their own headers, so normalize each one here.
     fix_expanded_dependencies(tables, "tool.poetry.dependencies");
     fix_expanded_dependencies(tables, "tool.poetry.dev-dependencies");
     fix_expanded_dependencies(tables, "tool.poetry.requires-plugins");
@@ -297,9 +282,6 @@ fn fix_expanded_dependencies(tables: &mut Tables, table_key: &str) {
         return;
     };
     let table = &mut elements.first().unwrap().borrow_mut();
-    // Entries here are package names (`fastapi`, `requests`, …) mapped to either a version
-    // string or an inline-table dep spec. The InlineTableSchema set handles the inline-
-    // table key order; here we just promote `python` to the top via DEPENDENCIES_KEY_ORDER.
     reorder_table_keys(table, DEPENDENCIES_KEY_ORDER);
 }
 
@@ -372,7 +354,6 @@ fn fix_source(tables: &mut Tables) {
     }
 }
 
-/// Immediate next segment of every header under `prefix` (group. headers → ["dev", "test"]).
 fn collect_header_segments(tables: &Tables, prefix: &str) -> Vec<String> {
     let mut names: Vec<String> = tables
         .header_to_pos

--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -325,7 +325,6 @@ fn generate_classifiers_to_entry(
                                         break;
                                     }
                                     if v.kind() == COMMA {
-                                        // Keep the comma, remove whitespace/newline after it
                                         truncate_at = fwd_idx + 1;
                                         break;
                                     }

--- a/pyproject-fmt/rust/src/pylint.rs
+++ b/pyproject-fmt/rust/src/pylint.rs
@@ -2,8 +2,8 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// Sub-table order follows the pylint docs (main → messages_control → category checks);
-// keys within each sub-table alphabetize, since a hand-curated full order would rot.
+// Sub-table order follows the pylint docs (main → messages_control → category checks); keys within each sub-table
+// alphabetize, since a hand-curated full order would rot.
 const KEY_ORDER: &[&str] = &[
     "",
     "main",

--- a/pyproject-fmt/rust/src/pyrefly.rs
+++ b/pyproject-fmt/rust/src/pyrefly.rs
@@ -2,7 +2,6 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// Group: platform → paths → behavior → errors.
 const KEY_ORDER: &[&str] = &[
     "",
     "python_version",

--- a/pyproject-fmt/rust/src/pyright.rs
+++ b/pyproject-fmt/rust/src/pyright.rs
@@ -6,7 +6,6 @@ use tombi_syntax::SyntaxElement;
 // Shared schema for [tool.pyright] and [tool.basedpyright].
 const KEY_ORDER_PRE_REPORTS: &[&str] = &[
     "",
-    // Platform / interpreter
     "pythonVersion",
     "pythonPlatform",
     "pythonPath",
@@ -14,17 +13,14 @@ const KEY_ORDER_PRE_REPORTS: &[&str] = &[
     "venvPath",
     "typeshedPath",
     "stubPath",
-    // Mode flags
     "typeCheckingMode",
     "strict",
     "failOnWarnings",
     "useLibraryCodeForTypes",
-    // Paths
     "include",
     "exclude",
     "ignore",
     "extraPaths",
-    // Strict-flavor toggles
     "strictListInference",
     "strictDictionaryInference",
     "strictSetInference",
@@ -34,7 +30,6 @@ const KEY_ORDER_PRE_REPORTS: &[&str] = &[
     "analyzeUnannotatedFunctions",
     "disableBytesTypePromotions",
     "deprecateTypingAliases",
-    // Constants
     "defineConstant",
 ];
 
@@ -67,10 +62,8 @@ fn fix_one(tables: &mut Tables, table_name: &str) {
     reorder_table_keys(table, &refs);
 }
 
-/// Build a per-input KEY_ORDER. Pre-report keys are static; report* rules are collected
-/// from the input table and inserted alphabetized between the static blocks. This handles
-/// pyright's 70+ diagnostic rules plus any basedpyright extensions without hardcoding
-/// the full list (which evolves between releases).
+/// report* rules are collected from the input and inserted alphabetized between the static pre/post blocks, so
+/// pyright's 70+ diagnostic rules and any basedpyright extensions need no hardcoded list (it evolves between releases).
 fn build_key_order(table: &[SyntaxElement]) -> Vec<String> {
     use tombi_syntax::SyntaxKind::{KEYS, KEY_VALUE};
     let mut order: Vec<String> = KEY_ORDER_PRE_REPORTS.iter().map(|s| (*s).to_string()).collect();

--- a/pyproject-fmt/rust/src/pytest.rs
+++ b/pyproject-fmt/rust/src/pytest.rs
@@ -2,14 +2,12 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// Keys carry the ini_options. prefix: after collapse every key shows up as
-// ini_options.<name> under tool.pytest, its only standardized child.
+// Keys carry the ini_options. prefix: after collapse every key appears as ini_options.<name> under tool.pytest, its
+// only standardized child.
 const KEY_ORDER: &[&str] = &[
     "",
-    // pytest itself
     "ini_options.minversion",
     "ini_options.required_plugins",
-    // Discovery
     "ini_options.testpaths",
     "ini_options.pythonpath",
     "ini_options.norecursedirs",
@@ -21,55 +19,43 @@ const KEY_ORDER: &[&str] = &[
     "ini_options.consider_namespace_packages",
     "ini_options.confcutdir",
     "ini_options.rootdir_fallback",
-    // CLI arguments (preserved — order matters)
     "ini_options.addopts",
     "ini_options.usefixtures",
-    // Markers / parametrize / xfail
     "ini_options.markers",
     "ini_options.empty_parameter_set_mark",
     "ini_options.xfail_strict",
     "ini_options.disable_test_id_escaping_and_forfeit_all_rights_to_community_support",
-    // Warnings
     "ini_options.filterwarnings",
-    // Doctest
     "ini_options.doctest_encoding",
     "ini_options.doctest_optionflags",
-    // Output style
     "ini_options.console_output_style",
     "ini_options.verbosity_assertions",
     "ini_options.verbosity_test_cases",
     "ini_options.truncation_limit_chars",
     "ini_options.truncation_limit_lines",
-    // Logging — capture
     "ini_options.log_auto_indent",
     "ini_options.log_format",
     "ini_options.log_date_format",
     "ini_options.log_level",
-    // Logging — cli
     "ini_options.log_cli",
     "ini_options.log_cli_level",
     "ini_options.log_cli_format",
     "ini_options.log_cli_date_format",
-    // Logging — file
     "ini_options.log_file",
     "ini_options.log_file_level",
     "ini_options.log_file_format",
     "ini_options.log_file_mode",
     "ini_options.log_file_date_format",
-    // JUnit XML
     "ini_options.junit_suite_name",
     "ini_options.junit_family",
     "ini_options.junit_duration_report",
     "ini_options.junit_log_passing_tests",
     "ini_options.junit_logging",
-    // Cache / tmp_path
     "ini_options.cache_dir",
     "ini_options.tmp_path_retention_count",
     "ini_options.tmp_path_retention_policy",
-    // Assertion / faulthandler
     "ini_options.enable_assertion_pass_hook",
     "ini_options.faulthandler_timeout",
-    // Catch-all for any other ini_options
     "ini_options",
 ];
 

--- a/pyproject-fmt/rust/src/scikit_build.rs
+++ b/pyproject-fmt/rust/src/scikit_build.rs
@@ -4,31 +4,23 @@ use lexical_sort::natural_lexical_cmp;
 
 const KEY_ORDER: &[&str] = &[
     "",
-    // top-level
     "minimum-version",
     "build-dir",
     "fail",
     "experimental",
     "strict-config",
-    // build
     "build",
-    // cmake
     "cmake",
     "ninja",
-    // distribution
     "sdist",
     "wheel",
     "install",
     "editable",
-    // logging / messages
     "logging",
     "messages",
-    // metadata
     "metadata",
     "search",
-    // generate (AoT)
     "generate",
-    // overrides (AoT)
     "overrides",
 ];
 

--- a/pyproject-fmt/rust/src/semantic_release.rs
+++ b/pyproject-fmt/rust/src/semantic_release.rs
@@ -2,8 +2,6 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// Group: tag/version → assets → version source → repo → commit parser → branches →
-// publish → changelog → remote.
 const KEY_ORDER: &[&str] = &[
     "",
     "tag_format",

--- a/pyproject-fmt/rust/src/setuptools.rs
+++ b/pyproject-fmt/rust/src/setuptools.rs
@@ -3,11 +3,10 @@ use common::table::{for_entries, reorder_inline_table_keys, reorder_table_keys, 
 use lexical_sort::natural_lexical_cmp;
 use tombi_syntax::SyntaxNode;
 
-// Sub-tables collapse to dotted keys (packages.find.where, package-data."*", etc.); the
-// "packages" prefix catches them all, with finer entries added for inner ordering.
+// Sub-tables collapse to dotted keys (packages.find.where, package-data."*", etc.); the "packages" prefix catches
+// them all, with finer entries added for inner ordering.
 const KEY_ORDER: &[&str] = &[
     "",
-    // --- Packaging discovery ---
     "py-modules",
     "packages.find.where",
     "packages.find.include",
@@ -19,23 +18,17 @@ const KEY_ORDER: &[&str] = &[
     "packages.find-namespace.namespaces",
     "packages",
     "package-dir",
-    // --- Package data ---
     "include-package-data",
     "package-data",
     "exclude-package-data",
-    // --- Dynamic metadata ---
     "dynamic",
-    // --- Extensions / build customization ---
     "ext-modules",
     "cmdclass",
-    // --- Distribution metadata ---
     "platforms",
     "provides",
     "obsoletes",
     "license-files",
-    // --- Discouraged / legacy data files ---
     "data-files",
-    // --- Deprecated / obsolete (pushed last) ---
     "script-files",
     "namespace-packages",
     "zip-safe",
@@ -43,8 +36,8 @@ const KEY_ORDER: &[&str] = &[
     "dependency-links",
 ];
 
-// Safe-to-sort arrays only; packages, license-files, and ext-module paths/argv are left
-// out — order affects build, link, or PEP-639 concatenation.
+// Safe-to-sort arrays only; packages, license-files, and ext-module paths/argv are left out because order affects
+// build, link, or PEP-639 concatenation.
 const TOP_LEVEL_SORT_ARRAYS: &[&str] = &[
     "py-modules",
     "platforms",
@@ -61,31 +54,25 @@ const TOP_LEVEL_SORT_ARRAYS: &[&str] = &[
 
 const SCM_KEY_ORDER: &[&str] = &[
     "",
-    // --- Version output ---
     "version_file",
     "version_file_template",
-    // --- Version computation / scheme ---
     "version_scheme",
     "local_scheme",
     "version_cls",
     "normalize",
-    // --- Root / discovery ---
     "root",
     "relative_to",
     "fallback_root",
     "parent",
     "search_parent_directories",
     "dist_name",
-    // --- Tag / parse ---
     "tag_regex",
     "parse",
     "parentdir_prefix_version",
     "fallback_version",
-    // --- Nested SCM-specific tables (collapse to dotted keys) ---
     "scm.git.pre_parse",
     "scm.git.describe_command",
     "scm",
-    // --- Deprecated (push last) ---
     "git_describe_command",
     "write_to",
     "write_to_template",
@@ -197,8 +184,8 @@ fn fix_expanded_alpha_table(tables: &mut Tables, table_key: &str) {
     reorder_table_keys(table, &[""]);
 }
 
-// Discriminators attr/content-type are unique to dynamic directives; file is too generic
-// to discriminate on, so it is omitted from the discriminator set.
+// Discriminators attr/content-type are unique to dynamic directives; file is too generic, so it is omitted from the
+// discriminator set.
 const DYNAMIC_DIRECTIVE_ORDER: &[&str] = &["attr", "file", "content-type"];
 
 pub const INLINE_TABLE_SCHEMAS: &[InlineTableSchema] = &[

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -111,7 +111,6 @@ fn test_format_toml_scripts() {
     "#);
 }
 
-/// Test expand_tables with main table
 #[test]
 fn test_expand_tables_with_project() {
     let start = indoc! {r#"
@@ -137,7 +136,6 @@ fn test_expand_tables_with_project() {
     "#);
 }
 
-/// Test collapse_tables with project.authors
 #[test]
 fn test_collapse_project_authors() {
     let start = indoc! {r#"
@@ -159,7 +157,6 @@ fn test_collapse_project_authors() {
     "#);
 }
 
-/// Test collapse_tables with project.maintainers
 #[test]
 fn test_collapse_project_maintainers() {
     let start = indoc! {r#"
@@ -181,7 +178,6 @@ fn test_collapse_project_maintainers() {
     "#);
 }
 
-/// Test table_format="long" with entry-points
 #[test]
 fn test_table_format_long_with_entry_points() {
     let start = indoc! {r#"
@@ -200,7 +196,6 @@ fn test_table_format_long_with_entry_points() {
     "#);
 }
 
-/// Test expand_tables with project.authors
 #[test]
 fn test_expand_project_authors() {
     let start = indoc! {r#"
@@ -230,7 +225,6 @@ fn test_expand_project_authors() {
     "#);
 }
 
-/// Test expand_tables with project.maintainers
 #[test]
 fn test_expand_project_maintainers() {
     let start = indoc! {r#"
@@ -260,7 +254,6 @@ fn test_expand_project_maintainers() {
     "#);
 }
 
-/// Test expand single author
 #[test]
 fn test_expand_single_author() {
     let start = indoc! {r#"
@@ -284,7 +277,6 @@ fn test_expand_single_author() {
     email = "john@example.com"
     "#);
 }
-/// Test collapse authors with custom url field (covers line 640 in project.rs)
 #[test]
 fn test_collapse_authors_with_url_field() {
     let start = indoc! {r#"
@@ -308,7 +300,6 @@ fn test_collapse_authors_with_url_field() {
     ]
     "#);
 }
-/// Test collapse empty authors (covers line 653 in project.rs)
 #[test]
 fn test_collapse_empty_authors() {
     let start = indoc! {r#"
@@ -328,7 +319,6 @@ fn test_collapse_empty_authors() {
     "#);
 }
 
-/// Test collapse authors when parent doesn't end with newline (covers line 664)
 #[test]
 fn test_collapse_authors_without_trailing_newline() {
     let start = "[project]\nname = \"test\"\n[[project.authors]]\nname = \"Alice\"\nemail = \"alice@example.com\"";
@@ -337,7 +327,6 @@ fn test_collapse_authors_without_trailing_newline() {
     assert!(got.contains("{ name = \"Alice\", email = \"alice@example.com\" }"));
 }
 
-/// Test collapse authors with compact parent table
 #[test]
 fn test_collapse_authors_compact_parent() {
     let start =
@@ -346,7 +335,6 @@ fn test_collapse_authors_compact_parent() {
     assert!(got.contains("authors = ["));
 }
 
-/// Test expand when authors already in array of tables format (covers line 686)
 #[test]
 fn test_expand_authors_already_expanded() {
     let start = indoc! {r#"
@@ -365,7 +353,6 @@ fn test_expand_authors_already_expanded() {
     assert!(got.contains("name = \"John Doe\""));
 }
 
-/// Test issue 146: expand_tables keeps specific sub-table expanded while others collapse
 #[test]
 fn test_issue_146_expand_specific_subtable() {
     let start = indoc! {r#"
@@ -393,7 +380,6 @@ fn test_issue_146_expand_specific_subtable() {
     assert!(got.contains("urls.homepage ="), "urls should be collapsed");
 }
 
-/// Test CSS-like specificity: more specific selector wins
 #[test]
 fn test_css_specificity_more_specific_wins() {
     let start = indoc! {r#"
@@ -422,7 +408,6 @@ fn test_css_specificity_more_specific_wins() {
     );
 }
 
-/// Test nested table specificity: project.entry-points.tox can be different from project.entry-points
 #[test]
 fn test_nested_table_specificity() {
     use crate::TableFormatConfig;
@@ -454,7 +439,6 @@ fn test_nested_table_specificity() {
     );
 }
 
-/// Test parent inheritance: sub-table inherits from parent setting
 #[test]
 fn test_parent_inheritance() {
     use crate::TableFormatConfig;
@@ -480,7 +464,6 @@ fn test_parent_inheritance() {
     );
 }
 
-/// Test that default_collapse is used when no specific setting exists
 #[test]
 fn test_default_collapse_fallback() {
     use crate::TableFormatConfig;
@@ -497,7 +480,6 @@ fn test_default_collapse_fallback() {
     assert!(config.should_collapse("tool.ruff.lint"));
 }
 
-/// Test issue 146 with deeply nested ruff table: expand_tables works for deep paths
 #[test]
 fn test_issue_146_deeply_nested_ruff_table() {
     let start = indoc! {r#"

--- a/pyproject-fmt/rust/src/tests/mypy_tests.rs
+++ b/pyproject-fmt/rust/src/tests/mypy_tests.rs
@@ -277,8 +277,8 @@ fn test_mypy_no_table_is_noop() {
 
 #[test]
 fn test_mypy_does_not_reorder_unrelated_inline_tables() {
-    // [[project.authors]] has `{ name, email }`. Our schemas key on mypy-specific
-    // discriminators, so authors must be untouched.
+    // [[project.authors]] has `{ name, email }`. Our schemas key on mypy-specific discriminators, so authors stay
+    // untouched.
     let start = indoc::indoc! {r#"
     [project]
     name = "demo"
@@ -358,7 +358,6 @@ fn test_mypy_long_format_overrides_expanded() {
         result.contains("[[tool.mypy.overrides]]"),
         "expected AoT preserved:\n{result}"
     );
-    // module first, then disable_error_code sorted
     let m = result.find("module = ").expect("module");
     let i = result
         .find("ignore_missing_imports = ")

--- a/pyproject-fmt/rust/src/tests/poetry_tests.rs
+++ b/pyproject-fmt/rust/src/tests/poetry_tests.rs
@@ -13,8 +13,8 @@ fn evaluate(start: &str) -> String {
     fix(&mut tables);
     let entries = collect_entries(&tables);
     root_ast.splice_children(0..count, entries);
-    // Inline-table reordering operates AST-wide, so run it after the root children have
-    // been restored from the table_set (mirrors what format_toml does in main.rs).
+    // Inline-table reordering operates AST-wide, so run it after the root children are restored from the table_set
+    // (mirrors what format_toml does in main.rs).
     reorder_inline_tables(&root_ast);
     ensure_all_arrays_multiline(&root_ast, 120);
     let result = format_syntax(root_ast, 120);
@@ -544,9 +544,8 @@ fn test_poetry_full_pipeline_idempotent() {
 
 #[test]
 fn test_poetry_does_not_reorder_unrelated_inline_tables() {
-    // [project.authors] uses `{ name, email }` inline tables. Our schemas key on
-    // poetry-specific discriminators (priority, git, path, file, etc.), so authors
-    // should be left untouched.
+    // [project.authors] uses `{ name, email }` inline tables. Our schemas key on poetry-specific discriminators
+    // (priority, git, path, file, etc.), so authors stay untouched.
     let start = indoc::indoc! {r#"
     [project]
     name = "demo"
@@ -569,7 +568,6 @@ fn test_poetry_long_format_dependencies_expanded() {
     alpha = "^2.0"
     "#};
     let result = evaluate_long(start);
-    // python first, then alphabetized
     assert!(
         result.contains("[tool.poetry.dependencies]"),
         "expected expanded form, got:\n{result}"
@@ -592,7 +590,6 @@ fn test_poetry_long_format_extras_expanded() {
         result.contains("[tool.poetry.extras]"),
         "expected expanded form, got:\n{result}"
     );
-    // Inner arrays alphabetized
     assert!(
         result.contains(r#"cli = [ "rich", "typer" ]"#),
         "cli sort failed:\n{result}"
@@ -633,7 +630,7 @@ fn test_poetry_long_format_urls_alphabetized() {
 
 #[test]
 fn test_poetry_long_format_plugins_unquoted_inner() {
-    // Unquoted plugin group names (no dots) — fix_expanded_plugins handles these.
+    // fix_expanded_plugins handles unquoted plugin group names (no dots).
     let start = indoc::indoc! {r#"
     [tool.poetry.plugins.console_scripts]
     zebra = "z:Z"
@@ -657,7 +654,6 @@ fn test_poetry_long_format_group_inner_order() {
     let opt_pos = result.find("optional = ").expect("optional");
     let inc_pos = result.find("include-groups = ").expect("include-groups");
     assert!(opt_pos < inc_pos, "group key order wrong:\n{result}");
-    // include-groups sorted
     assert!(
         result.contains(r#"include-groups = [ "docs", "lint", "test" ]"#),
         "include-groups not sorted:\n{result}"
@@ -693,7 +689,6 @@ fn test_poetry_long_format_source_aot_preserved() {
         result.contains("[[tool.poetry.source]]"),
         "expected AoT preserved, got:\n{result}"
     );
-    // name → url → priority
     let n = result.find("name = ").expect("name");
     let u = result.find("url = ").expect("url");
     let p = result.find("priority = ").expect("priority");
@@ -759,8 +754,6 @@ fn test_poetry_long_format_build_constraints_expanded() {
 
 #[test]
 fn test_poetry_long_format_plugins_top_alphabetized() {
-    // When there are multiple plugin groups, the parent plugins table's keys are
-    // ordered via fix_expanded_plugins.
     let start = indoc::indoc! {r#"
     [tool.poetry.plugins]
     zeta = "z:Z"

--- a/pyproject-fmt/rust/src/towncrier.rs
+++ b/pyproject-fmt/rust/src/towncrier.rs
@@ -4,12 +4,10 @@ use lexical_sort::natural_lexical_cmp;
 
 const KEY_ORDER: &[&str] = &[
     "",
-    // Package identity
     "name",
     "version",
     "package",
     "package_dir",
-    // News location
     "directory",
     "filename",
     "start_string",
@@ -17,16 +15,13 @@ const KEY_ORDER: &[&str] = &[
     "title_format",
     "issue_format",
     "underlines",
-    // Rendering
     "wrap",
     "all_bullets",
     "single_file",
     "orphan_prefix",
     "create_eof_newline",
     "create_add_extension",
-    // Behavior
     "ignore",
-    // AoT entries last
     "type",
     "section",
 ];

--- a/pyproject-fmt/rust/src/tox.rs
+++ b/pyproject-fmt/rust/src/tox.rs
@@ -1,24 +1,19 @@
 use common::table::Tables;
 use tombi_syntax::SyntaxNode;
 
-// Thin wrapper around the shared tox-toml-fmt rules — anything the standalone tox.toml
-// formatter knows (key aliases, root key order, per-env key order, requirement
-// normalization, env list sorting, inline-table reordering) applies identically to
-// `[tool.tox]` in pyproject.toml. We just pass the `"tool.tox"` prefix so the shared
-// functions look up tables under that namespace instead of at the root.
+// Delegates to the shared tox-toml-fmt rules; the `"tool.tox"` prefix resolves tables under that namespace instead of
+// the root, so `[tool.tox]` in pyproject.toml formats identically to a standalone tox.toml.
 const TOOL_TOX: &str = "tool.tox";
 
 pub fn fix(tables: &mut Tables) {
     if tables.get(TOOL_TOX).is_none() {
-        // Skip the work (and the env-table scans) when the project doesn't use tox.
         return;
     }
     _tox_toml_fmt::global::normalize_aliases_with_prefix(tables, TOOL_TOX);
     _tox_toml_fmt::global::fix_root_with_prefix(tables, TOOL_TOX);
     _tox_toml_fmt::global::fix_envs_with_prefix(tables, TOOL_TOX);
-    // `pin_envs` is a tox-toml-fmt Setting that doesn't surface in pyproject-fmt's CLI
-    // (matching what `[tool.tox]` users get from the standalone formatter without a
-    // pin_envs override).
+    // pin_envs is a tox-toml-fmt Setting with no pyproject-fmt CLI surface, so pass none, matching what standalone
+    // tox.toml users get without a pin_envs override.
     _tox_toml_fmt::global::sort_env_list_with_prefix(tables, &[], TOOL_TOX);
 }
 

--- a/pyproject-fmt/rust/src/ty.rs
+++ b/pyproject-fmt/rust/src/ty.rs
@@ -5,16 +5,11 @@ use lexical_sort::natural_lexical_cmp;
 // Pre-1.0 schema: keep the canonical set small, let unknown keys alphabetize.
 const KEY_ORDER: &[&str] = &[
     "",
-    // paths
     "src",
     "respect-ignore-files",
-    // environment
     "environment",
-    // rules
     "rules",
-    // terminal
     "terminal",
-    // overrides (AoT)
     "overrides",
 ];
 

--- a/pyproject-fmt/rust/src/vulture.rs
+++ b/pyproject-fmt/rust/src/vulture.rs
@@ -2,7 +2,6 @@ use common::array::sort_strings;
 use common::table::{for_entries, reorder_table_keys, Tables};
 use lexical_sort::natural_lexical_cmp;
 
-// Group: paths → ignore → behavior → output.
 const KEY_ORDER: &[&str] = &[
     "",
     "paths",

--- a/pyproject-fmt/rust/src/yapf.rs
+++ b/pyproject-fmt/rust/src/yapf.rs
@@ -1,7 +1,6 @@
 use common::table::{reorder_table_keys, Tables};
 
-// based_on_style sets defaults and column_limit is most-used, so they lead; the rest
-// alphabetizes via the fallback.
+// based_on_style sets defaults and column_limit is most-used, so they lead; the rest alphabetizes via the fallback.
 const KEY_ORDER: &[&str] = &[
     "",
     "based_on_style",

--- a/tox-toml-fmt/docs/configuration.rst
+++ b/tox-toml-fmt/docs/configuration.rst
@@ -32,12 +32,11 @@ which defaults to an empty list).
 Shared configuration file
 -------------------------
 
-You can place formatting settings in a standalone ``tox-toml-fmt.toml`` file instead of (or in addition to) the
-``[tox-toml-fmt]`` table. This is useful for monorepos or when you want to share the same configuration across multiple
-projects without duplicating it in each ``tox.toml``.
+Place formatting settings in a standalone ``tox-toml-fmt.toml`` file instead of (or alongside) the ``[tox-toml-fmt]``
+table. In a monorepo this shares one configuration across projects without repeating it in every ``tox.toml``.
 
-The formatter searches for ``tox-toml-fmt.toml`` starting from the directory of the file being formatted and walking up
-to the filesystem root. The first match wins. You can also pass an explicit path via ``--config``:
+The formatter searches for ``tox-toml-fmt.toml`` from the directory of the file being formatted up to the filesystem
+root, and the first match wins. Pass an explicit path via ``--config``:
 
 .. code-block:: bash
 

--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -1,19 +1,15 @@
 Formatting Rules
 ================
 
-``tox-toml-fmt`` is an opinionated formatter, much like `black <https://github.com/psf/black>`_ is for Python code.
-The tool intentionally provides minimal configuration options because the goal is to establish a single standard format
-that all ``tox.toml`` files follow.
+``tox-toml-fmt`` is an opinionated formatter, much like `black <https://github.com/psf/black>`_ is for Python code. It
+keeps configuration minimal so every ``tox.toml`` lands on one standard format. That buys you:
 
-**Benefits of this approach:**
+- less time configuring tools
+- smaller diffs when committing changes
+- code reviews where formatting never comes up
 
-- Less time configuring tools
-- Smaller diffs when committing changes
-- Easier code reviews since formatting is never a question
-
-While a few key options exist (``column_width``, ``indent``, ``table_format``, ``sub_table_spacing``,
-``separate_root_table``), the tool does not expose dozens of toggles. You get what the maintainers have chosen to be the
-right balance of readability, consistency, and usability.
+A few options exist (``column_width``, ``indent``, ``table_format``, ``sub_table_spacing``, ``separate_root_table``),
+but there are no dozens of toggles.
 
 General Formatting
 ------------------
@@ -474,7 +470,7 @@ Certain arrays within environment tables are sorted automatically:
 
 **Sorted by canonical PEP 508 package name:**
 
-- ``deps``, ``constraints`` — dependencies normalized and sorted by package name
+- ``deps``, ``constraints``: dependencies normalized and sorted by package name
 
 Pip file references (``-r``, ``-c``), editable installs (``-e``), local paths (``./``, ``../``,
 ``/``), and entries containing tox substitution variables (``{tox_root}``, etc.) are preserved as-is
@@ -507,8 +503,8 @@ then string entries are sorted alphabetically:
 
 **Arrays NOT sorted:**
 
-- ``commands``, ``commands_pre``, ``commands_post`` — execution order matters
-- ``base_python`` — first entry takes priority
+- ``commands``, ``commands_pre``, ``commands_post``: execution order matters
+- ``base_python``: first entry takes priority
 
 Inline Table Key Reordering
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -516,11 +512,11 @@ Inline Table Key Reordering
 Keys within inline tables are reordered into a consistent order based on the inline table's type. The type
 is detected by the presence of a discriminator key:
 
-- **``replace``** — ``replace`` → ``condition`` → ``of`` → ``env`` → ``key`` → ``name`` → ``pattern`` →
+- **``replace``**: ``replace`` → ``condition`` → ``of`` → ``env`` → ``key`` → ``name`` → ``pattern`` →
   ``then`` → ``else`` → ``default`` → ``extend`` → ``marker``
-- **``prefix``** — ``prefix`` → ``start`` → ``stop``
-- **``product``** — ``product`` → ``exclude``
-- **``value``** — ``value`` → ``marker``
+- **``prefix``**: ``prefix`` → ``start`` → ``stop``
+- **``product``**: ``product`` → ``exclude``
+- **``value``**: ``value`` → ``marker``
 
 Keys not listed in the schema are appended at the end in their original order.
 

--- a/tox-toml-fmt/docs/index.rst
+++ b/tox-toml-fmt/docs/index.rst
@@ -7,9 +7,8 @@ Apply a consistent format to your ``tox.toml`` file with comment support. See
 
 Philosophy
 ----------
-This tool aims to be an *opinionated formatter*, with similar objectives to `black <https://github.com/psf/black>`_.
-This means it deliberately does not support a wide variety of configuration settings. In return, you get consistency,
-predictability, and smaller diffs.
+This is an *opinionated formatter*, with the same objectives as `black <https://github.com/psf/black>`_: it offers few
+configuration settings on purpose. In return you get consistency, predictability, and smaller diffs.
 
 Use
 ---
@@ -17,10 +16,9 @@ Use
 Via ``CLI``
 ~~~~~~~~~~~
 
-:pypi:`tox-toml-fmt` is a CLI tool that needs a Python interpreter (version 3.10 or higher) to run. We recommend
-either :pypi:`pipx` or :pypi:`uv` to install tox-toml-fmt into an isolated environment. This has the added benefit that
-later you will be able to upgrade tox-toml-fmt without affecting other parts of the system. We provide a method for
-``pip`` too here, but we discourage that path if you can:
+:pypi:`tox-toml-fmt` is a CLI tool that needs Python 3.10 or higher to run. Install it into an isolated environment
+with :pypi:`pipx` or :pypi:`uv`; that way you can upgrade tox-toml-fmt later without disturbing the rest of your
+system. A ``pip`` path follows for completeness, though we discourage it:
 
 .. tab:: uv
 
@@ -46,10 +44,9 @@ later you will be able to upgrade tox-toml-fmt without affecting other parts of 
         python -m pip install --user tox-toml-fmt
         tox-toml-fmt --help
 
-    You can install it within the global Python interpreter itself (perhaps as a user package via the
-    ``--user`` flag). Be cautious if you are using a Python installation that is managed by your operating system or
-    another package manager. ``pip`` might not coordinate with those tools, and may leave your system in an inconsistent
-    state. Note, if you go down this path you need to ensure pip is new enough per the subsections below
+    You can install it into the global Python interpreter (as a user package via the ``--user`` flag). Take care if
+    your Python is managed by the operating system or another package manager: ``pip`` may not coordinate with those
+    tools and can leave your system inconsistent. On this path, make sure pip is new enough per the subsections below.
 
 
 Via ``pre-commit`` hook
@@ -67,7 +64,7 @@ See :gh:`pre-commit/pre-commit` for instructions, sample ``.pre-commit-config.ya
 Via Python
 ~~~~~~~~~~
 
-You can use ``tox-toml-fmt`` as a Python module to format TOML content programmatically.
+Call ``tox-toml-fmt`` as a Python module to format TOML from your own code.
 
 .. code-block:: python
 

--- a/tox-toml-fmt/rust/src/global.rs
+++ b/tox-toml-fmt/rust/src/global.rs
@@ -15,8 +15,6 @@ use common::table::{
     Tables,
 };
 
-/// Strips `<prefix>.` from `key` and returns the relative key. When `prefix` is empty
-/// returns the key unchanged. Returns `None` when `key` is outside the prefix scope.
 fn strip_prefix<'a>(key: &'a str, prefix: &str) -> Option<&'a str> {
     if prefix.is_empty() {
         Some(key)
@@ -42,9 +40,8 @@ fn env_tables<'a>(tables: &'a Tables, prefix: &str) -> Vec<(&'a String, Vec<&'a 
         .header_to_pos
         .keys()
         .filter(|k| is_env_table(k, prefix))
-        // After collapse the sub-table cells can be empty; `Tables::get` returns None in
-        // that case. Skip those entries instead of unwrapping (the collapsed content is
-        // already living under the parent table and gets handled there).
+        // Collapsed sub-tables leave empty cells where `get` returns None; their content already lives under the parent
+        // table, so skip rather than unwrap.
         .filter_map(|k| tables.get(k).map(|v| (k, v)))
         .collect()
 }
@@ -249,7 +246,6 @@ fn upgrade_use_develop(table: &mut Vec<SyntaxElement>) {
     if !is_true {
         return;
     }
-    // Remove use_develop = true and any trailing whitespace/newline
     table.remove(idx);
     while idx < table.len() && matches!(table[idx].kind(), WHITESPACE | tombi_syntax::SyntaxKind::LINE_BREAK) {
         table.remove(idx);

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -197,8 +197,8 @@ fn format_core(content: &str, opt: &Settings) -> String {
 /// # Errors
 ///
 /// Will return `PyErr` if an error is raised during formatting.
-// Gated so sibling crates (pyproject-fmt) that pull this in as an rlib don't get a
-// duplicate `PyInit__lib` symbol from pyo3 at link time.
+// Gated so sibling crates (pyproject-fmt) that pull this in as an rlib don't get a duplicate `PyInit__lib` symbol from
+// pyo3 at link time.
 #[cfg(feature = "extension-module")]
 #[pymodule(gil_used = false)]
 #[pyo3(name = "_lib")]


### PR DESCRIPTION
Comments across the three Rust crates carried a lot of narration that restated what the code already shows. This pass keeps a comment only where it gives a reason the code cannot: an invariant, a gotcha, an ordering dependency, or provenance. 📝 The `KEY_ORDER` constants now state once that their order follows the upstream tool's own configuration reference, rather than labelling every group.

Every remaining comment wraps to 120 columns to match the code width. The prose in `CONTRIBUTING.md` and the `docs/` sources loses its filler, passive voice, and em dashes.

No code, key ordering, or test behaviour changes; the diff touches only comments and documentation. The net is about 360 fewer lines.
