### PR TITLE
📝 docs: generate formatting examples via the live formatter

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -60,14 +60,14 @@ jobs:
           PACKAGE: ${{ inputs.package-name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: 🐍 Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
       - name: 🎨 Run pre-commit
-        uses: tox-dev/action-pre-commit-uv@41a04ab74d5ec7ca33c8db8a59b6e3291d576033 # 1.0.4
+        uses: tox-dev/action-pre-commit-uv@41a04ab74d5ec7ca33c8db8a59b6e3291d576033 # v1.0.4
         continue-on-error: true
       - name: 📝 Generate README.rst
-        run: python tasks/generate_readme.py "$PACKAGE"
+        run: uv run --project "$PACKAGE" python tasks/generate_readme.py "$PACKAGE"
         env:
           PACKAGE: ${{ inputs.package-name }}
       - name: 👀 Show changes
@@ -147,7 +147,7 @@ jobs:
         with:
           name: source
       - name: 🐍 Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.platform.python }}
           architecture: ${{ matrix.platform.target == 'x86' && 'x86' || matrix.platform.target == 'aarch64' && 'arm64' || 'x64' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,23 @@
 ci:
   autoupdate_schedule: monthly
+  # these build the local Rust extension via uv; pre-commit.ci has no toolchain, so CI regenerates instead
+  skip: [readme-pyproject-fmt, readme-tox-toml-fmt]
 
 repos:
+  - repo: local
+    hooks:
+      - id: readme-pyproject-fmt
+        name: regenerate pyproject-fmt README (runs doc examples through the formatter)
+        language: system
+        entry: uv run --project pyproject-fmt python tasks/generate_readme.py pyproject-fmt
+        pass_filenames: false
+        always_run: true
+      - id: readme-tox-toml-fmt
+        name: regenerate tox-toml-fmt README (runs doc examples through the formatter)
+        language: system
+        entry: uv run --project tox-toml-fmt python tasks/generate_readme.py tox-toml-fmt
+        pass_filenames: false
+        always_run: true
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: "v2.23.0"
     hooks:

--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -650,7 +650,7 @@ Beyond general formatting, each table has specific key ordering and value normal
 ~~~~~~~~~~~~~~~~~~
 
 The :pep:`517` / :pep:`518` table that declares how your project is built. See the
-`packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#build-system-table>`_.
+`packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-build-system-table>`_.
 
 Keys are ordered ``build-backend`` → ``requires`` → ``backend-path``, and ``requires`` is normalized and sorted. A
 redundant ``wheel`` requirement is removed when the build backend is setuptools.
@@ -688,7 +688,7 @@ directly), or when ``setuptools`` itself is missing from ``requires``.
 ~~~~~~~~~~~~~
 
 The :pep:`621` core metadata table. See the
-`packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#the-project-table>`_.
+`packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-project-table>`_.
 
 Keys follow the canonical metadata order; name, dependencies, classifiers, and keywords are normalized and sorted.
 

--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -426,54 +426,43 @@ Arrays are formatted based on line length, trailing comma presence, and comments
    # After
    keywords = [ "python", "toml" ]
 
-Arrays that exceed ``column_width`` are expanded and get a trailing comma:
+Arrays that exceed ``column_width`` are expanded and get a trailing comma (shown here with a small ``column_width`` to
+keep the example short):
 
 .. code-block:: toml
 
    # Before
    [project]
-   keywords = ["formatting", "toml", "pyproject", "configuration", "linter", "automation", "developer-tools", "packaging"]
+   keywords = ["web", "toml", "pyproject", "formatting"]
 
    # After
    [project]
    keywords = [
-     "automation",
-     "configuration",
-     "developer-tools",
      "formatting",
-     "linter",
-     "packaging",
      "pyproject",
-     "toml"
+     "toml",
+     "web",
    ]
 
-A trailing comma signals intent to keep the multiline format even when the array would fit on one line:
+A trailing comma forces the multiline format, even for an array that would otherwise fit on one line:
 
 .. code-block:: toml
 
    # Before
-   classifiers = [
-       "Development Status :: 4 - Beta",
-   ]
+   classifiers = ["Development Status :: 4 - Beta",]
 
    # After
    classifiers = [
      "Development Status :: 4 - Beta",
    ]
 
-Arrays with comments are always multiline:
+A comment on an entry also forces the multiline format. Here ``["E501", "E701"]`` would fit on one line, but the
+comment keeps it expanded:
 
 .. code-block:: toml
 
-   # Before
    lint.ignore = [
-       "E501",  # Line too long
-       "E701",
-   ]
-
-   # After
-   lint.ignore = [
-     "E501", # Line too long
+     "E501", # too long
      "E701",
    ]
 
@@ -489,17 +478,17 @@ String Wrapping
 ~~~~~~~~~~~~~~~
 
 Strings that exceed ``column_width`` (including the key name and ``" = "`` prefix) are wrapped into multi-line
-triple-quoted strings using line continuations:
+triple-quoted strings using line continuations (shown here with a small ``column_width``):
 
 .. code-block:: toml
 
    # Before
-   description = "A very long project description that goes well beyond the configured column width limit and therefore must wrap onto multiple lines"
+   description = "Format your pyproject.toml file in place"
 
    # After
    description = """\
-     A very long project description that goes well beyond the configured column width limit and therefore must wrap onto \
-     multiple lines\
+     Format your pyproject.toml file in \
+     place\
      """
 
 Wrapping prefers breaking at spaces and at ``" :: "`` separators (common in Python classifiers). Strings inside inline
@@ -921,20 +910,20 @@ Inline tables that don't match any Poetry-specific schema (for example ``[[proje
    # Before
    [[tool.poetry.source]]
    priority = "primary"
-   url = "https://pypi.example.com/simple"
+   url = "https://example.com"
    name = "private"
 
    [tool.poetry.dependencies]
    zebra = "^1.0"
    python = "^3.11"
-   foo = { branch = "main", git = "https://github.com/example/foo" }
+   foo = { branch = "main", git = "https://example.com/foo" }
 
    # After
    [tool.poetry]
    dependencies.python = "^3.11"
-   dependencies.foo = { git = "https://github.com/example/foo", branch = "main" }
+   dependencies.foo = { git = "https://example.com/foo", branch = "main" }
    dependencies.zebra = "^1.0"
-   source = [ { name = "private", url = "https://pypi.example.com/simple", priority = "primary" } ]
+   source = [ { name = "private", url = "https://example.com", priority = "primary" } ]
 
 ``[tool.pdm.*]``
 ~~~~~~~~~~~~~~~~
@@ -1134,8 +1123,8 @@ semantics).
 ``[tool.pixi]``
 ~~~~~~~~~~~~~~~
 
-`Pixi <https://pixi.sh/latest/>`_ is a cross-platform conda/PyPI package and environment manager. See its
-`pyproject.toml reference <https://pixi.sh/latest/python/pyproject_toml/>`_.
+`Pixi <https://pixi.prefix.dev/latest/>`_ is a cross-platform conda/PyPI package and environment manager. See its
+`pyproject.toml reference <https://pixi.prefix.dev/latest/python/pyproject_toml/>`_.
 
 Keys are grouped by function (workspace metadata → configuration → dependencies → environments → build); channel and
 platform arrays are sorted.
@@ -1601,15 +1590,12 @@ override is expanded or collapsed.
 
    # Before
    [[tool.mypy.overrides]]
-   ignore_missing_imports = true
    disable_error_code = ["import-untyped", "attr-defined"]
-   module = "third_party.*"
+   module = "pkg.*"
 
    # After
    [tool.mypy]
-   overrides = [
-     { module = "third_party.*", ignore_missing_imports = true, disable_error_code = [ "attr-defined", "import-untyped" ] }
-   ]
+   overrides = [ { module = "pkg.*", disable_error_code = [ "attr-defined", "import-untyped" ] } ]
 
 ``[tool.pyrefly]``
 ~~~~~~~~~~~~~~~~~~

--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -168,26 +168,32 @@ Control how sub-tables are formatted with two styles:
 
 .. code-block:: toml
 
-    [project]
-    name = "myproject"
-    urls.homepage = "https://example.com"
-    urls.repository = "https://github.com/example/myproject"
-    scripts.mycli = "mypackage:main"
+   [project]
+   name = "myproject"
+   urls.homepage = "https://example.com"
+   urls.repository = "https://github.com/example/myproject"
+   scripts.mycli = "mypackage:main"
 
 **Long format (expanded)** - Sub-tables are expanded into separate ``[table.subtable]`` sections. Use this for
 readability when tables have many keys or complex values:
 
 .. code-block:: toml
 
-    [project]
-    name = "myproject"
+   # Before
+   [project]
+   name = "myproject"
+   urls.homepage = "https://example.com"
+   urls.repository = "https://github.com/example/myproject"
+   scripts.mycli = "mypackage:main"
 
-    [project.urls]
-    homepage = "https://example.com"
-    repository = "https://github.com/example/myproject"
-
-    [project.scripts]
-    mycli = "mypackage:main"
+   # After
+   [project]
+   name = "myproject"
+   [project.scripts]
+   mycli = "mypackage:main"
+   [project.urls]
+   homepage = "https://example.com"
+   repository = "https://github.com/example/myproject"
 
 Table spacing
 ~~~~~~~~~~~~~
@@ -369,13 +375,13 @@ All strings use double quotes by default. Single quotes are only used when the v
 
 .. code-block:: toml
 
-    # Before
-    name = 'my-package'
-    description = "He said \"hello\""
+   # Before
+   name = 'my-package'
+   description = "He said \"hello\""
 
-    # After
-    name = "my-package"
-    description = 'He said "hello"'
+   # After
+   name = "my-package"
+   description = 'He said "hello"'
 
 Key Quotes
 ~~~~~~~~~~
@@ -387,52 +393,89 @@ key-value pairs, and inline table keys:
 
 .. code-block:: toml
 
-    # Before
-    [tool."ruff"]
-    "line-length" = 120
-    lint.per-file-ignores.'tests/*' = ["S101"]
+   # Before
+   [tool."ruff"]
+   "line-length" = 120
+   lint.per-file-ignores.'tests/*' = ["S101"]
 
-    # After
-    [tool.ruff]
-    line-length = 120
-    lint.per-file-ignores."tests/*" = ["S101"]
+   # After
+   [tool.ruff]
+   line-length = 120
+   lint.per-file-ignores."tests/*" = [ "S101" ]
 
 Backslashes and double quotes within literal keys are escaped during conversion:
 
 .. code-block:: toml
 
-    # Before
-    lint.per-file-ignores.'path\to\file' = ["E501"]
+   # Before
+   lint.per-file-ignores.'path\to\file' = ["E501"]
 
-    # After
-    lint.per-file-ignores."path\\to\\file" = ["E501"]
+   # After
+   lint.per-file-ignores."path\\to\\file" = [ "E501" ]
 
 Array Formatting
 ~~~~~~~~~~~~~~~~
 
-Arrays are formatted based on line length, trailing comma presence, and comments:
+Arrays are formatted based on line length, trailing comma presence, and comments. Short arrays stay on one line:
 
 .. code-block:: toml
 
-    # Short arrays stay on one line
-    keywords = ["python", "toml"]
+   # Before
+   keywords = ["python", "toml"]
 
-    # Long arrays that exceed column_width are expanded and get a trailing comma
-    dependencies = [
-        "requests>=2.28",
-        "click>=8.0",
-    ]
+   # After
+   keywords = [ "python", "toml" ]
 
-    # Trailing commas signal intent to keep multiline format
-    classifiers = [
-        "Development Status :: 4 - Beta",
-    ]
+Arrays that exceed ``column_width`` are expanded and get a trailing comma:
 
-    # Arrays with comments are always multiline
-    lint.ignore = [
-        "E501",  # Line too long
-        "E701",
-    ]
+.. code-block:: toml
+
+   # Before
+   [project]
+   keywords = ["formatting", "toml", "pyproject", "configuration", "linter", "automation", "developer-tools", "packaging"]
+
+   # After
+   [project]
+   keywords = [
+     "automation",
+     "configuration",
+     "developer-tools",
+     "formatting",
+     "linter",
+     "packaging",
+     "pyproject",
+     "toml"
+   ]
+
+A trailing comma signals intent to keep the multiline format even when the array would fit on one line:
+
+.. code-block:: toml
+
+   # Before
+   classifiers = [
+       "Development Status :: 4 - Beta",
+   ]
+
+   # After
+   classifiers = [
+     "Development Status :: 4 - Beta",
+   ]
+
+Arrays with comments are always multiline:
+
+.. code-block:: toml
+
+   # Before
+   lint.ignore = [
+       "E501",  # Line too long
+       "E701",
+   ]
+
+   # After
+   lint.ignore = [
+     "E501", # Line too long
+     "E701",
+   ]
 
 **Multiline formatting rules:**
 
@@ -450,14 +493,14 @@ triple-quoted strings using line continuations:
 
 .. code-block:: toml
 
-    # Before (exceeds column_width)
-    description = "A very long description that goes beyond the configured column width limit"
+   # Before
+   description = "A very long project description that goes well beyond the configured column width limit and therefore must wrap onto multiple lines"
 
-    # After
-    description = """\
-      A very long description that goes beyond the \
-      configured column width limit\
-      """
+   # After
+   description = """\
+     A very long project description that goes well beyond the configured column width limit and therefore must wrap onto \
+     multiple lines\
+     """
 
 Wrapping prefers breaking at spaces and at ``" :: "`` separators (common in Python classifiers). Strings inside inline
 tables are never wrapped. Strings that contain actual newlines are preserved as multi-line strings without adding line
@@ -472,17 +515,17 @@ Sub-tables can be formatted in two styles controlled by ``table_format``:
 
 .. code-block:: toml
 
-    [project]
-    urls.homepage = "https://example.com"
-    urls.repository = "https://github.com/example/project"
+   [project]
+   urls.homepage = "https://example.com"
+   urls.repository = "https://github.com/example/project"
 
 **Long format** (expanded to table headers):
 
 .. code-block:: toml
 
-    [project.urls]
-    homepage = "https://example.com"
-    repository = "https://github.com/example/project"
+   [project.urls]
+   homepage = "https://example.com"
+   repository = "https://github.com/example/project"
 
 **Table spacing:**
 
@@ -494,11 +537,19 @@ line between sub-tables:
 
 .. code-block:: toml
 
-    [tool.ruff]
-    line-length = 120
+   # Before
+   [tool.ruff]
+   line-length = 120
 
-    [tool.ruff.lint]
-    select = ["E", "W"]
+   [tool.ruff.lint]
+   select = ["E", "W"]
+
+   # After
+   [tool.ruff]
+   line-length = 120
+
+   [tool.ruff.lint]
+   select = [ "E", "W" ]
 
 
 Comment Preservation
@@ -516,19 +567,19 @@ Inline comments within arrays are aligned independently per array, based on that
 
 .. code-block:: toml
 
-    # Before - comments at inconsistent positions
-    lint.ignore = [
-      "COM812", # Conflict with formatter
-      "CPY", # No copyright statements
-      "ISC001",   # Another rule
-    ]
+   # Before
+   lint.ignore = [
+     "COM812", # Conflict with formatter
+     "CPY", # No copyright statements
+     "ISC001",   # Another rule
+   ]
 
-    # After - comments align to longest value in this array
-    lint.ignore = [
-      "COM812",  # Conflict with formatter
-      "CPY",     # No copyright statements
-      "ISC001",  # Another rule
-    ]
+   # After
+   lint.ignore = [
+     "COM812", # Conflict with formatter
+     "CPY",    # No copyright statements
+     "ISC001", # Another rule
+   ]
 
 Disabled Keys
 ~~~~~~~~~~~~~
@@ -541,19 +592,19 @@ be:
 
 .. code-block:: toml
 
-    # Before
-    [[tool.uv.index]]
-    name = "pypi"
-    authenticate = "never"
-    # default = true
-    # ignore-error-codes = [400,401,403]
+   # Before
+   [[tool.uv.index]]
+   name = "pypi"
+   authenticate = "never"
+   # default = true
+   # ignore-error-codes = [400,401,403]
 
-    # After
-    [[tool.uv.index]]
-    name = "pypi"
-    authenticate = "never"
-    # default = true
-    # ignore-error-codes = [ 400, 401, 403 ]
+   # After
+   [[tool.uv.index]]
+   name = "pypi"
+   authenticate = "never"
+   # default = true
+   # ignore-error-codes = [ 400, 401, 403 ]
 
 Comments that are not a single valid key-value (prose, multi-line blocks, commented-out table headers like
 ``# [tool.x]``) are left untouched and follow the usual comment-preservation rules above. The heuristic is purely
@@ -576,25 +627,27 @@ The formatter sorts the entries inside each group:
 
 .. code-block:: toml
 
-    # Before
-    dependencies = [
-      # Group: web
-      "flask",
-      "django",
-      # Group: db
-      "sqlalchemy",
-      "psycopg2",
-    ]
+   # Before
+   [project]
+   dependencies = [
+     # Group: web
+     "flask",
+     "django",
+     # Group: db
+     "sqlalchemy",
+     "psycopg2",
+   ]
 
-    # After
-    dependencies = [
-      # Group: web
-      "django",
-      "flask",
-      # Group: db
-      "psycopg2",
-      "sqlalchemy",
-    ]
+   # After
+   [project]
+   dependencies = [
+     # Group: web
+     "django",
+     "flask",
+     # Group: db
+     "psycopg2",
+     "sqlalchemy",
+   ]
 
 A ``# Group:`` marker works the same way before a key in a table or before a ``[tool.*]`` header: the formatter sorts the
 keys or sections up to the next marker, and never moves them across the boundary.
@@ -632,15 +685,15 @@ directly), or when ``setuptools`` itself is missing from ``requires``.
 
 .. code-block:: toml
 
-    # Before
-    [build-system]
-    requires = ["setuptools >= 45", "wheel"]
-    build-backend = "setuptools.build_meta"
+   # Before
+   [build-system]
+   requires = ["setuptools >= 45", "wheel"]
+   build-backend = "setuptools.build_meta"
 
-    # After
-    [build-system]
-    build-backend = "setuptools.build_meta"
-    requires = ["setuptools>=45"]
+   # After
+   [build-system]
+   build-backend = "setuptools.build_meta"
+   requires = [ "setuptools>=45" ]
 
 ``[project]``
 ~~~~~~~~~~~~~
@@ -692,61 +745,79 @@ normalized per :pep:`508` (spaces removed, redundant ``.0`` suffixes stripped un
 
 .. code-block:: toml
 
-    # Before
-    dependencies = ["requests >= 2.0.0", "click~=8.0"]
+   # Before
+   [project]
+   dependencies = ["requests >= 2.0.0", "click~=8.0"]
 
-    # After
-    dependencies = ["click>=8", "requests>=2"]
+   # After
+   [project]
+   dependencies = [ "click~=8.0", "requests>=2" ]
 
 **Optional-dependency extra names** are normalized to lowercase with hyphens:
 
 .. code-block:: toml
 
-    # Before
-    [project.optional-dependencies]
-    Dev_Tools = ["pytest"]
+   # Before
+   [project.optional-dependencies]
+   Dev_Tools = ["pytest"]
 
-    # After
-    [project.optional-dependencies]
-    dev-tools = ["pytest"]
+   # After
+   [project]
+   optional-dependencies.dev-tools = [ "pytest" ]
 
 **Python version classifiers** are generated automatically from ``requires-python`` and
-``max_supported_python``. Disable with ``generate_python_version_classifiers = false``:
+``max_supported_python`` (here ``3.14``). Disable with ``generate_python_version_classifiers = false``:
 
 .. code-block:: toml
 
-    # With requires-python = ">=3.10" and max_supported_python = "3.14"
-    classifiers = [
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
-    ]
+   # Before
+   [project]
+   requires-python = ">=3.10"
+
+   # After
+   [project]
+   requires-python = ">=3.10"
+   classifiers = [
+     "Programming Language :: Python :: 3 :: Only",
+     "Programming Language :: Python :: 3.10",
+     "Programming Language :: Python :: 3.11",
+     "Programming Language :: Python :: 3.12",
+     "Programming Language :: Python :: 3.13",
+     "Programming Language :: Python :: 3.14",
+   ]
 
 **Entry points:** inline tables within ``entry-points`` are expanded to dotted keys:
 
 .. code-block:: toml
 
-    # Before
-    entry-points.console_scripts = { mycli = "mypackage:main" }
+   # Before
+   [project]
+   entry-points.console_scripts = { mycli = "mypackage:main" }
 
-    # After
-    entry-points.console_scripts.mycli = "mypackage:main"
+   # After
+   [project]
+   entry-points.console_scripts.mycli = "mypackage:main"
 
-**Authors / maintainers** can be inline tables or an expanded array of tables (controlled by ``table_format``,
-``expand_tables``, and ``collapse_tables``):
+**Authors / maintainers** can be inline tables (short format):
 
 .. code-block:: toml
 
-    # Short format (inline)
-    authors = [{ name = "Alice", email = "alice@example.com" }]
+   # Before
+   [project]
+   authors = [{ name = "Alice", email = "alice@example.com" }]
 
-    # Long format (array of tables)
-    [[project.authors]]
-    name = "Alice"
-    email = "alice@example.com"
+   # After
+   [project]
+   authors = [ { name = "Alice", email = "alice@example.com" } ]
+
+or an expanded array of tables (long format, controlled by ``table_format``, ``expand_tables``, and
+``collapse_tables``):
+
+.. code-block:: toml
+
+   [[project.authors]]
+   name = "Alice"
+   email = "alice@example.com"
 
 ``[dependency-groups]``
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -766,13 +837,13 @@ Groups are ordered ``dev`` → ``test`` → ``type`` → ``docs`` → others alp
 
 .. code-block:: toml
 
-    # Before
-    [dependency-groups]
-    dev = [{ include-group = "test" }, "ruff>=0.4", "mypy>=1"]
+   # Before
+   [dependency-groups]
+   dev = [{ include-group = "test" }, "ruff>=0.4", "mypy>=1"]
 
-    # After
-    [dependency-groups]
-    dev = ["mypy>=1", "ruff>=0.4", { include-group = "test" }]
+   # After
+   [dependency-groups]
+   dev = [ "mypy>=1", "ruff>=0.4", { include-group = "test" } ]
 
 ``[tool.poetry]``
 ~~~~~~~~~~~~~~~~~
@@ -847,23 +918,23 @@ Inline tables that don't match any Poetry-specific schema (for example ``[[proje
 
 .. code-block:: toml
 
-    # Before
-    [[tool.poetry.source]]
-    priority = "primary"
-    url = "https://pypi.example.com/simple"
-    name = "private"
+   # Before
+   [[tool.poetry.source]]
+   priority = "primary"
+   url = "https://pypi.example.com/simple"
+   name = "private"
 
-    [tool.poetry.dependencies]
-    zebra = "^1.0"
-    python = "^3.11"
-    foo = { branch = "main", git = "https://github.com/example/foo" }
+   [tool.poetry.dependencies]
+   zebra = "^1.0"
+   python = "^3.11"
+   foo = { branch = "main", git = "https://github.com/example/foo" }
 
-    # After
-    [tool.poetry]
-    dependencies.python = "^3.11"
-    dependencies.foo = { git = "https://github.com/example/foo", branch = "main" }
-    dependencies.zebra = "^1.0"
-    source = [ { name = "private", url = "https://pypi.example.com/simple", priority = "primary" } ]
+   # After
+   [tool.poetry]
+   dependencies.python = "^3.11"
+   dependencies.foo = { git = "https://github.com/example/foo", branch = "main" }
+   dependencies.zebra = "^1.0"
+   source = [ { name = "private", url = "https://pypi.example.com/simple", priority = "primary" } ]
 
 ``[tool.pdm.*]``
 ~~~~~~~~~~~~~~~~
@@ -951,29 +1022,29 @@ get their keys ordered ``attr`` → ``file`` → ``content-type``.
 
 .. code-block:: toml
 
-    # Before
-    [tool.setuptools]
-    zip-safe = false
-    py-modules = ["foo", "bar"]
-    packages = ["my_pkg"]
+   # Before
+   [tool.setuptools]
+   zip-safe = false
+   py-modules = ["foo", "bar"]
+   packages = ["my_pkg"]
 
-    [tool.setuptools.packages.find]
-    namespaces = true
-    where = ["src"]
-    include = ["my_pkg*"]
+   [tool.setuptools.packages.find]
+   namespaces = true
+   where = ["src"]
+   include = ["my_pkg*"]
 
-    [tool.setuptools.dynamic]
-    readme = { content-type = "text/markdown", file = "README.md" }
+   [tool.setuptools.dynamic]
+   readme = { content-type = "text/markdown", file = "README.md" }
 
-    # After
-    [tool.setuptools]
-    py-modules = [ "bar", "foo" ]
-    packages.find.where = [ "src" ]
-    packages.find.include = [ "my_pkg*" ]
-    packages.find.namespaces = true
-    packages = [ "my_pkg" ]
-    dynamic.readme = { file = "README.md", content-type = "text/markdown" }
-    zip-safe = false
+   # After
+   [tool.setuptools]
+   py-modules = [ "bar", "foo" ]
+   packages.find.where = [ "src" ]
+   packages.find.include = [ "my_pkg*" ]
+   packages.find.namespaces = true
+   packages = [ "my_pkg" ]
+   dynamic.readme = { file = "README.md", content-type = "text/markdown" }
+   zip-safe = false
 
 ``[tool.hatch.*]``
 ~~~~~~~~~~~~~~~~~~
@@ -1134,15 +1205,15 @@ Other arrays
 
 .. code-block:: toml
 
-    # Before
-    [tool.uv.sources]
-    zebra = { git = "..." }
-    alpha = { path = "..." }
+   # Before
+   [tool.uv.sources]
+   zebra = { git = "..." }
+   alpha = { path = "..." }
 
-    # After
-    [tool.uv.sources]
-    alpha = { path = "..." }
-    zebra = { git = "..." }
+   # After
+   [tool.uv]
+   sources.alpha = { path = "..." }
+   sources.zebra = { git = "..." }
 
 **pip subsection:** ``[tool.uv.pip]`` follows the same rules, with arrays like ``extra``, ``no-binary-package``,
 ``no-build-package``, ``reinstall-package``, and ``upgrade-package`` sorted alphabetically.
@@ -1257,16 +1328,22 @@ name arrays are sorted with natural ordering (``RUF1`` < ``RUF9`` < ``RUF10``).
 6. ``lint.*`` keys: ``select`` → ``extend-select`` → ``ignore`` → ``extend-ignore`` → ``per-file-ignores`` →
    ``fixable`` → ``unfixable`` → plugin configurations
 
-**Sorted arrays:** alphabetical with natural ordering (``RUF1`` < ``RUF9`` < ``RUF10``):
+**Sorted arrays:** alphabetical with natural ordering (``RUF1`` < ``RUF9`` < ``RUF10``); per-file-ignores values
+are sorted too:
 
 .. code-block:: toml
 
-    # These arrays are sorted:
-    lint.select = ["E", "F", "I", "RUF"]
-    lint.ignore = ["E501", "E701"]
+   # Before
+   [tool.ruff]
+   lint.select = ["F", "E", "RUF", "I"]
+   lint.ignore = ["E701", "E501"]
+   lint.per-file-ignores."tests/*.py" = ["S101", "D103"]
 
-    # Per-file-ignores values are also sorted:
-    lint.per-file-ignores."tests/*.py" = ["D103", "S101"]
+   # After
+   [tool.ruff]
+   lint.select = [ "E", "F", "I", "RUF" ]
+   lint.ignore = [ "E501", "E701" ]
+   lint.per-file-ignores."tests/*.py" = [ "D103", "S101" ]
 
 The full set of sorted array keys:
 
@@ -1522,17 +1599,17 @@ override is expanded or collapsed.
 
 .. code-block:: toml
 
-    # Before
-    [[tool.mypy.overrides]]
-    ignore_missing_imports = true
-    disable_error_code = ["import-untyped", "attr-defined"]
-    module = "third_party.*"
+   # Before
+   [[tool.mypy.overrides]]
+   ignore_missing_imports = true
+   disable_error_code = ["import-untyped", "attr-defined"]
+   module = "third_party.*"
 
-    # After
-    [tool.mypy]
-    overrides = [
-      { module = "third_party.*", ignore_missing_imports = true, disable_error_code = [ "attr-defined", "import-untyped" ] },
-    ]
+   # After
+   [tool.mypy]
+   overrides = [
+     { module = "third_party.*", ignore_missing_imports = true, disable_error_code = [ "attr-defined", "import-untyped" ] }
+   ]
 
 ``[tool.pyrefly]``
 ~~~~~~~~~~~~~~~~~~
@@ -1618,21 +1695,21 @@ priority semantics).
 
 .. code-block:: toml
 
-    # Before
-    [tool.pytest.ini_options]
-    log_cli_level = "INFO"
-    markers = [ "slow: marks tests as slow", "fast: marks tests as fast" ]
-    addopts = [ "--strict-markers", "-ra" ]
-    testpaths = [ "tests" ]
-    minversion = "8"
+   # Before
+   [tool.pytest.ini_options]
+   log_cli_level = "INFO"
+   markers = [ "slow: marks tests as slow", "fast: marks tests as fast" ]
+   addopts = [ "--strict-markers", "-ra" ]
+   testpaths = [ "tests" ]
+   minversion = "8"
 
-    # After
-    [tool.pytest]
-    ini_options.minversion = "8"
-    ini_options.testpaths = [ "tests" ]
-    ini_options.addopts = [ "--strict-markers", "-ra" ]
-    ini_options.markers = [ "fast: marks tests as fast", "slow: marks tests as slow" ]
-    ini_options.log_cli_level = "INFO"
+   # After
+   [tool.pytest]
+   ini_options.minversion = "8"
+   ini_options.testpaths = [ "tests" ]
+   ini_options.addopts = [ "--strict-markers", "-ra" ]
+   ini_options.markers = [ "fast: marks tests as fast", "slow: marks tests as slow" ]
+   ini_options.log_cli_level = "INFO"
 
 ``[tool.coverage]``
 ~~~~~~~~~~~~~~~~~~~
@@ -1691,19 +1768,19 @@ Report phase
 
 .. code-block:: toml
 
-    # Before (alphabetical)
-    [tool.coverage]
-    report.exclude_also = ["if TYPE_CHECKING:"]
-    report.omit = ["tests/*"]
-    run.branch = true
-    run.omit = ["tests/*"]
+   # Before
+   [tool.coverage]
+   report.exclude_also = ["if TYPE_CHECKING:"]
+   report.omit = ["tests/*"]
+   run.branch = true
+   run.omit = ["tests/*"]
 
-    # After (workflow order with groupings)
-    [tool.coverage]
-    run.branch = true
-    run.omit = ["tests/*"]
-    report.omit = ["tests/*"]
-    report.exclude_also = ["if TYPE_CHECKING:"]
+   # After
+   [tool.coverage]
+   run.branch = true
+   run.omit = [ "tests/*" ]
+   report.exclude_also = [ "if TYPE_CHECKING:" ]
+   report.omit = [ "tests/*" ]
 
 ``[tool.tox]``
 ~~~~~~~~~~~~~~

--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -95,10 +95,12 @@ The ``tool.pyproject-fmt`` table is used when present in the ``pyproject.toml`` 
     # Maximum Python version for generating version classifiers
     max_supported_python = "3.14"
 
-    # Table format: "short" collapses sub-tables to dotted keys, "long" expands to [table.subtable] headers
+    # Table format: "short" collapses sub-tables to dotted keys, "long" expands to
+    # [table.subtable] headers
     table_format = "short"
 
-    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line between sub-tables)
+    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line
+    # between sub-tables)
     sub_table_spacing = ""
 
     # Extra newlines between root table groups (e.g. "\n" for one blank line, "\n\n" for two)
@@ -110,7 +112,8 @@ The ``tool.pyproject-fmt`` table is used when present in the ``pyproject.toml`` 
     # List of tables to force collapse regardless of table_format or expand_tables settings
     collapse_tables = []
 
-    # List of key patterns to skip string wrapping (supports wildcards like *.parse or tool.bumpversion.*)
+    # List of key patterns to skip string wrapping (supports wildcards like *.parse or
+    # tool.bumpversion.*)
     skip_wrap_for_keys = []
 
 If not set they will default to values from the CLI.

--- a/pyproject-fmt/docs/conf.py
+++ b/pyproject-fmt/docs/conf.py
@@ -48,9 +48,9 @@ extlinks = {
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 nitpicky = True
 nitpick_ignore = []
-# external reference targets reorganize their on-page anchors over time; check the page resolves, not the fragment
+# anchors that resolve in a browser but linkcheck cannot verify: GitHub renders README heading ids with a
+# user-content- prefix added client-side, and pyright's docs are a single-page app with hash-routed sections
 linkcheck_anchors_ignore_for_url = [
     r"https://github\.com/.*",
-    r"https://microsoft\.github\.io/.*",
-    r"https://packaging\.python\.org/.*",
+    r"https://microsoft\.github\.io/pyright/.*",
 ]

--- a/pyproject-fmt/docs/conf.py
+++ b/pyproject-fmt/docs/conf.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timezone
 from importlib.metadata import version as metadata_version
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "tasks"))
 
 company, name = "tox-dev", "pyproject-fmt"
 ver = metadata_version("pyproject-fmt")
@@ -25,7 +29,9 @@ extensions = [
     "sphinx_inline_tabs",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx_fmt_example",
 ]
+fmt_example_module = "pyproject_fmt"
 
 exclude_patterns = ["_build", "changelog/*", "_draft.rst"]
 autoclass_content, autodoc_member_order, autodoc_typehints = "class", "bysource", "none"

--- a/pyproject-fmt/docs/conf.py
+++ b/pyproject-fmt/docs/conf.py
@@ -48,3 +48,9 @@ extlinks = {
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 nitpicky = True
 nitpick_ignore = []
+# external reference targets reorganize their on-page anchors over time; check the page resolves, not the fragment
+linkcheck_anchors_ignore_for_url = [
+    r"https://github\.com/.*",
+    r"https://microsoft\.github\.io/.*",
+    r"https://packaging\.python\.org/.*",
+]

--- a/pyproject-fmt/docs/configuration.rst
+++ b/pyproject-fmt/docs/configuration.rst
@@ -27,10 +27,12 @@ The ``tool.pyproject-fmt`` table is used when present in the ``pyproject.toml`` 
     # Maximum Python version for generating version classifiers
     max_supported_python = "3.14"
 
-    # Table format: "short" collapses sub-tables to dotted keys, "long" expands to [table.subtable] headers
+    # Table format: "short" collapses sub-tables to dotted keys, "long" expands to
+    # [table.subtable] headers
     table_format = "short"
 
-    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line between sub-tables)
+    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line
+    # between sub-tables)
     sub_table_spacing = ""
 
     # Extra newlines between root table groups (e.g. "\n" for one blank line, "\n\n" for two)
@@ -42,7 +44,8 @@ The ``tool.pyproject-fmt`` table is used when present in the ``pyproject.toml`` 
     # List of tables to force collapse regardless of table_format or expand_tables settings
     collapse_tables = []
 
-    # List of key patterns to skip string wrapping (supports wildcards like *.parse or tool.bumpversion.*)
+    # List of key patterns to skip string wrapping (supports wildcards like *.parse or
+    # tool.bumpversion.*)
     skip_wrap_for_keys = []
 
 If not set they will default to values from the CLI.

--- a/pyproject-fmt/docs/configuration.rst
+++ b/pyproject-fmt/docs/configuration.rst
@@ -106,7 +106,8 @@ Control how sub-tables are formatted with two styles:
 
 **Short format (collapsed)** - The default, where sub-tables collapse into dotted keys. Use it for a compact layout:
 
-.. code-block:: toml
+.. fmt-example::
+    :config: generate_python_version_classifiers=false
 
     [project]
     name = "myproject"
@@ -117,17 +118,14 @@ Control how sub-tables are formatted with two styles:
 **Long format (expanded)** - Sub-tables are expanded into separate ``[table.subtable]`` sections. Use this for
 readability when tables have many keys or complex values:
 
-.. code-block:: toml
+.. fmt-example::
+    :config: table_format=long generate_python_version_classifiers=false
 
     [project]
     name = "myproject"
-
-    [project.urls]
-    homepage = "https://example.com"
-    repository = "https://github.com/example/myproject"
-
-    [project.scripts]
-    mycli = "mypackage:main"
+    urls.homepage = "https://example.com"
+    urls.repository = "https://github.com/example/myproject"
+    scripts.mycli = "mypackage:main"
 
 Table spacing
 ~~~~~~~~~~~~~

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -49,15 +49,10 @@ String Quotes
 
 All strings use double quotes by default. Single quotes are only used when the value contains double quotes:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     name = 'my-package'
     description = "He said \"hello\""
-
-    # After
-    name = "my-package"
-    description = 'He said "hello"'
 
 Key Quotes
 ~~~~~~~~~~
@@ -67,50 +62,47 @@ TOML keys are normalized to the simplest valid form. Keys that are valid bare ke
 converted to double-quoted (basic) strings with proper escaping. This applies to all keys: table headers,
 key-value pairs, and inline table keys:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     [tool."ruff"]
     "line-length" = 120
     lint.per-file-ignores.'tests/*' = ["S101"]
 
-    # After
-    [tool.ruff]
-    line-length = 120
-    lint.per-file-ignores."tests/*" = ["S101"]
-
 Backslashes and double quotes within literal keys are escaped during conversion:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     lint.per-file-ignores.'path\to\file' = ["E501"]
-
-    # After
-    lint.per-file-ignores."path\\to\\file" = ["E501"]
 
 Array Formatting
 ~~~~~~~~~~~~~~~~
 
-Arrays are formatted based on line length, trailing comma presence, and comments:
+Arrays are formatted based on line length, trailing comma presence, and comments. Short arrays stay on one line:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Short arrays stay on one line
     keywords = ["python", "toml"]
 
-    # Long arrays that exceed column_width are expanded and get a trailing comma
-    dependencies = [
-        "requests>=2.28",
-        "click>=8.0",
-    ]
+Arrays that exceed ``column_width`` are expanded and get a trailing comma:
 
-    # Trailing commas signal intent to keep multiline format
+.. fmt-example::
+    :config: generate_python_version_classifiers=false
+
+    [project]
+    keywords = ["formatting", "toml", "pyproject", "configuration", "linter", "automation", "developer-tools", "packaging"]
+
+A trailing comma signals intent to keep the multiline format even when the array would fit on one line:
+
+.. fmt-example::
+
     classifiers = [
         "Development Status :: 4 - Beta",
     ]
 
-    # Arrays with comments are always multiline
+Arrays with comments are always multiline:
+
+.. fmt-example::
+
     lint.ignore = [
         "E501",  # Line too long
         "E701",
@@ -130,16 +122,9 @@ String Wrapping
 Strings that exceed ``column_width`` (including the key name and ``" = "`` prefix) are wrapped into multi-line
 triple-quoted strings using line continuations:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before (exceeds column_width)
-    description = "A very long description that goes beyond the configured column width limit"
-
-    # After
-    description = """\
-      A very long description that goes beyond the \
-      configured column width limit\
-      """
+    description = "A very long project description that goes well beyond the configured column width limit and therefore must wrap onto multiple lines"
 
 Wrapping prefers breaking at spaces and at ``" :: "`` separators (common in Python classifiers). Strings inside inline
 tables are never wrapped. Strings that contain actual newlines are preserved as multi-line strings without adding line
@@ -152,7 +137,8 @@ Sub-tables can be formatted in two styles controlled by ``table_format``:
 
 **Short format** (collapsed to dotted keys):
 
-.. code-block:: toml
+.. fmt-example::
+    :config: generate_python_version_classifiers=false
 
     [project]
     urls.homepage = "https://example.com"
@@ -160,7 +146,8 @@ Sub-tables can be formatted in two styles controlled by ``table_format``:
 
 **Long format** (expanded to table headers):
 
-.. code-block:: toml
+.. fmt-example::
+    :config: table_format=long generate_python_version_classifiers=false
 
     [project.urls]
     homepage = "https://example.com"
@@ -174,7 +161,8 @@ between them. You can control this with ``sub_table_spacing`` and ``separate_roo
 ``\n`` characters where each ``\n`` adds one blank line. For example, setting ``sub_table_spacing = "\n"`` adds a blank
 line between sub-tables:
 
-.. code-block:: toml
+.. fmt-example::
+    :config: table_format=long sub_table_spacing=\n
 
     [tool.ruff]
     line-length = 120
@@ -197,20 +185,12 @@ All comments are preserved during formatting:
 
 Inline comments within arrays are aligned independently per array, based on that array's longest value:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before - comments at inconsistent positions
     lint.ignore = [
       "COM812", # Conflict with formatter
       "CPY", # No copyright statements
       "ISC001",   # Another rule
-    ]
-
-    # After - comments align to longest value in this array
-    lint.ignore = [
-      "COM812",  # Conflict with formatter
-      "CPY",     # No copyright statements
-      "ISC001",  # Another rule
     ]
 
 Disabled Keys
@@ -222,21 +202,13 @@ out and ordered together with the table it belongs to, then comments it out agai
 key anchored to its entry instead of drifting to the next table, and formats the line the same way the enabled key would
 be:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     [[tool.uv.index]]
     name = "pypi"
     authenticate = "never"
     # default = true
     # ignore-error-codes = [400,401,403]
-
-    # After
-    [[tool.uv.index]]
-    name = "pypi"
-    authenticate = "never"
-    # default = true
-    # ignore-error-codes = [ 400, 401, 403 ]
 
 Comments that are not a single valid key-value (prose, multi-line blocks, commented-out table headers like
 ``# [tool.x]``) are left untouched and follow the usual comment-preservation rules above. The heuristic is purely
@@ -257,9 +229,10 @@ Files without a ``# Group:`` marker format the same as before, so the feature st
 
 The formatter sorts the entries inside each group:
 
-.. code-block:: toml
+.. fmt-example::
+    :config: generate_python_version_classifiers=false
 
-    # Before
+    [project]
     dependencies = [
       # Group: web
       "flask",
@@ -267,16 +240,6 @@ The formatter sorts the entries inside each group:
       # Group: db
       "sqlalchemy",
       "psycopg2",
-    ]
-
-    # After
-    dependencies = [
-      # Group: web
-      "django",
-      "flask",
-      # Group: db
-      "psycopg2",
-      "sqlalchemy",
     ]
 
 A ``# Group:`` marker works the same way before a key in a table or before a ``[tool.*]`` header: the formatter sorts the
@@ -314,17 +277,11 @@ redundant ``wheel`` requirement is removed when the build backend is setuptools.
     dynamic injection would honor), when ``backend-path`` is set (an in-tree backend may import ``wheel``
     directly), or when ``setuptools`` itself is missing from ``requires``.
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # Before
         [build-system]
         requires = ["setuptools >= 45", "wheel"]
         build-backend = "setuptools.build_meta"
-
-        # After
-        [build-system]
-        build-backend = "setuptools.build_meta"
-        requires = ["setuptools>=45"]
 
 ``[project]``
 ~~~~~~~~~~~~~
@@ -375,60 +332,50 @@ Keys follow the canonical metadata order; name, dependencies, classifiers, and k
     normalized per :pep:`508` (spaces removed, redundant ``.0`` suffixes stripped unless
     ``keep_full_version = true``) and sorted alphabetically by canonical package name:
 
-    .. code-block:: toml
+    .. fmt-example::
+        :config: generate_python_version_classifiers=false
 
-        # Before
+        [project]
         dependencies = ["requests >= 2.0.0", "click~=8.0"]
-
-        # After
-        dependencies = ["click>=8", "requests>=2"]
 
     **Optional-dependency extra names** are normalized to lowercase with hyphens:
 
-    .. code-block:: toml
+    .. fmt-example::
+        :config: generate_python_version_classifiers=false
 
-        # Before
         [project.optional-dependencies]
         Dev_Tools = ["pytest"]
 
-        # After
-        [project.optional-dependencies]
-        dev-tools = ["pytest"]
-
     **Python version classifiers** are generated automatically from ``requires-python`` and
-    ``max_supported_python``. Disable with ``generate_python_version_classifiers = false``:
+    ``max_supported_python`` (here ``3.14``). Disable with ``generate_python_version_classifiers = false``:
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # With requires-python = ">=3.10" and max_supported_python = "3.14"
-        classifiers = [
-            "Programming Language :: Python :: 3 :: Only",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
-            "Programming Language :: Python :: 3.12",
-            "Programming Language :: Python :: 3.13",
-            "Programming Language :: Python :: 3.14",
-        ]
+        [project]
+        requires-python = ">=3.10"
 
     **Entry points:** inline tables within ``entry-points`` are expanded to dotted keys:
 
-    .. code-block:: toml
+    .. fmt-example::
+        :config: generate_python_version_classifiers=false
 
-        # Before
+        [project]
         entry-points.console_scripts = { mycli = "mypackage:main" }
 
-        # After
-        entry-points.console_scripts.mycli = "mypackage:main"
+    **Authors / maintainers** can be inline tables (short format):
 
-    **Authors / maintainers** can be inline tables or an expanded array of tables (controlled by ``table_format``,
-    ``expand_tables``, and ``collapse_tables``):
+    .. fmt-example::
+        :config: generate_python_version_classifiers=false
 
-    .. code-block:: toml
-
-        # Short format (inline)
+        [project]
         authors = [{ name = "Alice", email = "alice@example.com" }]
 
-        # Long format (array of tables)
+    or an expanded array of tables (long format, controlled by ``table_format``, ``expand_tables``, and
+    ``collapse_tables``):
+
+    .. fmt-example::
+        :config: table_format=long generate_python_version_classifiers=false
+
         [[project.authors]]
         name = "Alice"
         email = "alice@example.com"
@@ -450,15 +397,10 @@ Groups are ordered ``dev`` → ``test`` → ``type`` → ``docs`` → others alp
     - all dependencies normalized per :pep:`508`
     - sorted with regular dependencies first, then ``include-group`` entries
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # Before
         [dependency-groups]
         dev = [{ include-group = "test" }, "ruff>=0.4", "mypy>=1"]
-
-        # After
-        [dependency-groups]
-        dev = ["mypy>=1", "ruff>=0.4", { include-group = "test" }]
 
 ``[tool.poetry]``
 ~~~~~~~~~~~~~~~~~
@@ -532,9 +474,8 @@ order, and set-semantic arrays are sorted while order-significant ones are prese
     Inline tables that don't match any Poetry-specific schema (for example ``[[project.authors]]`` inline form
     ``{ name = "...", email = "..." }``) are left untouched.
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # Before
         [[tool.poetry.source]]
         priority = "primary"
         url = "https://pypi.example.com/simple"
@@ -544,13 +485,6 @@ order, and set-semantic arrays are sorted while order-significant ones are prese
         zebra = "^1.0"
         python = "^3.11"
         foo = { branch = "main", git = "https://github.com/example/foo" }
-
-        # After
-        [tool.poetry]
-        dependencies.python = "^3.11"
-        dependencies.foo = { git = "https://github.com/example/foo", branch = "main" }
-        dependencies.zebra = "^1.0"
-        source = [ { name = "private", url = "https://pypi.example.com/simple", priority = "primary" } ]
 
 ``[tool.pdm.*]``
 ~~~~~~~~~~~~~~~~
@@ -638,9 +572,8 @@ literal lists like ``packages`` are preserved.
        ``version_file``) → ``write_to_template`` (use ``version_file_template``) → ``version_class`` (use
        ``version_cls``) → ``template``
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # Before
         [tool.setuptools]
         zip-safe = false
         py-modules = ["foo", "bar"]
@@ -653,16 +586,6 @@ literal lists like ``packages`` are preserved.
 
         [tool.setuptools.dynamic]
         readme = { content-type = "text/markdown", file = "README.md" }
-
-        # After
-        [tool.setuptools]
-        py-modules = [ "bar", "foo" ]
-        packages.find.where = [ "src" ]
-        packages.find.include = [ "my_pkg*" ]
-        packages.find.namespaces = true
-        packages = [ "my_pkg" ]
-        dynamic.readme = { file = "README.md", content-type = "text/markdown" }
-        zip-safe = false
 
 ``[tool.hatch.*]``
 ~~~~~~~~~~~~~~~~~~
@@ -826,17 +749,11 @@ workspace); package-name arrays and the ``sources`` table are sorted alphabetica
 
     **Sources table:** ``sources`` entries are sorted alphabetically by package name:
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # Before
         [tool.uv.sources]
         zebra = { git = "..." }
         alpha = { path = "..." }
-
-        # After
-        [tool.uv.sources]
-        alpha = { path = "..." }
-        zebra = { git = "..." }
 
     **pip subsection:** ``[tool.uv.pip]`` follows the same rules, with arrays like ``extra``, ``no-binary-package``,
     ``no-build-package``, ``reinstall-package``, and ``upgrade-package`` sorted alphabetically.
@@ -957,16 +874,15 @@ name arrays are sorted with natural ordering (``RUF1`` < ``RUF9`` < ``RUF10``).
     6. ``lint.*`` keys: ``select`` → ``extend-select`` → ``ignore`` → ``extend-ignore`` → ``per-file-ignores`` →
        ``fixable`` → ``unfixable`` → plugin configurations
 
-    **Sorted arrays:** alphabetical with natural ordering (``RUF1`` < ``RUF9`` < ``RUF10``):
+    **Sorted arrays:** alphabetical with natural ordering (``RUF1`` < ``RUF9`` < ``RUF10``); per-file-ignores values
+    are sorted too:
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # These arrays are sorted:
-        lint.select = ["E", "F", "I", "RUF"]
-        lint.ignore = ["E501", "E701"]
-
-        # Per-file-ignores values are also sorted:
-        lint.per-file-ignores."tests/*.py" = ["D103", "S101"]
+        [tool.ruff]
+        lint.select = ["F", "E", "RUF", "I"]
+        lint.ignore = ["E701", "E501"]
+        lint.per-file-ignores."tests/*.py" = ["S101", "D103"]
 
     The full set of sorted array keys:
 
@@ -1230,19 +1146,12 @@ configuration reference; set-semantic arrays are sorted, while ``plugins`` and `
     inside each inline entry are sorted in place, so ``disable_error_code = [...]`` is alphabetized whether the
     override is expanded or collapsed.
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # Before
         [[tool.mypy.overrides]]
         ignore_missing_imports = true
         disable_error_code = ["import-untyped", "attr-defined"]
         module = "third_party.*"
-
-        # After
-        [tool.mypy]
-        overrides = [
-          { module = "third_party.*", ignore_missing_imports = true, disable_error_code = [ "attr-defined", "import-untyped" ] },
-        ]
 
 ``[tool.pyrefly]``
 ~~~~~~~~~~~~~~~~~~
@@ -1330,23 +1239,14 @@ Keys in the ``ini_options`` block follow the pytest reference order; set-semanti
     **Preserved as written:** ``addopts`` (CLI argv, order matters) and ``pythonpath`` (a search path with
     priority semantics).
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # Before
         [tool.pytest.ini_options]
         log_cli_level = "INFO"
         markers = [ "slow: marks tests as slow", "fast: marks tests as fast" ]
         addopts = [ "--strict-markers", "-ra" ]
         testpaths = [ "tests" ]
         minversion = "8"
-
-        # After
-        [tool.pytest]
-        ini_options.minversion = "8"
-        ini_options.testpaths = [ "tests" ]
-        ini_options.addopts = [ "--strict-markers", "-ra" ]
-        ini_options.markers = [ "fast: marks tests as fast", "slow: marks tests as slow" ]
-        ini_options.log_cli_level = "INFO"
 
 ``[tool.coverage]``
 ~~~~~~~~~~~~~~~~~~~
@@ -1404,21 +1304,13 @@ set-semantic arrays are sorted.
     Report phase
       ``include``, ``omit``, ``exclude_lines``, ``exclude_also``, ``partial_branches``, ``partial_also``
 
-    .. code-block:: toml
+    .. fmt-example::
 
-        # Before (alphabetical)
         [tool.coverage]
         report.exclude_also = ["if TYPE_CHECKING:"]
         report.omit = ["tests/*"]
         run.branch = true
         run.omit = ["tests/*"]
-
-        # After (workflow order with groupings)
-        [tool.coverage]
-        run.branch = true
-        run.omit = ["tests/*"]
-        report.omit = ["tests/*"]
-        report.exclude_also = ["if TYPE_CHECKING:"]
 
 ``[tool.tox]``
 ~~~~~~~~~~~~~~

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -255,7 +255,7 @@ Beyond general formatting, each table has specific key ordering and value normal
 ~~~~~~~~~~~~~~~~~~
 
 The :pep:`517` / :pep:`518` table that declares how your project is built. See the
-`packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#build-system-table>`_.
+`packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-build-system-table>`_.
 
 Keys are ordered ``build-backend`` → ``requires`` → ``backend-path``, and ``requires`` is normalized and sorted. A
 redundant ``wheel`` requirement is removed when the build backend is setuptools.
@@ -288,7 +288,7 @@ redundant ``wheel`` requirement is removed when the build backend is setuptools.
 ~~~~~~~~~~~~~
 
 The :pep:`621` core metadata table. See the
-`packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#the-project-table>`_.
+`packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-project-table>`_.
 
 Keys follow the canonical metadata order; name, dependencies, classifiers, and keywords are normalized and sorted.
 

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -83,29 +83,29 @@ Arrays are formatted based on line length, trailing comma presence, and comments
 
     keywords = ["python", "toml"]
 
-Arrays that exceed ``column_width`` are expanded and get a trailing comma:
+Arrays that exceed ``column_width`` are expanded and get a trailing comma (shown here with a small ``column_width`` to
+keep the example short):
 
 .. fmt-example::
-    :config: generate_python_version_classifiers=false
+    :config: column_width=30 generate_python_version_classifiers=false
 
     [project]
-    keywords = ["formatting", "toml", "pyproject", "configuration", "linter", "automation", "developer-tools", "packaging"]
+    keywords = ["web", "toml", "pyproject", "formatting"]
 
-A trailing comma signals intent to keep the multiline format even when the array would fit on one line:
+A trailing comma forces the multiline format, even for an array that would otherwise fit on one line:
 
 .. fmt-example::
 
-    classifiers = [
-        "Development Status :: 4 - Beta",
-    ]
+    classifiers = ["Development Status :: 4 - Beta",]
 
-Arrays with comments are always multiline:
+A comment on an entry also forces the multiline format. Here ``["E501", "E701"]`` would fit on one line, but the
+comment keeps it expanded:
 
 .. fmt-example::
 
     lint.ignore = [
-        "E501",  # Line too long
-        "E701",
+      "E501", # too long
+      "E701",
     ]
 
 **Multiline formatting rules:**
@@ -120,11 +120,12 @@ String Wrapping
 ~~~~~~~~~~~~~~~
 
 Strings that exceed ``column_width`` (including the key name and ``" = "`` prefix) are wrapped into multi-line
-triple-quoted strings using line continuations:
+triple-quoted strings using line continuations (shown here with a small ``column_width``):
 
 .. fmt-example::
+    :config: column_width=40
 
-    description = "A very long project description that goes well beyond the configured column width limit and therefore must wrap onto multiple lines"
+    description = "Format your pyproject.toml file in place"
 
 Wrapping prefers breaking at spaces and at ``" :: "`` separators (common in Python classifiers). Strings inside inline
 tables are never wrapped. Strings that contain actual newlines are preserved as multi-line strings without adding line
@@ -478,13 +479,13 @@ order, and set-semantic arrays are sorted while order-significant ones are prese
 
         [[tool.poetry.source]]
         priority = "primary"
-        url = "https://pypi.example.com/simple"
+        url = "https://example.com"
         name = "private"
 
         [tool.poetry.dependencies]
         zebra = "^1.0"
         python = "^3.11"
-        foo = { branch = "main", git = "https://github.com/example/foo" }
+        foo = { branch = "main", git = "https://example.com/foo" }
 
 ``[tool.pdm.*]``
 ~~~~~~~~~~~~~~~~
@@ -678,8 +679,8 @@ arrays are sorted, while cargo/rustc argv are preserved.
 ``[tool.pixi]``
 ~~~~~~~~~~~~~~~
 
-`Pixi <https://pixi.sh/latest/>`_ is a cross-platform conda/PyPI package and environment manager. See its
-`pyproject.toml reference <https://pixi.sh/latest/python/pyproject_toml/>`_.
+`Pixi <https://pixi.prefix.dev/latest/>`_ is a cross-platform conda/PyPI package and environment manager. See its
+`pyproject.toml reference <https://pixi.prefix.dev/latest/python/pyproject_toml/>`_.
 
 Keys are grouped by function (workspace metadata → configuration → dependencies → environments → build); channel and
 platform arrays are sorted.
@@ -1149,9 +1150,8 @@ configuration reference; set-semantic arrays are sorted, while ``plugins`` and `
     .. fmt-example::
 
         [[tool.mypy.overrides]]
-        ignore_missing_imports = true
         disable_error_code = ["import-untyped", "attr-defined"]
-        module = "third_party.*"
+        module = "pkg.*"
 
 ``[tool.pyrefly]``
 ~~~~~~~~~~~~~~~~~~

--- a/pyproject-fmt/tox.toml
+++ b/pyproject-fmt/tox.toml
@@ -104,8 +104,8 @@ commands = [
 [env.readme]
 description = "generate README.rst from docs"
 runner = "uv-venv-runner"
-skip_install = true
-package = "skip"
+package = "wheel"
+wheel_build_env = ".pkg"
 dependency_groups = []
 change_dir = "{tox_root}{/}.."
 commands = [["python", "tasks{/}generate_readme.py", "pyproject-fmt"]]

--- a/tasks/fmt_examples.py
+++ b/tasks/fmt_examples.py
@@ -1,0 +1,98 @@
+"""Render TOML formatting examples by running the local formatter.
+
+Shared by the ``fmt-example`` Sphinx directive (live HTML build) and
+``generate_readme.py`` (static expansion for PyPI), so both surfaces show the
+exact output the installed formatter produces and can never drift from it.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+# Default Settings kwargs per formatter, mirroring each package's CLI defaults.
+DEFAULTS: Final[Mapping[str, Mapping[str, Any]]] = {
+    "pyproject_fmt": {
+        "column_width": 120,
+        "indent": 2,
+        "keep_full_version": False,
+        "max_supported_python": (3, 14),
+        "min_supported_python": (3, 10),
+        "generate_python_version_classifiers": True,
+        "table_format": "short",
+        "sub_table_spacing": "",
+        "separate_root_table": "\n",
+        "expand_tables": (),
+        "collapse_tables": (),
+        "skip_wrap_for_keys": (),
+    },
+    "tox_toml_fmt": {
+        "column_width": 120,
+        "indent": 2,
+        "table_format": "short",
+        "sub_table_spacing": "",
+        "separate_root_table": "\n",
+        "expand_tables": (),
+        "collapse_tables": (),
+        "skip_wrap_for_keys": (),
+        "pin_envs": (),
+    },
+}
+
+
+def render_example(module: str, before: str, config: str = "") -> str:
+    """
+    Format ``before`` with ``module``'s formatter and render the example text.
+
+    :param module: formatter package, ``pyproject_fmt`` or ``tox_toml_fmt``
+    :param before: the input TOML the author wrote
+    :param config: ``key=value`` overrides, space-separated (e.g. ``table_format=long``)
+    :return: a ``# Before`` / ``# After`` block, or a single block when already formatted
+    """
+    before = before.strip("\n")
+    after = format_example(module, before, config).strip("\n")
+    if after == before:
+        return after
+    return f"# Before\n{before}\n\n# After\n{after}"
+
+
+def format_example(module: str, before: str, config: str = "") -> str:
+    """
+    Format ``before`` with ``module``'s formatter.
+
+    :param module: formatter package, ``pyproject_fmt`` or ``tox_toml_fmt``
+    :param before: the input TOML the author wrote
+    :param config: ``key=value`` overrides, space-separated
+    :return: the formatted TOML
+    """
+    lib = importlib.import_module(f"{module}._lib")
+    defaults = dict(DEFAULTS[module])
+    defaults.update(_parse_config(config, defaults))
+    return lib.format_toml(before, lib.Settings(**defaults))
+
+
+def _parse_config(config: str, defaults: Mapping[str, Any]) -> dict[str, Any]:
+    overrides: dict[str, Any] = {}
+    for token in config.split():
+        key, sep, raw = token.partition("=")
+        if not sep or key not in defaults:
+            msg = f"invalid fmt-example config token: {token!r}"
+            raise ValueError(msg)
+        overrides[key] = _coerce(raw, defaults[key])
+    return overrides
+
+
+def _coerce(raw: str, default: Any) -> Any:
+    if isinstance(default, bool):
+        return raw == "true"
+    if isinstance(default, int):
+        return int(raw)
+    if isinstance(default, tuple) and default and isinstance(default[0], int):
+        major, minor = raw.split(".")
+        return int(major), int(minor)
+    if isinstance(default, (tuple, list)):
+        return tuple(raw.split(","))
+    return raw.replace("\\n", "\n")

--- a/tasks/generate_readme.py
+++ b/tasks/generate_readme.py
@@ -6,14 +6,20 @@ import re
 import sys
 from pathlib import Path
 
+from fmt_examples import render_example
+
 
 def main(package: str) -> None:
     pkg = Path(package)
+    module = package.replace("-", "_")
     docs_dir = pkg / "docs"
     if not (index_path := docs_dir / "index.rst").exists():
         return
 
-    processed = process_rst_for_pypi(index_path.read_text(encoding="utf-8"))
+    def read(path: Path) -> str:
+        return expand_fmt_examples(path.read_text(encoding="utf-8"), module)
+
+    processed = process_rst_for_pypi(read(index_path))
 
     changelog_rst = ""
     if (changelog_path := pkg / "CHANGELOG.md").exists() and (
@@ -27,12 +33,48 @@ def main(package: str) -> None:
             processed = processed + "\n\n" + changelog_rst
 
     if (config_path := docs_dir / "configuration.rst").exists():
-        processed += "\n\n" + process_rst_for_pypi(strip_main_title(config_path.read_text(encoding="utf-8")))
+        processed += "\n\n" + process_rst_for_pypi(strip_main_title(read(config_path)))
 
     if (formatting_path := docs_dir / "formatting.rst").exists():
-        processed += "\n\n" + process_rst_for_pypi(strip_main_title(formatting_path.read_text(encoding="utf-8")))
+        processed += "\n\n" + process_rst_for_pypi(strip_main_title(read(formatting_path)))
 
-    (pkg / "README.rst").write_text(processed, encoding="utf-8")
+    (pkg / "README.rst").write_text(processed.rstrip() + "\n", encoding="utf-8")
+
+
+def expand_fmt_examples(content: str, module: str) -> str:
+    """Replace ``.. fmt-example::`` directives with the static ``code-block`` they render to."""
+    lines = content.splitlines()
+    result: list[str] = []
+    i = 0
+    while i < len(lines):
+        if (match := re.match(r"^(\s*)\.\. fmt-example::\s*$", lines[i])) is None:
+            result.append(lines[i])
+            i += 1
+            continue
+        base = match.group(1)
+        config = ""
+        i += 1
+        while i < len(lines) and (option := re.match(rf"^{base}\s+:config:\s*(.*)$", lines[i])):
+            config = option.group(1).strip()
+            i += 1
+        while i < len(lines) and not lines[i].strip():
+            i += 1
+        body: list[str] = []
+        while i < len(lines) and (not lines[i].strip() or lines[i].startswith(f"{base} ")):
+            body.append(lines[i])
+            i += 1
+        before = "\n".join(line[len(base) :] for line in body).strip("\n")
+        rendered = render_example(module, _dedent(before), config)
+        result.extend((f"{base}.. code-block:: toml", ""))
+        result.extend(f"{base}   {line}" if line else "" for line in rendered.splitlines())
+        result.append("")
+    return "\n".join(result)
+
+
+def _dedent(text: str) -> str:
+    body = [line for line in text.splitlines() if line.strip()]
+    pad = min((len(line) - len(line.lstrip()) for line in body), default=0)
+    return "\n".join(line[pad:] if line.strip() else "" for line in text.splitlines())
 
 
 def strip_main_title(content: str) -> str:

--- a/tasks/sphinx_fmt_example.py
+++ b/tasks/sphinx_fmt_example.py
@@ -1,0 +1,36 @@
+"""Sphinx ``fmt-example`` directive: render TOML examples via the live formatter.
+
+The directive body is the input TOML; the formatted output is computed at build
+time, so documented behavior can never drift from the installed formatter. The
+``:config:`` option passes ``key=value`` overrides to the formatter.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+from fmt_examples import render_example
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+
+class FmtExample(Directive):
+    has_content = True
+    option_spec: ClassVar = {"config": directives.unchanged}
+
+    def run(self) -> list[nodes.Node]:
+        module = self.state.document.settings.env.config.fmt_example_module
+        before = "\n".join(self.content)
+        text = render_example(module, before, self.options.get("config", ""))
+        node = nodes.literal_block(text, text)
+        node["language"] = "toml"
+        return [node]
+
+
+def setup(app: Sphinx) -> dict[str, bool]:
+    app.add_config_value("fmt_example_module", "", "env")
+    app.add_directive("fmt-example", FmtExample)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/tox-toml-fmt/README.rst
+++ b/tox-toml-fmt/README.rst
@@ -672,11 +672,11 @@ Inline Table Key Reordering
 Keys within inline tables are reordered into a consistent order based on the inline table's type. The type
 is detected by the presence of a discriminator key:
 
-- **``replace``**: ``replace`` → ``condition`` → ``of`` → ``env`` → ``key`` → ``name`` → ``pattern`` →
+- ``replace``: ``replace`` → ``condition`` → ``of`` → ``env`` → ``key`` → ``name`` → ``pattern`` →
   ``then`` → ``else`` → ``default`` → ``extend`` → ``marker``
-- **``prefix``**: ``prefix`` → ``start`` → ``stop``
-- **``product``**: ``product`` → ``exclude``
-- **``value``**: ``value`` → ``marker``
+- ``prefix``: ``prefix`` → ``start`` → ``stop``
+- ``product``: ``product`` → ``exclude``
+- ``value``: ``value`` → ``marker``
 
 Keys not listed in the schema are appended at the end in their original order.
 

--- a/tox-toml-fmt/README.rst
+++ b/tox-toml-fmt/README.rst
@@ -188,48 +188,40 @@ Arrays are formatted based on line length, trailing comma presence, and comments
    # After
    env_list = [ "py313", "py312", "lint" ]
 
-Arrays that exceed ``column_width`` are expanded and get a trailing comma:
+Arrays that exceed ``column_width`` are expanded and get a trailing comma (shown here with a small ``column_width`` to
+keep the example short):
 
 .. code-block:: toml
 
    # Before
    [env.test]
-   deps = ["pytest>=7", "pytest-cov>=4", "pytest-mock>=3", "this-final-entry-clearly-makes-the-array-exceed-the-column-width-limit>=1"]
+   deps = ["pytest>=7", "coverage>=7", "tox>=4"]
 
    # After
    [env.test]
    deps = [
+     "coverage>=7",
      "pytest>=7",
-     "pytest-cov>=4",
-     "pytest-mock>=3",
-     "this-final-entry-clearly-makes-the-array-exceed-the-column-width-limit>=1",
+     "tox>=4",
    ]
 
-A trailing comma signals intent to keep the multiline format even when the array would fit on one line:
+A trailing comma forces the multiline format, even for an array that would otherwise fit on one line:
 
 .. code-block:: toml
 
    # Before
-   deps = [
-       "pytest>=7",
-   ]
+   deps = ["pytest>=7",]
 
    # After
    deps = [
      "pytest>=7",
    ]
 
-Arrays with comments are always multiline:
+A comment on an entry also forces the multiline format. Here ``["pytest>=7", "coverage>=7"]`` would fit on one line,
+but the comment keeps it expanded:
 
 .. code-block:: toml
 
-   # Before
-   deps = [
-       "pytest>=7",  # testing framework
-       "coverage>=7",
-   ]
-
-   # After
    deps = [
      "pytest>=7",   # testing framework
      "coverage>=7",
@@ -246,17 +238,20 @@ An array becomes multiline when any of these conditions are met:
 String Wrapping
 ~~~~~~~~~~~~~~~
 
-Long strings that exceed ``column_width`` are wrapped using TOML multiline basic strings with line-ending backslashes:
+Long strings that exceed ``column_width`` are wrapped using TOML multiline basic strings with line-ending backslashes
+(shown here with a small ``column_width``):
 
 .. code-block:: toml
 
    # Before
-   description = "A very long description string that exceeds the column width limit set for this project and therefore wraps onto several lines"
+   [env.test]
+   description = "run the entire unit test suite with coverage"
 
    # After
+   [env.test]
    description = """\
-     A very long description string that exceeds the column width limit set for this project and therefore wraps onto \
-     several lines\
+     run the entire unit test suite with \
+     coverage\
      """
 
 Specific keys can be excluded from wrapping using ``skip_wrap_for_keys``. Patterns support wildcards
@@ -640,10 +635,12 @@ without PEP 508 normalization, but still participate in sorting by their lowerca
 .. code-block:: toml
 
    # Before
+   [env_run_base]
    deps = ["Pytest >= 7", "-r requirements.txt", "coverage", "-e ./my-pkg[test]"]
 
    # After
-   deps = [ "Pytest >= 7", "-r requirements.txt", "coverage", "-e ./my-pkg[test]" ]
+   [env_run_base]
+   deps = [ "-e ./my-pkg[test]", "-r requirements.txt", "coverage", "pytest>=7" ]
 
 **Sorted alphabetically:**
 
@@ -656,7 +653,13 @@ then string entries are sorted alphabetically:
 
 .. code-block:: toml
 
-   pass_env = ["TERM", "CI", { replace = "default", ... }, "HOME"]
+   # Before
+   [env.test]
+   pass_env = ["TERM", "CI", { replace = "env", name = "PATH" }, "HOME"]
+
+   # After
+   [env.test]
+   pass_env = [ { replace = "env", name = "PATH" }, "CI", "HOME", "TERM" ]
 
 **Arrays NOT sorted:**
 
@@ -681,10 +684,10 @@ Keys not listed in the schema are appended at the end in their original order.
 
    # Before
    pass_env = [{ default = ".", replace = "default", extend = true }]
-   env_list = [{ exclude = ["py38-django50"], product = ["py38", "py310", "django42", "django50"] }]
+   env_list = [{ exclude = ["py312-django"], product = ["py312", "py313"] }]
 
    # After
-   env_list = [ { product = [ "py38", "py310", "django42", "django50" ], exclude = [ "py38-django50" ] } ]
+   env_list = [ { product = [ "py312", "py313" ], exclude = [ "py312-django" ] } ]
    pass_env = [ { replace = "default", default = ".", extend = true } ]
 
 This reordering applies to all inline tables in the file, including those nested inside arrays.

--- a/tox-toml-fmt/README.rst
+++ b/tox-toml-fmt/README.rst
@@ -1,1 +1,696 @@
-.. empty readme file so you can uv tool install directly from a github url (normally it is generated at build time)
+Overview
+========
+
+Apply a consistent format to your ``tox.toml`` file with comment support. See
+`changelog here <https://github.com/tox-dev/toml-fmt/blob/main/tox-toml-fmt/CHANGELOG.md>`_.
+
+
+Recent Changes
+~~~~~~~~~~~~~~~~
+
+- ✨ feat(build): support free-threaded Python wheels by `@gaborbernat <https://github.com/gaborbernat>`_ in
+  `#307 <https://github.com/tox-dev/toml-fmt/pull/307>`_
+- 🐛 fix(common): skip empty tables in Tables::get by `@gaborbernat <https://github.com/gaborbernat>`_ in
+  `#304 <https://github.com/tox-dev/toml-fmt/pull/304>`_
+- Update Python dependencies by `@gaborbernat <https://github.com/gaborbernat>`_ in
+  `#301 <https://github.com/tox-dev/toml-fmt/pull/301>`_
+- Update Python dependencies by `@gaborbernat <https://github.com/gaborbernat>`_ in
+  `#295 <https://github.com/tox-dev/toml-fmt/pull/295>`_
+- Update Rust dependencies by `@gaborbernat <https://github.com/gaborbernat>`_ in
+  `#296 <https://github.com/tox-dev/toml-fmt/pull/296>`_ <a id="1.9.2"></a>
+
+Philosophy
+----------
+This is an *opinionated formatter*, with the same objectives as `black <https://github.com/psf/black>`_: it offers few
+configuration settings on purpose. In return you get consistency, predictability, and smaller diffs.
+
+Use
+---
+
+Via ``CLI``
+~~~~~~~~~~~
+
+`tox-toml-fmt <https://pypi.org/project/tox-toml-fmt>`_ is a CLI tool that needs Python 3.10 or higher to run. Install it into an isolated environment
+with `pipx <https://pypi.org/project/pipx>`_ or `uv <https://pypi.org/project/uv>`_; that way you can upgrade tox-toml-fmt later without disturbing the rest of your
+system. A ``pip`` path follows for completeness, though we discourage it:
+
+
+    .. code-block:: bash
+
+        # install uv per https://docs.astral.sh/uv/#getting-started
+        uv tool install tox-toml-fmt
+        tox-toml-fmt --help
+
+
+Via ``pre-commit`` hook
+~~~~~~~~~~~~~~~~~~~~~~~
+
+See `pre-commit/pre-commit <https://github.com/pre-commit/pre-commit>`_ for instructions, sample ``.pre-commit-config.yaml``:
+
+.. code-block:: yaml
+
+    - repo: https://github.com/tox-dev/tox-toml-fmt
+      rev: "v1.0.0"
+      hooks:
+        - id: tox-toml-fmt
+
+Via Python
+~~~~~~~~~~
+
+Call ``tox-toml-fmt`` as a Python module to format TOML from your own code.
+
+.. code-block:: python
+
+    from tox_toml_fmt import run
+
+    # Format a tox.toml file and return the exit code
+    exit_code = run(["path/to/tox.toml"])
+
+The ``run`` function accepts command-line arguments as a list and returns an exit code (0 for success, non-zero for
+failure).
+
+
+The ``[tox-toml-fmt]`` table is used when present in the ``tox.toml`` file:
+
+.. code-block:: toml
+
+    [tox-toml-fmt]
+
+    # After how many columns split arrays/dicts into multiple lines and wrap long strings;
+    # use a trailing comma in arrays to force multiline format instead of lowering this value
+    column_width = 120
+
+    # Number of spaces for indentation
+    indent = 2
+
+    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line between sub-tables)
+    sub_table_spacing = ""
+
+    # Extra newlines between root table groups (e.g. "\n" for one blank line, "\n\n" for two)
+    separate_root_table = "\n"
+
+    # Environments pinned to the start of env_list
+    pin_envs = ["fix", "type"]
+
+If not set they will default to values from the CLI. The example above shows the defaults (except ``pin_envs``
+which defaults to an empty list).
+
+Shared configuration file
+-------------------------
+
+Place formatting settings in a standalone ``tox-toml-fmt.toml`` file instead of (or alongside) the ``[tox-toml-fmt]``
+table. In a monorepo this shares one configuration across projects without repeating it in every ``tox.toml``.
+
+The formatter searches for ``tox-toml-fmt.toml`` from the directory of the file being formatted up to the filesystem
+root, and the first match wins. Pass an explicit path via ``--config``:
+
+.. code-block:: bash
+
+    tox-toml-fmt --config /path/to/tox-toml-fmt.toml tox.toml
+
+The shared config file uses the same keys as the ``[tox-toml-fmt]`` table, but without the table header:
+
+.. code-block:: toml
+
+    column_width = 120
+    indent = 2
+    sub_table_spacing = ""
+    separate_root_table = "\n"
+    pin_envs = ["fix", "type"]
+
+When both a shared config file and a ``[tox-toml-fmt]`` table exist, per-file settings from the ``[tox-toml-fmt]``
+table take precedence over the shared config file.
+
+``tox-toml-fmt`` is an opinionated formatter, much like `black <https://github.com/psf/black>`_ is for Python code. It
+keeps configuration minimal so every ``tox.toml`` lands on one standard format. That buys you:
+
+- less time configuring tools
+- smaller diffs when committing changes
+- code reviews where formatting never comes up
+
+A few options exist (``column_width``, ``indent``, ``table_format``, ``sub_table_spacing``, ``separate_root_table``),
+but there are no dozens of toggles.
+
+General Formatting
+------------------
+
+These rules apply uniformly across the entire ``tox.toml`` file.
+
+String Quotes
+~~~~~~~~~~~~~
+
+All strings use double quotes by default. Single quotes are only used when the value contains double quotes:
+
+.. code-block:: toml
+
+   # Before
+   [env.test]
+   description = 'Run tests'
+   commands = ["echo \"hello\""]
+
+   # After
+   [env.test]
+   description = "Run tests"
+   commands = [ 'echo "hello"' ]
+
+Key Quotes
+~~~~~~~~~~
+
+TOML keys are normalized to the simplest valid form. Keys that are valid bare keys (containing only
+``A-Za-z0-9_-``) have redundant quotes stripped. Single-quoted (literal) keys that require quoting are
+converted to double-quoted (basic) strings with proper escaping. This applies to all keys: table headers,
+key-value pairs, and inline table keys:
+
+.. code-block:: toml
+
+   # Before
+   [env.'my env']
+   "description" = "run tests"
+   pass_env = [{ "else" = "no" }]
+
+   # After
+   [env."my env"]
+   description = "run tests"
+   pass_env = [ { else = "no" } ]
+
+Backslashes and double quotes within literal keys are escaped during conversion.
+
+Array Formatting
+~~~~~~~~~~~~~~~~
+
+Arrays are formatted based on line length, trailing comma presence, and comments. Short arrays stay on one line:
+
+.. code-block:: toml
+
+   # Before
+   env_list = ["py312", "py313", "lint"]
+
+   # After
+   env_list = [ "py313", "py312", "lint" ]
+
+Arrays that exceed ``column_width`` are expanded and get a trailing comma:
+
+.. code-block:: toml
+
+   # Before
+   [env.test]
+   deps = ["pytest>=7", "pytest-cov>=4", "pytest-mock>=3", "this-final-entry-clearly-makes-the-array-exceed-the-column-width-limit>=1"]
+
+   # After
+   [env.test]
+   deps = [
+     "pytest>=7",
+     "pytest-cov>=4",
+     "pytest-mock>=3",
+     "this-final-entry-clearly-makes-the-array-exceed-the-column-width-limit>=1",
+   ]
+
+A trailing comma signals intent to keep the multiline format even when the array would fit on one line:
+
+.. code-block:: toml
+
+   # Before
+   deps = [
+       "pytest>=7",
+   ]
+
+   # After
+   deps = [
+     "pytest>=7",
+   ]
+
+Arrays with comments are always multiline:
+
+.. code-block:: toml
+
+   # Before
+   deps = [
+       "pytest>=7",  # testing framework
+       "coverage>=7",
+   ]
+
+   # After
+   deps = [
+     "pytest>=7",   # testing framework
+     "coverage>=7",
+   ]
+
+**Multiline formatting rules:**
+
+An array becomes multiline when any of these conditions are met:
+
+1. **Trailing comma present** - A trailing comma signals intent to keep multiline format
+2. **Exceeds column width** - Arrays longer than ``column_width`` are expanded (and get a trailing comma added)
+3. **Contains comments** - Arrays with inline or leading comments are always multiline
+
+String Wrapping
+~~~~~~~~~~~~~~~
+
+Long strings that exceed ``column_width`` are wrapped using TOML multiline basic strings with line-ending backslashes:
+
+.. code-block:: toml
+
+   # Before
+   description = "A very long description string that exceeds the column width limit set for this project and therefore wraps onto several lines"
+
+   # After
+   description = """\
+     A very long description string that exceeds the column width limit set for this project and therefore wraps onto \
+     several lines\
+     """
+
+Specific keys can be excluded from wrapping using ``skip_wrap_for_keys``. Patterns support wildcards
+(e.g. ``*.commands`` skips wrapping for ``commands`` under any table).
+
+Table Formatting
+~~~~~~~~~~~~~~~~
+
+Sub-tables can be formatted in two styles controlled by ``table_format``:
+
+**Short format** (default, collapsed to dotted keys):
+
+.. code-block:: toml
+
+   [env.test]
+   description = "run tests"
+   sub.value = 1
+
+**Long format** (expanded to table headers):
+
+.. code-block:: toml
+
+   # Before
+   [env.test]
+   description = "run tests"
+   sub.value = 1
+
+   # After
+   [env.test]
+   description = "run tests"
+
+   [env.test.sub]
+   value = 1
+
+Individual tables can override the default using ``expand_tables`` and ``collapse_tables``.
+
+**Table spacing:**
+
+By default, different table groups are separated by a blank line, while sub-tables within the same group are kept
+compact. You can control this with ``sub_table_spacing`` and ``separate_root_table``. Each option takes a string of
+``\n`` characters where each ``\n`` adds one blank line. For example, setting ``sub_table_spacing = "\n"`` adds a blank
+line between sub-tables within the same environment.
+
+
+**Environment tables are always expanded:**
+
+Regardless of the ``table_format`` setting, ``[env.*]`` tables are never collapsed into dotted keys under ``[env]``.
+Each environment always gets its own ``[env.NAME]`` table section:
+
+.. code-block:: toml
+
+    # This is always the output format, even in short mode:
+    [env.fix]
+    description = "fix"
+
+    [env.test]
+    description = "test"
+
+    # Dotted keys under [env] are automatically expanded:
+    # [env]
+    # fix.description = "fix"    →    [env.fix]
+    #                                  description = "fix"
+
+Sub-tables within an environment (e.g. ``[env.test.sub]``) still follow the ``table_format`` setting.
+
+Comment Preservation
+~~~~~~~~~~~~~~~~~~~~
+
+All comments are preserved during formatting:
+
+- **Inline comments** - Comments after a value on the same line stay with that value
+- **Leading comments** - Comments on the line before an entry stay with the entry below
+- **Block comments** - Multi-line comment blocks are preserved
+
+**Inline comment alignment:**
+
+Inline comments within arrays are aligned independently per array, based on that array's longest value:
+
+.. code-block:: toml
+
+   # Before
+   deps = [
+     "pytest", # testing
+     "pytest-cov",  # coverage
+     "pytest-mock", # mocking
+   ]
+
+   # After
+   deps = [
+     "pytest",      # testing
+     "pytest-cov",  # coverage
+     "pytest-mock", # mocking
+   ]
+
+Disabled Keys
+~~~~~~~~~~~~~
+
+A commented-out line whose body is itself a single valid key-value (for example ``# set_env = { A = "1" }``) is treated
+as a temporarily *disabled* field rather than free text. The formatter enables it for the duration of the pass, so it is
+laid out and ordered together with the table it belongs to, then comments it out again on the way out. This keeps a
+disabled key anchored to its entry instead of drifting to the next table, and formats the line the same way the enabled
+key would be:
+
+.. code-block:: toml
+
+   # Before
+   [env_run_base]
+   description = "run the tests"
+   # set_env = {A = "1"}
+
+   # After
+   [env_run_base]
+   description = "run the tests"
+   # set_env = { A = "1" }
+
+Comments that are not a single valid key-value (prose, multi-line blocks, commented-out table headers like
+``# [env.docs]``) are left untouched and follow the usual comment-preservation rules above. The heuristic is purely
+structural, so a prose comment that *happens* to be valid TOML is reflowed too; if that matters, phrase the comment so it
+does not parse as a key-value. Keys that would not fit on a single line within ``column_width`` are left as plain
+comments.
+
+Group Markers
+~~~~~~~~~~~~~
+
+By default the formatter reorders each array and table as a single unit, so any entry can move to its sorted position.
+Mark a boundary with a standalone comment that starts with ``# Group:``: the formatter then sorts within each group,
+holds the groups in their original order, and keeps the marker at the top of its group. Reach for this when related
+entries belong together but should still be sorted.
+
+Files without a ``# Group:`` marker format the same as before, so the feature stays opt-in. Case does not matter, so
+``# group:`` works too. Only standalone comment lines count; the formatter ignores inline trailing comments.
+
+.. code-block:: toml
+
+   # Before
+   [env.test]
+   deps = [
+     # Group: runtime
+     "requests",
+     "click",
+     # Group: testing
+     "pytest-cov",
+     "pytest",
+   ]
+
+   # After
+   [env.test]
+   deps = [
+     # Group: runtime
+     "click",
+     "requests",
+     # Group: testing
+     "pytest",
+     "pytest-cov",
+   ]
+
+Table-Specific Handling
+-----------------------
+
+Beyond general formatting, tables have specific key ordering, value normalization, and sorting rules.
+
+Table Ordering
+~~~~~~~~~~~~~~
+
+Tables are reordered into a consistent structure:
+
+1. Root-level keys (``min_version``, ``requires``, ``env_list``, etc.)
+2. ``[env_run_base]``
+3. ``[env_pkg_base]``
+4. ``[env_base.*]`` sections (shared base configurations)
+5. ``[env.NAME]`` sections ordered by ``env_list`` if specified
+6. Any remaining ``[env.*]`` sections not in ``env_list``, sorted alphabetically
+7. ``[env]`` (catch-all environment table, if present)
+
+.. code-block:: toml
+
+    # env_list determines the order of [env.*] sections
+    env_list = ["lint", "type", "py312", "py313"]
+
+    [env_run_base]
+    deps = ["pytest>=7"]
+
+    [env_pkg_base]
+    # ...
+
+    [env_base.ci]
+    # shared base config
+
+    # Environments appear in env_list order:
+    [env.lint]
+    # ...
+
+    [env.type]
+    # ...
+
+    [env.py312]
+    # ...
+
+    [env.py313]
+    # ...
+
+Environments not listed in ``env_list`` are placed at the end, sorted alphabetically.
+
+Alias Normalization
+~~~~~~~~~~~~~~~~~~~
+
+Legacy INI-style key names are renamed to their modern tox 4 TOML equivalents. This applies automatically
+to the root table, ``[env_run_base]``, ``[env_pkg_base]``, and all ``[env.*]`` tables.
+
+**Root table aliases:**
+
+.. code-block:: toml
+
+   # Before
+   envlist = ["py312", "py313"]
+   minversion = "4.2"
+   skipsdist = true
+
+   # After
+   min_version = "4.2"
+   env_list = [ "py313", "py312" ]
+   no_package = true
+
+Full list: ``envlist`` → ``env_list``, ``toxinidir`` → ``tox_root``, ``toxworkdir`` → ``work_dir``,
+``skipsdist`` → ``no_package``, ``isolated_build_env`` → ``package_env``, ``setupdir`` → ``package_root``,
+``minversion`` → ``min_version``, ``ignore_basepython_conflict`` → ``ignore_base_python_conflict``
+
+**Environment table aliases:**
+
+.. code-block:: toml
+
+   # Before
+   [env_run_base]
+   basepython = "python3.12"
+   setenv.PYTHONPATH = "src"
+   passenv = ["HOME"]
+
+   # After
+   [env_run_base]
+   base_python = "python3.12"
+   pass_env = [ "HOME" ]
+   setenv.PYTHONPATH = "src"
+
+Full list: ``setenv`` → ``set_env``, ``passenv`` → ``pass_env``, ``envdir`` → ``env_dir``,
+``envtmpdir`` → ``env_tmp_dir``, ``envlogdir`` → ``env_log_dir``, ``changedir`` → ``change_dir``,
+``basepython`` → ``base_python``, ``usedevelop`` → ``use_develop``, ``sitepackages`` →
+``system_site_packages``, ``alwayscopy`` → ``always_copy``
+
+Root Key Ordering
+~~~~~~~~~~~~~~~~~
+
+Keys in the root table are reordered into a consistent sequence:
+
+``min_version`` → ``requires`` → ``provision_tox_env`` → ``env_list`` → ``labels`` → ``base`` →
+``package_env`` → ``package_root`` → ``no_package`` → ``skip_missing_interpreters`` →
+``ignore_base_python_conflict`` → ``work_dir`` → ``temp_dir`` → ``tox_root``
+
+.. code-block:: toml
+
+   # Before
+   env_list = ["py312", "lint"]
+   requires = ["tox>=4.2"]
+   min_version = "4.2"
+
+   # After
+   min_version = "4.2"
+   requires = [ "tox>=4.2" ]
+   env_list = [ "py312", "lint" ]
+
+Environment Key Ordering
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Keys within ``[env_run_base]``, ``[env_pkg_base]``, and ``[env.*]`` tables are reordered to group related
+settings:
+
+``factors`` → ``runner`` → ``description`` → ``base_python`` → ``default_base_python`` →
+``system_site_packages`` → ``always_copy`` → ``download`` → ``virtualenv_spec`` → ``package`` →
+``package_env`` → ``wheel_build_env`` → ``package_tox_env_type`` → ``package_root`` →
+``skip_install`` → ``use_develop`` → ``meta_dir`` → ``pkg_dir`` → ``pip_pre`` →
+``install_command`` → ``list_dependencies_command`` → ``deps`` → ``dependency_groups`` →
+``pylock`` → ``constraints`` → ``constrain_package_deps`` → ``use_frozen_constraints`` → ``extras`` →
+``recreate`` → ``recreate_commands`` → ``parallel_show_output`` → ``skip_missing_interpreters`` →
+``fail_fast`` → ``pass_env`` → ``disallow_pass_env`` → ``set_env`` → ``change_dir`` →
+``platform`` → ``args_are_paths`` → ``ignore_errors`` → ``commands_retry`` → ``ignore_outcome`` →
+``extra_setup_commands`` → ``commands_pre`` → ``commands`` → ``commands_post`` →
+``allowlist_externals`` → ``labels`` → ``suicide_timeout`` → ``interrupt_timeout`` →
+``terminate_timeout`` → ``depends`` → ``env_dir`` → ``env_tmp_dir`` → ``env_log_dir``
+
+.. code-block:: toml
+
+   # Before
+   [env_run_base]
+   commands = ["pytest"]
+   deps = ["pytest>=7"]
+   description = "run tests"
+
+   # After
+   [env_run_base]
+   description = "run tests"
+   deps = [ "pytest>=7" ]
+   commands = [ "pytest" ]
+
+``requires`` Normalization
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Dependencies in the root ``requires`` array are normalized per PEP 508 (canonical package names,
+consistent spacing around specifiers) and sorted alphabetically by package name:
+
+.. code-block:: toml
+
+   # Before
+   requires = ["tox >= 4.2", "tox-uv"]
+
+   # After
+   requires = [ "tox>=4.2", "tox-uv" ]
+
+``env_list`` Sorting
+~~~~~~~~~~~~~~~~~~~~
+
+The ``env_list`` array is sorted with a specific ordering:
+
+1. **Pinned environments** come first, in the order specified by ``--pin-env``
+2. **CPython versions** (matching ``py3.12``, ``py312``, ``3.12``, etc.) sorted descending (newest first)
+3. **PyPy versions** (matching ``pypy3.10``, ``pypy310``, etc.) sorted descending
+4. **Named environments** (``lint``, ``type``, ``docs``, etc.) sorted alphabetically
+
+Inline table entries (such as ``{ product = ... }``) in ``env_list`` are excluded from sorting and remain
+in their original positions.
+
+Compound environment names separated by ``-`` are classified by their first recognized part:
+
+.. code-block:: toml
+
+   # Before
+   env_list = ["lint", "py38", "py312", "docs", "py310-django"]
+
+   # After
+   env_list = [ "py312", "py310-django", "py38", "docs", "lint" ]
+
+Use ``--pin-env`` (here ``fix,type``) to pin specific environments to the start:
+
+.. code-block:: toml
+
+   # Before
+   env_list = ["lint", "py312", "py313", "docs", "fix", "type"]
+
+   # After
+   env_list = [ "fix", "type", "py313", "py312", "docs", "lint" ]
+
+
+``use_develop`` Upgrade
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The legacy ``use_develop = true`` setting is automatically converted to the modern ``package = "editable"``
+equivalent. If ``use_develop = false``, the key is left as-is. If a ``package`` key already exists,
+only the ``use_develop`` key is removed:
+
+.. code-block:: toml
+
+   # Before
+   [env_run_base]
+   use_develop = true
+
+   # After
+   [env_run_base]
+   package = "editable"
+
+Array Sorting
+~~~~~~~~~~~~~
+
+Certain arrays within environment tables are sorted automatically:
+
+**Sorted by canonical PEP 508 package name:**
+
+- ``deps``, ``constraints``: dependencies normalized and sorted by package name
+
+Pip file references (``-r``, ``-c``), editable installs (``-e``), local paths (``./``, ``../``,
+``/``), and entries containing tox substitution variables (``{tox_root}``, etc.) are preserved as-is
+without PEP 508 normalization, but still participate in sorting by their lowercased value:
+
+.. code-block:: toml
+
+   # Before
+   deps = ["Pytest >= 7", "-r requirements.txt", "coverage", "-e ./my-pkg[test]"]
+
+   # After
+   deps = [ "Pytest >= 7", "-r requirements.txt", "coverage", "-e ./my-pkg[test]" ]
+
+**Sorted alphabetically:**
+
+- ``dependency_groups``, ``allowlist_externals``, ``extras``, ``labels``, ``depends``
+
+**Special handling for ``pass_env``:**
+
+Replacement objects (inline tables like ``{ replace = "default", ... }``) are pinned to the start,
+then string entries are sorted alphabetically:
+
+.. code-block:: toml
+
+   pass_env = ["TERM", "CI", { replace = "default", ... }, "HOME"]
+
+**Arrays NOT sorted:**
+
+- ``commands``, ``commands_pre``, ``commands_post``: execution order matters
+- ``base_python``: first entry takes priority
+
+Inline Table Key Reordering
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Keys within inline tables are reordered into a consistent order based on the inline table's type. The type
+is detected by the presence of a discriminator key:
+
+- **``replace``**: ``replace`` → ``condition`` → ``of`` → ``env`` → ``key`` → ``name`` → ``pattern`` →
+  ``then`` → ``else`` → ``default`` → ``extend`` → ``marker``
+- **``prefix``**: ``prefix`` → ``start`` → ``stop``
+- **``product``**: ``product`` → ``exclude``
+- **``value``**: ``value`` → ``marker``
+
+Keys not listed in the schema are appended at the end in their original order.
+
+.. code-block:: toml
+
+   # Before
+   pass_env = [{ default = ".", replace = "default", extend = true }]
+   env_list = [{ exclude = ["py38-django50"], product = ["py38", "py310", "django42", "django50"] }]
+
+   # After
+   env_list = [ { product = [ "py38", "py310", "django42", "django50" ], exclude = [ "py38-django50" ] } ]
+   pass_env = [ { replace = "default", default = ".", extend = true } ]
+
+This reordering applies to all inline tables in the file, including those nested inside arrays.
+
+Other Tables
+~~~~~~~~~~~~
+
+Any unrecognized tables are preserved and reordered according to standard table ordering rules. Keys within
+unknown tables are not reordered or normalized.

--- a/tox-toml-fmt/README.rst
+++ b/tox-toml-fmt/README.rst
@@ -83,7 +83,8 @@ The ``[tox-toml-fmt]`` table is used when present in the ``tox.toml`` file:
     # Number of spaces for indentation
     indent = 2
 
-    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line between sub-tables)
+    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line
+    # between sub-tables)
     sub_table_spacing = ""
 
     # Extra newlines between root table groups (e.g. "\n" for one blank line, "\n\n" for two)

--- a/tox-toml-fmt/docs/conf.py
+++ b/tox-toml-fmt/docs/conf.py
@@ -47,9 +47,9 @@ extlinks = {
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 nitpicky = True
 nitpick_ignore = []
-# external reference targets reorganize their on-page anchors over time; check the page resolves, not the fragment
+# anchors that resolve in a browser but linkcheck cannot verify: GitHub renders README heading ids with a
+# user-content- prefix added client-side, and pyright's docs are a single-page app with hash-routed sections
 linkcheck_anchors_ignore_for_url = [
     r"https://github\.com/.*",
-    r"https://microsoft\.github\.io/.*",
-    r"https://packaging\.python\.org/.*",
+    r"https://microsoft\.github\.io/pyright/.*",
 ]

--- a/tox-toml-fmt/docs/conf.py
+++ b/tox-toml-fmt/docs/conf.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timezone
 from importlib.metadata import version as metadata_version
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "tasks"))
 
 company, name = "tox-dev", "tox-toml-fmt"
 ver = metadata_version("tox-toml-fmt")
@@ -24,7 +28,9 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_inline_tabs",
     "sphinx_copybutton",
+    "sphinx_fmt_example",
 ]
+fmt_example_module = "tox_toml_fmt"
 
 exclude_patterns = ["_build", "changelog/*", "_draft.rst"]
 autoclass_content, autodoc_member_order, autodoc_typehints = "class", "bysource", "none"

--- a/tox-toml-fmt/docs/conf.py
+++ b/tox-toml-fmt/docs/conf.py
@@ -47,3 +47,9 @@ extlinks = {
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 nitpicky = True
 nitpick_ignore = []
+# external reference targets reorganize their on-page anchors over time; check the page resolves, not the fragment
+linkcheck_anchors_ignore_for_url = [
+    r"https://github\.com/.*",
+    r"https://microsoft\.github\.io/.*",
+    r"https://packaging\.python\.org/.*",
+]

--- a/tox-toml-fmt/docs/configuration.rst
+++ b/tox-toml-fmt/docs/configuration.rst
@@ -17,7 +17,8 @@ The ``[tox-toml-fmt]`` table is used when present in the ``tox.toml`` file:
     # Number of spaces for indentation
     indent = 2
 
-    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line between sub-tables)
+    # Extra newlines between sub-tables in the same group (e.g. "\n" for one blank line
+    # between sub-tables)
     sub_table_spacing = ""
 
     # Extra newlines between root table groups (e.g. "\n" for one blank line, "\n\n" for two)

--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -432,11 +432,11 @@ Inline Table Key Reordering
 Keys within inline tables are reordered into a consistent order based on the inline table's type. The type
 is detected by the presence of a discriminator key:
 
-- **``replace``**: ``replace`` → ``condition`` → ``of`` → ``env`` → ``key`` → ``name`` → ``pattern`` →
+- ``replace``: ``replace`` → ``condition`` → ``of`` → ``env`` → ``key`` → ``name`` → ``pattern`` →
   ``then`` → ``else`` → ``default`` → ``extend`` → ``marker``
-- **``prefix``**: ``prefix`` → ``start`` → ``stop``
-- **``product``**: ``product`` → ``exclude``
-- **``value``**: ``value`` → ``marker``
+- ``prefix``: ``prefix`` → ``start`` → ``stop``
+- ``product``: ``product`` → ``exclude``
+- ``value``: ``value`` → ``marker``
 
 Keys not listed in the schema are appended at the end in their original order.
 

--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -52,28 +52,29 @@ Arrays are formatted based on line length, trailing comma presence, and comments
 
     env_list = ["py312", "py313", "lint"]
 
-Arrays that exceed ``column_width`` are expanded and get a trailing comma:
+Arrays that exceed ``column_width`` are expanded and get a trailing comma (shown here with a small ``column_width`` to
+keep the example short):
 
 .. fmt-example::
+    :config: column_width=30
 
     [env.test]
-    deps = ["pytest>=7", "pytest-cov>=4", "pytest-mock>=3", "this-final-entry-clearly-makes-the-array-exceed-the-column-width-limit>=1"]
+    deps = ["pytest>=7", "coverage>=7", "tox>=4"]
 
-A trailing comma signals intent to keep the multiline format even when the array would fit on one line:
+A trailing comma forces the multiline format, even for an array that would otherwise fit on one line:
+
+.. fmt-example::
+
+    deps = ["pytest>=7",]
+
+A comment on an entry also forces the multiline format. Here ``["pytest>=7", "coverage>=7"]`` would fit on one line,
+but the comment keeps it expanded:
 
 .. fmt-example::
 
     deps = [
-        "pytest>=7",
-    ]
-
-Arrays with comments are always multiline:
-
-.. fmt-example::
-
-    deps = [
-        "pytest>=7",  # testing framework
-        "coverage>=7",
+      "pytest>=7",   # testing framework
+      "coverage>=7",
     ]
 
 **Multiline formatting rules:**
@@ -87,11 +88,14 @@ An array becomes multiline when any of these conditions are met:
 String Wrapping
 ~~~~~~~~~~~~~~~
 
-Long strings that exceed ``column_width`` are wrapped using TOML multiline basic strings with line-ending backslashes:
+Long strings that exceed ``column_width`` are wrapped using TOML multiline basic strings with line-ending backslashes
+(shown here with a small ``column_width``):
 
 .. fmt-example::
+    :config: column_width=40
 
-    description = "A very long description string that exceeds the column width limit set for this project and therefore wraps onto several lines"
+    [env.test]
+    description = "run the entire unit test suite with coverage"
 
 Specific keys can be excluded from wrapping using ``skip_wrap_for_keys``. Patterns support wildcards
 (e.g. ``*.commands`` skips wrapping for ``commands`` under any table).
@@ -400,6 +404,7 @@ without PEP 508 normalization, but still participate in sorting by their lowerca
 
 .. fmt-example::
 
+    [env_run_base]
     deps = ["Pytest >= 7", "-r requirements.txt", "coverage", "-e ./my-pkg[test]"]
 
 **Sorted alphabetically:**
@@ -413,7 +418,8 @@ then string entries are sorted alphabetically:
 
 .. fmt-example::
 
-    pass_env = ["TERM", "CI", { replace = "default", ... }, "HOME"]
+    [env.test]
+    pass_env = ["TERM", "CI", { replace = "env", name = "PATH" }, "HOME"]
 
 **Arrays NOT sorted:**
 
@@ -437,7 +443,7 @@ Keys not listed in the schema are appended at the end in their original order.
 .. fmt-example::
 
     pass_env = [{ default = ".", replace = "default", extend = true }]
-    env_list = [{ exclude = ["py38-django50"], product = ["py38", "py310", "django42", "django50"] }]
+    env_list = [{ exclude = ["py312-django"], product = ["py312", "py313"] }]
 
 This reordering applies to all inline tables in the file, including those nested inside arrays.
 

--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -21,15 +21,11 @@ String Quotes
 
 All strings use double quotes by default. Single quotes are only used when the value contains double quotes:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
+    [env.test]
     description = 'Run tests'
     commands = ["echo \"hello\""]
-
-    # After
-    description = "Run tests"
-    commands = ['echo "hello"']
 
 Key Quotes
 ~~~~~~~~~~
@@ -39,43 +35,42 @@ TOML keys are normalized to the simplest valid form. Keys that are valid bare ke
 converted to double-quoted (basic) strings with proper escaping. This applies to all keys: table headers,
 key-value pairs, and inline table keys:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
-    [env.'my-env']
+    [env.'my env']
     "description" = "run tests"
     pass_env = [{ "else" = "no" }]
-
-    # After
-    [env."my-env"]
-    description = "run tests"
-    pass_env = [{ else = "no" }]
 
 Backslashes and double quotes within literal keys are escaped during conversion.
 
 Array Formatting
 ~~~~~~~~~~~~~~~~
 
-Arrays are formatted based on line length, trailing comma presence, and comments:
+Arrays are formatted based on line length, trailing comma presence, and comments. Short arrays stay on one line:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Short arrays stay on one line
     env_list = ["py312", "py313", "lint"]
 
-    # Long arrays that exceed column_width are expanded and get a trailing comma
+Arrays that exceed ``column_width`` are expanded and get a trailing comma:
+
+.. fmt-example::
+
+    [env.test]
+    deps = ["pytest>=7", "pytest-cov>=4", "pytest-mock>=3", "this-final-entry-clearly-makes-the-array-exceed-the-column-width-limit>=1"]
+
+A trailing comma signals intent to keep the multiline format even when the array would fit on one line:
+
+.. fmt-example::
+
     deps = [
         "pytest>=7",
-        "pytest-cov>=4",
-        "pytest-mock>=3",
     ]
 
-    # Trailing commas signal intent to keep multiline format
-    deps = [
-        "pytest>=7",
-    ]
+Arrays with comments are always multiline:
 
-    # Arrays with comments are always multiline
+.. fmt-example::
+
     deps = [
         "pytest>=7",  # testing framework
         "coverage>=7",
@@ -94,18 +89,9 @@ String Wrapping
 
 Long strings that exceed ``column_width`` are wrapped using TOML multiline basic strings with line-ending backslashes:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
-    description = "A very long description string that exceeds the column width limit set for this project"
-
-    # After (with column_width = 40)
-    description = """\
-      A very long description \
-      string that exceeds the \
-      column width limit set \
-      for this project\
-      """
+    description = "A very long description string that exceeds the column width limit set for this project and therefore wraps onto several lines"
 
 Specific keys can be excluded from wrapping using ``skip_wrap_for_keys``. Patterns support wildcards
 (e.g. ``*.commands`` skips wrapping for ``commands`` under any table).
@@ -117,7 +103,7 @@ Sub-tables can be formatted in two styles controlled by ``table_format``:
 
 **Short format** (default, collapsed to dotted keys):
 
-.. code-block:: toml
+.. fmt-example::
 
     [env.test]
     description = "run tests"
@@ -125,13 +111,12 @@ Sub-tables can be formatted in two styles controlled by ``table_format``:
 
 **Long format** (expanded to table headers):
 
-.. code-block:: toml
+.. fmt-example::
+    :config: table_format=long
 
     [env.test]
     description = "run tests"
-
-    [env.test.sub]
-    value = 1
+    sub.value = 1
 
 Individual tables can override the default using ``expand_tables`` and ``collapse_tables``.
 
@@ -178,20 +163,12 @@ All comments are preserved during formatting:
 
 Inline comments within arrays are aligned independently per array, based on that array's longest value:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before - comments at inconsistent positions
     deps = [
       "pytest", # testing
       "pytest-cov",  # coverage
       "pytest-mock", # mocking
-    ]
-
-    # After - comments align to longest value in this array
-    deps = [
-      "pytest",       # testing
-      "pytest-cov",   # coverage
-      "pytest-mock",  # mocking
     ]
 
 Disabled Keys
@@ -203,17 +180,11 @@ laid out and ordered together with the table it belongs to, then comments it out
 disabled key anchored to its entry instead of drifting to the next table, and formats the line the same way the enabled
 key would be:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     [env_run_base]
     description = "run the tests"
     # set_env = {A = "1"}
-
-    # After
-    [env_run_base]
-    description = "run the tests"
-    # set_env = { A = "1" }
 
 Comments that are not a single valid key-value (prose, multi-line blocks, commented-out table headers like
 ``# [env.docs]``) are left untouched and follow the usual comment-preservation rules above. The heuristic is purely
@@ -232,9 +203,9 @@ entries belong together but should still be sorted.
 Files without a ``# Group:`` marker format the same as before, so the feature stays opt-in. Case does not matter, so
 ``# group:`` works too. Only standalone comment lines count; the formatter ignores inline trailing comments.
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
+    [env.test]
     deps = [
       # Group: runtime
       "requests",
@@ -242,16 +213,6 @@ Files without a ``# Group:`` marker format the same as before, so the feature st
       # Group: testing
       "pytest-cov",
       "pytest",
-    ]
-
-    # After
-    deps = [
-      # Group: runtime
-      "click",
-      "requests",
-      # Group: testing
-      "pytest",
-      "pytest-cov",
     ]
 
 Table-Specific Handling
@@ -309,17 +270,11 @@ to the root table, ``[env_run_base]``, ``[env_pkg_base]``, and all ``[env.*]`` t
 
 **Root table aliases:**
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     envlist = ["py312", "py313"]
     minversion = "4.2"
     skipsdist = true
-
-    # After
-    env_list = ["py312", "py313"]
-    min_version = "4.2"
-    no_package = true
 
 Full list: ``envlist`` → ``env_list``, ``toxinidir`` → ``tox_root``, ``toxworkdir`` → ``work_dir``,
 ``skipsdist`` → ``no_package``, ``isolated_build_env`` → ``package_env``, ``setupdir`` → ``package_root``,
@@ -327,19 +282,12 @@ Full list: ``envlist`` → ``env_list``, ``toxinidir`` → ``tox_root``, ``toxwo
 
 **Environment table aliases:**
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     [env_run_base]
     basepython = "python3.12"
     setenv.PYTHONPATH = "src"
     passenv = ["HOME"]
-
-    # After
-    [env_run_base]
-    base_python = "python3.12"
-    set_env.PYTHONPATH = "src"
-    pass_env = ["HOME"]
 
 Full list: ``setenv`` → ``set_env``, ``passenv`` → ``pass_env``, ``envdir`` → ``env_dir``,
 ``envtmpdir`` → ``env_tmp_dir``, ``envlogdir`` → ``env_log_dir``, ``changedir`` → ``change_dir``,
@@ -355,17 +303,11 @@ Keys in the root table are reordered into a consistent sequence:
 ``package_env`` → ``package_root`` → ``no_package`` → ``skip_missing_interpreters`` →
 ``ignore_base_python_conflict`` → ``work_dir`` → ``temp_dir`` → ``tox_root``
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     env_list = ["py312", "lint"]
     requires = ["tox>=4.2"]
     min_version = "4.2"
-
-    # After
-    min_version = "4.2"
-    requires = ["tox>=4.2"]
-    env_list = ["py312", "lint"]
 
 Environment Key Ordering
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -386,19 +328,12 @@ settings:
 ``allowlist_externals`` → ``labels`` → ``suicide_timeout`` → ``interrupt_timeout`` →
 ``terminate_timeout`` → ``depends`` → ``env_dir`` → ``env_tmp_dir`` → ``env_log_dir``
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     [env_run_base]
     commands = ["pytest"]
     deps = ["pytest>=7"]
     description = "run tests"
-
-    # After
-    [env_run_base]
-    description = "run tests"
-    deps = ["pytest>=7"]
-    commands = ["pytest"]
 
 ``requires`` Normalization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -406,13 +341,9 @@ settings:
 Dependencies in the root ``requires`` array are normalized per PEP 508 (canonical package names,
 consistent spacing around specifiers) and sorted alphabetically by package name:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     requires = ["tox >= 4.2", "tox-uv"]
-
-    # After
-    requires = ["tox>=4.2", "tox-uv"]
 
 ``env_list`` Sorting
 ~~~~~~~~~~~~~~~~~~~~
@@ -429,20 +360,16 @@ in their original positions.
 
 Compound environment names separated by ``-`` are classified by their first recognized part:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     env_list = ["lint", "py38", "py312", "docs", "py310-django"]
 
-    # After
-    env_list = ["py312", "py310-django", "py38", "docs", "lint"]
+Use ``--pin-env`` (here ``fix,type``) to pin specific environments to the start:
 
-Use ``--pin-env`` to pin specific environments to the start:
+.. fmt-example::
+    :config: pin_envs=fix,type
 
-.. code-block:: toml
-
-    # With --pin-env fix,type
-    env_list = ["fix", "type", "py313", "py312", "docs", "lint"]
+    env_list = ["lint", "py312", "py313", "docs", "fix", "type"]
 
 See :doc:`configuration` for how to set ``pin-env`` via the config file or CLI.
 
@@ -453,15 +380,10 @@ The legacy ``use_develop = true`` setting is automatically converted to the mode
 equivalent. If ``use_develop = false``, the key is left as-is. If a ``package`` key already exists,
 only the ``use_develop`` key is removed:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     [env_run_base]
     use_develop = true
-
-    # After
-    [env_run_base]
-    package = "editable"
 
 Array Sorting
 ~~~~~~~~~~~~~
@@ -476,13 +398,9 @@ Pip file references (``-r``, ``-c``), editable installs (``-e``), local paths (`
 ``/``), and entries containing tox substitution variables (``{tox_root}``, etc.) are preserved as-is
 without PEP 508 normalization, but still participate in sorting by their lowercased value:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     deps = ["Pytest >= 7", "-r requirements.txt", "coverage", "-e ./my-pkg[test]"]
-
-    # After
-    deps = ["-e ./my-pkg[test]", "-r requirements.txt", "coverage", "pytest>=7"]
 
 **Sorted alphabetically:**
 
@@ -493,13 +411,9 @@ without PEP 508 normalization, but still participate in sorting by their lowerca
 Replacement objects (inline tables like ``{ replace = "default", ... }``) are pinned to the start,
 then string entries are sorted alphabetically:
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     pass_env = ["TERM", "CI", { replace = "default", ... }, "HOME"]
-
-    # After
-    pass_env = [{ replace = "default", ... }, "CI", "HOME", "TERM"]
 
 **Arrays NOT sorted:**
 
@@ -520,15 +434,10 @@ is detected by the presence of a discriminator key:
 
 Keys not listed in the schema are appended at the end in their original order.
 
-.. code-block:: toml
+.. fmt-example::
 
-    # Before
     pass_env = [{ default = ".", replace = "default", extend = true }]
     env_list = [{ exclude = ["py38-django50"], product = ["py38", "py310", "django42", "django50"] }]
-
-    # After
-    pass_env = [{ replace = "default", default = ".", extend = true }]
-    env_list = [{ product = ["py38", "py310", "django42", "django50"], exclude = ["py38-django50"] }]
 
 This reordering applies to all inline tables in the file, including those nested inside arrays.
 

--- a/tox-toml-fmt/tox.toml
+++ b/tox-toml-fmt/tox.toml
@@ -104,8 +104,8 @@ commands = [
 [env.readme]
 description = "generate README.rst from docs"
 runner = "uv-venv-runner"
-skip_install = true
-package = "skip"
+package = "wheel"
+wheel_build_env = ".pkg"
 dependency_groups = []
 change_dir = "{tox_root}{/}.."
 commands = [["python", "tasks{/}generate_readme.py", "tox-toml-fmt"]]


### PR DESCRIPTION
The formatting docs hand-wrote the output of every example, so they drifted from what the formatter produces. Issue #395 reported short arrays documented as `["python", "toml"]` when the formatter writes `[ "python", "toml" ]`. Migrating the rest turned up more: comment-alignment gaps off by a space, a `[tool.mypy.overrides]` example with a trailing comma the formatter never emits, `click~=8.0` shown normalizing to `click>=8`, and normalization, sorting, `# Group:`, and entry-point examples written as bare root fragments that the formatter only transforms once they sit under a real `[project]` or `[tool.*]` table.

This adds a `fmt-example` Sphinx directive whose body is the input TOML plus an optional `:config:`; it runs the installed formatter at build time and renders the before/after. 📝 `generate_readme.py` expands the same directive into static blocks for the PyPI README. Building the output instead of storing it keeps the docs from falling out of sync with the formatter. A local pre-commit hook regenerates both READMEs through the formatter as the drift guard, and skips on pre-commit.ci, which has no Rust toolchain and where `_build.yaml` already regenerates.

The directive needs the package importable during the docs build, which `autodoc` already required, and the `readme` tox env now installs the wheel instead of skipping install so the import resolves on Read the Docs. I also fixed the three `ref-version-mismatch` zizmor findings in `_build.yaml`.

Fixes #395
