### PR TITLE
🐛 fix(common): space before marker after URL

### DIFF
--- a/common/src/pep508/requirement.rs
+++ b/common/src/pep508/requirement.rs
@@ -168,11 +168,17 @@ impl std::fmt::Display for Requirement {
                 }
             }
         }
+        // PEP 508 requires whitespace after a URL, otherwise the `;` is parsed as part of the URI.
+        let separator = if matches!(self.version_or_url, Some(VersionOrUrl::Url(_))) {
+            " ;"
+        } else {
+            ";"
+        };
         if let Some(marker) = &self.marker {
-            write!(&mut result, "; {marker}")?;
+            write!(&mut result, "{separator} {marker}")?;
         }
         if self.private {
-            write!(&mut result, "; private")?;
+            write!(&mut result, "{separator} private")?;
         }
         write!(f, "{}", result)
     }

--- a/common/src/tests/pep508_tests.rs
+++ b/common/src/tests/pep508_tests.rs
@@ -67,6 +67,24 @@ fn test_format_requirement_url() {
 }
 
 #[test]
+fn test_format_requirement_url_with_marker() {
+    let start = "pytest-notebook @ git+https://github.com/x/pytest-notebook.git@master; python_version>='3.10'";
+    let got = format_requirement_helper(start, true);
+    insta::assert_snapshot!(got.clone(), @"pytest-notebook @ git+https://github.com/x/pytest-notebook.git@master ; python_version>='3.10'");
+    let stable = format_requirement_helper(&got, true);
+    assert_eq!(stable, got, "formatting should remain stable");
+}
+
+#[test]
+fn test_format_requirement_url_private() {
+    let start = "pkg @ https://example.com/pkg-1.0.tar.gz; private";
+    let got = format_requirement_helper(start, true);
+    insta::assert_snapshot!(got.clone(), @"pkg @ https://example.com/pkg-1.0.tar.gz ; private");
+    let stable = format_requirement_helper(&got, true);
+    assert_eq!(stable, got, "formatting should remain stable");
+}
+
+#[test]
 fn test_format_requirement_keep_rc_version() {
     let start = "a==5.2rc1";
     let got = format_requirement_helper(start, true);

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -339,6 +339,15 @@ Keys follow the canonical metadata order; name, dependencies, classifiers, and k
         [project]
         dependencies = ["requests >= 2.0.0", "click~=8.0"]
 
+    A direct-reference dependency keeps a space before its marker separator, because :pep:`508` only ends the URL
+    at whitespace; without it, installers read the ``;`` and the marker as part of the URL and reject the entry:
+
+    .. fmt-example::
+        :config: generate_python_version_classifiers=false
+
+        [project]
+        dependencies = ["pkg @ git+https://github.com/user/repo.git@main; python_version>='3.10'"]
+
     **Optional-dependency extra names** are normalized to lowercase with hyphens:
 
     .. fmt-example::

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -711,6 +711,25 @@ fn test_project_dependencies_git_urls() {
 }
 
 #[test]
+fn test_project_dependencies_git_urls_with_marker() {
+    let start = indoc! {r#"
+        [project]
+        dependencies = ["pkg @ git+https://github.com/user/repo.git@main; python_version>='3.10'"]
+    "#};
+    let result = evaluate_project(start, false, (3, 11), true);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    classifiers = [
+      "Programming Language :: Python :: 3 :: Only",
+      "Programming Language :: Python :: 3.9",
+      "Programming Language :: Python :: 3.10",
+      "Programming Language :: Python :: 3.11",
+    ]
+    dependencies = [ "pkg @ git+https://github.com/user/repo.git@main ; python_version>='3.10'" ]
+    "#);
+}
+
+#[test]
 fn test_project_dependencies_local_paths() {
     let start = indoc! {r#"
         [project]


### PR DESCRIPTION
PEP 508 ends a direct-reference URL at whitespace. Emitting the marker separator as `;` immediately after the URL made pip, uv and setuptools parse the semicolon and the marker as part of the URI, so an otherwise valid dependency was rejected:

```
configuration error: `project.optional-dependencies.testing[5]` must be pep508
```

Requirements carrying a URL now render ` ;` before the marker (and before a PEP 794 `private` suffix); everything else keeps `;`.

```toml
dependencies = [
  "pkg @ git+https://github.com/user/repo.git@main ; python_version>='3.10'",
  "pkg; python_version<'3.10'",
]
```

Fixes #407