### PR TITLE
🐛 fix(common): honor multi-blank table spacing options

### DIFF
--- a/common/src/table.rs
+++ b/common/src/table.rs
@@ -435,6 +435,83 @@ fn get_key(k: &str, multi_level_prefixes: &[&str]) -> String {
     }
 }
 
+/// Re-apply the table spacing the tombi format pass flattened. Tombi collapses every gap between
+/// top-level tables to one blank line, so the counts [`Tables::reorder`] inserted are lost. Reset
+/// each gap: `root_spacing` blank lines between different groups, `sub_spacing` between same-group
+/// sub-tables, where each `\n` is one blank line. Pass `sub_spacing` as `None` to leave same-group
+/// gaps as tombi left them (short format, where a force-expanded sub-table keeps its single blank
+/// line). Grouping matches `reorder`, so pass the same `multi_level_prefixes`.
+#[must_use]
+pub fn normalize_table_spacing(
+    content: &str,
+    multi_level_prefixes: &[&str],
+    root_spacing: &str,
+    sub_spacing: Option<&str>,
+) -> String {
+    let root_blanks = root_spacing.matches('\n').count();
+    let sub_blanks = sub_spacing.map(|s| s.matches('\n').count());
+    let lines: Vec<&str> = content.lines().collect();
+
+    let headers: Vec<(usize, String, String)> = lines
+        .iter()
+        .enumerate()
+        .filter_map(|(i, line)| header_name(line).map(|name| (i, get_key(&name, multi_level_prefixes), name)))
+        .collect();
+
+    let mut gap_before: HashMap<usize, usize> = HashMap::new();
+    for pair in headers.windows(2) {
+        let (prev_pos, prev_group, prev_name) = &pair[0];
+        let (pos, group, name) = &pair[1];
+        // Repeated array-of-tables entries share a name and keep reorder's fixed single blank line.
+        if name == prev_name {
+            continue;
+        }
+        let blanks = if group == prev_group {
+            let Some(blanks) = sub_blanks else { continue };
+            blanks
+        } else {
+            root_blanks
+        };
+        // Leading comments belong to the following table, so the gap sits above them.
+        let start = (prev_pos + 1..*pos)
+            .rev()
+            .take_while(|&line| lines[line].trim_start().starts_with('#'))
+            .last()
+            .unwrap_or(*pos);
+        gap_before.insert(start, blanks);
+    }
+
+    let mut out: Vec<&str> = Vec::with_capacity(lines.len());
+    for (i, line) in lines.iter().enumerate() {
+        if let Some(&blanks) = gap_before.get(&i) {
+            while out.last().is_some_and(|l| l.trim().is_empty()) {
+                out.pop();
+            }
+            out.resize(out.len() + blanks, "");
+        }
+        out.push(line);
+    }
+
+    let mut result = out.join("\n");
+    if content.ends_with('\n') {
+        result.push('\n');
+    }
+    result
+}
+
+fn header_name(line: &str) -> Option<String> {
+    if !line.starts_with('[') {
+        return None;
+    }
+    let trimmed = line.trim_end();
+    if let Some(rest) = trimmed.strip_prefix("[[") {
+        rest.find("]]").map(|end| rest[..end].trim().to_string())
+    } else {
+        let rest = &trimmed[1..];
+        rest.find(']').map(|end| rest[..end].trim().to_string())
+    }
+}
+
 pub fn reorder_table_keys(table: &mut RefMut<Vec<SyntaxElement>>, order: &[&str]) {
     let (size, mut to_insert) = (table.len(), Vec::<SyntaxElement>::new());
     let (key_to_position, key_set) = load_keys(table);

--- a/common/src/tests/table_tests.rs
+++ b/common/src/tests/table_tests.rs
@@ -3,8 +3,8 @@ use indoc::indoc;
 use super::format_toml;
 use crate::table::{
     InlineTableSchema, Tables, apply_table_formatting, collapse_sub_table, collapse_sub_tables, collect_all_sub_tables,
-    expand_sub_table, expand_sub_tables, find_key, for_entries, get_table_name, reorder_inline_table_keys,
-    reorder_table_keys,
+    expand_sub_table, expand_sub_tables, find_key, for_entries, get_table_name, normalize_table_spacing,
+    reorder_inline_table_keys, reorder_table_keys,
 };
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
@@ -286,6 +286,87 @@ fn test_sub_table_spacing_blank_line() {
 
     [tool.mypy]
     strict = true
+    "#);
+}
+
+#[test]
+fn test_normalize_table_spacing_expands_root_gap() {
+    let formatted = "[build-system]\nrequires = [ \"hatchling\" ]\n\n[project]\nname = \"a\"\n";
+    let got = normalize_table_spacing(formatted, &["tool"], "\n\n", Some(""));
+    insta::assert_snapshot!(got, @r#"
+    [build-system]
+    requires = [ "hatchling" ]
+
+
+    [project]
+    name = "a"
+    "#);
+}
+
+#[test]
+fn test_normalize_table_spacing_expands_sub_gap() {
+    let formatted = "[tool.uv.sources]\npkg = { workspace = true }\n\n[tool.uv.workspace]\nmembers = [ \"a\" ]\n";
+    let got = normalize_table_spacing(formatted, &["tool"], "\n", Some("\n\n"));
+    insta::assert_snapshot!(got, @r#"
+    [tool.uv.sources]
+    pkg = { workspace = true }
+
+
+    [tool.uv.workspace]
+    members = [ "a" ]
+    "#);
+}
+
+#[test]
+fn test_normalize_table_spacing_compacts_sub_gap() {
+    let formatted = "[tool.ruff]\nx = 1\n\n[tool.ruff.lint]\ny = 2\n";
+    let got = normalize_table_spacing(formatted, &["tool"], "\n", Some(""));
+    insta::assert_snapshot!(got, @r#"
+    [tool.ruff]
+    x = 1
+    [tool.ruff.lint]
+    y = 2
+    "#);
+}
+
+#[test]
+fn test_normalize_table_spacing_none_leaves_sub_gap() {
+    let formatted = "[project]\nname = \"a\"\n\n[project.urls]\nhome = \"h\"\n";
+    let got = normalize_table_spacing(formatted, &["tool"], "\n", None);
+    insta::assert_snapshot!(got, @r#"
+    [project]
+    name = "a"
+
+    [project.urls]
+    home = "h"
+    "#);
+}
+
+#[test]
+fn test_normalize_table_spacing_keeps_array_of_tables_gap() {
+    let formatted = "[[project.authors]]\nname = \"a\"\n\n[[project.authors]]\nname = \"b\"\n";
+    let got = normalize_table_spacing(formatted, &["tool"], "\n", Some(""));
+    insta::assert_snapshot!(got, @r#"
+    [[project.authors]]
+    name = "a"
+
+    [[project.authors]]
+    name = "b"
+    "#);
+}
+
+#[test]
+fn test_normalize_table_spacing_keeps_comment_with_next_table() {
+    let formatted = "[build-system]\nrequires = [ \"x\" ]\n\n# for project\n[project]\nname = \"a\"\n";
+    let got = normalize_table_spacing(formatted, &["tool"], "\n\n", Some(""));
+    insta::assert_snapshot!(got, @r#"
+    [build-system]
+    requires = [ "x" ]
+
+
+    # for project
+    [project]
+    name = "a"
     "#);
 }
 

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -248,78 +248,9 @@ fn format_core(content: &str, opt: &Settings) -> String {
     common::array::align_array_comments(&formatted_ast);
     let formatted = formatted_ast.to_string();
 
-    let result = if opt.table_format == "long" && opt.sub_table_spacing.is_empty() {
-        remove_blank_lines_between_same_group_tables(&formatted, &prefix_refs)
-    } else {
-        formatted
-    };
+    let sub_spacing = (opt.table_format == "long").then_some(opt.sub_table_spacing.as_str());
+    let result = common::table::normalize_table_spacing(&formatted, &["tool"], &opt.separate_root_table, sub_spacing);
     common::util::limit_blank_lines(&result, 2)
-}
-
-fn remove_blank_lines_between_same_group_tables(content: &str, multi_level_prefixes: &[&str]) -> String {
-    let lines: Vec<&str> = content.lines().collect();
-    let mut result = Vec::new();
-
-    for i in 0..lines.len() {
-        if lines[i].is_empty() && i > 0 && i + 1 < lines.len() {
-            let trimmed_next = lines[i + 1].trim();
-            let next_is_table = trimmed_next.starts_with('[');
-
-            if next_is_table {
-                let mut prev_table_name = None;
-                for j in (0..i).rev() {
-                    if let Some(name) = extract_any_table_name(lines[j]) {
-                        prev_table_name = Some(name);
-                        break;
-                    }
-                }
-
-                let next_table_name = extract_any_table_name(lines[i + 1]);
-
-                if let (Some(prev), Some(next)) = (prev_table_name, next_table_name) {
-                    let prev_key = get_table_key(&prev, multi_level_prefixes);
-                    let next_key = get_table_key(&next, multi_level_prefixes);
-
-                    if prev_key == next_key {
-                        continue;
-                    }
-                }
-            }
-        }
-
-        result.push(lines[i]);
-    }
-
-    let mut output = result.join("\n");
-    if content.ends_with('\n') && !output.ends_with('\n') {
-        output.push('\n');
-    }
-    output
-}
-
-fn extract_any_table_name(line: &str) -> Option<String> {
-    let trimmed = line.trim();
-    if trimmed.starts_with("[[") {
-        let end = trimmed.find("]]")?;
-        Some(trimmed[2..end].to_string())
-    } else if trimmed.starts_with('[') {
-        let end = trimmed.find(']')?;
-        Some(trimmed[1..end].to_string())
-    } else {
-        None
-    }
-}
-
-fn get_table_key(name: &str, multi_level_prefixes: &[&str]) -> String {
-    for prefix in multi_level_prefixes {
-        if name == *prefix || name.starts_with(&format!("{}.", prefix)) {
-            return prefix.to_string();
-        }
-    }
-    name.split('.')
-        .next()
-        .expect("split returns at least one element")
-        .to_string()
 }
 
 /// # Errors

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -868,6 +868,60 @@ fn test_sub_table_spacing_with_project_tables() {
 }
 
 #[test]
+fn test_issue_402_sub_table_spacing_two_blank_lines() {
+    let start = indoc! {r#"
+        [tool.uv.sources]
+        pkg = { workspace = true }
+
+        [tool.uv.workspace]
+        members = ["a", "b"]
+
+        [tool.pyproject-fmt]
+        indent = 4
+        "#};
+    let settings = Settings {
+        sub_table_spacing: String::from("\n\n"),
+        ..long_format_settings()
+    };
+    let got = format_toml(start, &settings);
+    assert_snapshot!(got, @r#"
+    [tool.uv.sources]
+    pkg = { workspace = true }
+
+
+    [tool.uv.workspace]
+    members = [ "a", "b" ]
+
+    [tool.pyproject-fmt]
+    indent = 4
+    "#);
+}
+
+#[test]
+fn test_issue_402_separate_root_table_two_blank_lines() {
+    let start = indoc! {r#"
+        [build-system]
+        requires = ["hatchling"]
+
+        [project]
+        name = "test"
+        "#};
+    let settings = Settings {
+        separate_root_table: String::from("\n\n"),
+        ..default_settings()
+    };
+    let got = format_toml(start, &settings);
+    assert_snapshot!(got, @r#"
+    [build-system]
+    requires = [ "hatchling" ]
+
+
+    [project]
+    name = "test"
+    "#);
+}
+
+#[test]
 fn test_issue_217_mixed_quotes_idempotent() {
     let start = indoc! {r#"
     [project]

--- a/tox-toml-fmt/rust/src/main.rs
+++ b/tox-toml-fmt/rust/src/main.rs
@@ -191,7 +191,10 @@ fn format_core(content: &str, opt: &Settings) -> String {
     common::array::align_array_comments(&formatted_ast);
     let aligned = formatted_ast.to_string();
 
-    common::util::limit_blank_lines(&aligned, 2)
+    let sub_spacing = (opt.table_format == "long").then_some(opt.sub_table_spacing.as_str());
+    let result =
+        common::table::normalize_table_spacing(&aligned, &["env_base", "env"], &opt.separate_root_table, sub_spacing);
+    common::util::limit_blank_lines(&result, 2)
 }
 
 /// # Errors

--- a/tox-toml-fmt/rust/src/tests/main_tests.rs
+++ b/tox-toml-fmt/rust/src/tests/main_tests.rs
@@ -559,7 +559,6 @@ fn test_table_expand_long_format() {
     assert_snapshot!(got, @r#"
     [env.test]
     description = "run tests"
-
     [env.test.sub]
     value = 1
     "#);


### PR DESCRIPTION
The docs describe `sub_table_spacing` and `separate_root_table` as adding one blank line per `\n`, so `"\n\n"` should produce two blank lines between tables. Instead `"\n\n"` and `"\n"` gave the same single blank line, as tox-dev/toml-fmt#402 reports.

`reorder` inserts the requested number of blank lines, but the tombi format pass that follows collapses every gap between top-level tables down to one blank line, and nothing put the wider spacing back. The existing post-pass stripped blank lines for long-format compaction, and `tox-toml-fmt` had no post-pass at all, so it dropped its spacing options too.

The fix re-derives the spacing after tombi runs, in a shared `normalize_table_spacing` that both formatters call. 🔧 It reuses `reorder`'s own grouping so the output matches what `reorder` intended: gaps between different root groups follow `separate_root_table`, while gaps between sub-tables of the same group follow `sub_table_spacing`. Same-group spacing takes effect in long format, keeping the short-format behavior where a force-expanded sub-table sits one blank line below its parent. Repeated `[[array.of.tables]]` entries keep their fixed single blank line instead of picking up `sub_table_spacing`.

One behavior change worth a look: `tox-toml-fmt` in long format now compacts same-group sub-tables under the default `sub_table_spacing = ""`, matching `pyproject-fmt`. Short-format output is unchanged.

Fixes tox-dev/toml-fmt#402.
