### PR TITLE
👷 ci(build): always post build gate on pull requests

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -9,6 +9,11 @@ on:
         required: true
         type: string
         description: "Pre-commit mirror repo (e.g. tox-dev/pyproject-fmt)"
+      run:
+        required: false
+        type: string
+        default: "true"
+        description: "When 'false', skip the build jobs but still post the aggregate gate"
     outputs:
       version:
         value: ${{ jobs.bump.outputs.version }}
@@ -25,6 +30,7 @@ env:
 jobs:
   bump:
     name: 🔖 bump
+    if: ${{ inputs.run == 'true' }}
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: read

--- a/.github/workflows/pyproject_fmt_build.yaml
+++ b/.github/workflows/pyproject_fmt_build.yaml
@@ -17,12 +17,6 @@ on:
       - ".github/workflows/pyproject_fmt_build.yaml"
       - ".github/workflows/_build.yaml"
   pull_request:
-    paths:
-      - "common/**"
-      - "toml-fmt-common/**"
-      - "pyproject-fmt/**"
-      - ".github/workflows/pyproject_fmt_build.yaml"
-      - ".github/workflows/_build.yaml"
   schedule:
     - cron: "0 8 * * *"
 
@@ -31,11 +25,37 @@ concurrency:
   cancel-in-progress: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null }}
 
 jobs:
+  changes:
+    name: 🔍 changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.run == 'true' }}
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: 🔍 Check for changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            run:
+              - 'common/**'
+              - 'toml-fmt-common/**'
+              - 'pyproject-fmt/**'
+              - '.github/workflows/pyproject_fmt_build.yaml'
+              - '.github/workflows/_build.yaml'
+
   build:
+    needs: changes
     uses: ./.github/workflows/_build.yaml
     with:
       package-name: pyproject-fmt
       pre-commit-mirror: tox-dev/pyproject-fmt
+      run: ${{ needs.changes.outputs.run }}
     secrets: inherit # zizmor: ignore[secrets-inherit]
     permissions:
       contents: write

--- a/.github/workflows/tox_toml_fmt_build.yaml
+++ b/.github/workflows/tox_toml_fmt_build.yaml
@@ -17,12 +17,6 @@ on:
       - ".github/workflows/tox_toml_fmt_build.yaml"
       - ".github/workflows/_build.yaml"
   pull_request:
-    paths:
-      - "common/**"
-      - "toml-fmt-common/**"
-      - "tox-toml-fmt/**"
-      - ".github/workflows/tox_toml_fmt_build.yaml"
-      - ".github/workflows/_build.yaml"
   schedule:
     - cron: "0 8 * * *"
 
@@ -31,11 +25,37 @@ concurrency:
   cancel-in-progress: ${{ github.event.inputs.release == 'no' || github.event.inputs.release == null }}
 
 jobs:
+  changes:
+    name: 🔍 changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.run == 'true' }}
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: 🔍 Check for changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            run:
+              - 'common/**'
+              - 'toml-fmt-common/**'
+              - 'tox-toml-fmt/**'
+              - '.github/workflows/tox_toml_fmt_build.yaml'
+              - '.github/workflows/_build.yaml'
+
   build:
+    needs: changes
     uses: ./.github/workflows/_build.yaml
     with:
       package-name: tox-toml-fmt
       pre-commit-mirror: tox-dev/tox-toml-fmt
+      run: ${{ needs.changes.outputs.run }}
     secrets: inherit # zizmor: ignore[secrets-inherit]
     permissions:
       contents: write


### PR DESCRIPTION
The branch ruleset requires the `build / ✅ pyproject-fmt-build` and `build / ✅ tox-toml-fmt-build` gates, but their workflows filter at the `on.pull_request.paths` level. A PR that leaves the package source untouched (a CI-config or docs change, say) does not trigger them, so the required gate does not post and the PR stays blocked on a check that cannot arrive. Adding `✅ common` as a required check made this reachable, since a workflow-only PR then has to satisfy build gates it does not run.

This gives the build workflows the shape the test workflows already use. 🔧 They trigger on each pull request, an internal `changes` job decides whether the source actually changed, and the result flows into the reusable `_build.yaml` as a `run` input. When `run` is `false`, `bump` does not run and the wheel matrix skips with it through `needs`, while the always-run aggregate job still posts a green `✅ <pkg>-build`. Source PRs set `run` to `true` and build the full matrix as before.

Push and release keep their current path filters and behavior: the reusable defaults `run` to `true`, and the release job stays gated on the `workflow_dispatch` release input. This changes which pull requests post the gate, not what any build does.
