### PR TITLE
👷 ci: run the test suite on Python 3.15

### DIFF
--- a/.github/workflows/toml_fmt_common_test.yaml
+++ b/.github/workflows/toml_fmt_common_test.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: ["3.14", "3.13", "3.12", "3.11", "3.10", type, pkg_meta]
+        env: ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10", type, pkg_meta]
     defaults:
       run:
         working-directory: toml-fmt-common

--- a/pyproject-fmt/tox.toml
+++ b/pyproject-fmt/tox.toml
@@ -1,5 +1,5 @@
 requires = ["tox>=4.56.4", "tox-uv>=1.35.2"]
-env_list = ["fix", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
+env_list = ["fix", "3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
 skip_missing_interpreters = true
 
 [env_run_base]

--- a/toml-fmt-common/pyproject.toml
+++ b/toml-fmt-common/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Internet",
   "Topic :: Software Development :: Libraries",
   "Topic :: System",
@@ -63,7 +64,7 @@ pkg-meta = [
 build-backend.source-include = [ "tests/**", "tox.toml" ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.mypy]
 strict = true

--- a/toml-fmt-common/tox.toml
+++ b/toml-fmt-common/tox.toml
@@ -1,5 +1,5 @@
 requires = ["tox>=4.56.4", "tox-uv>=1.35.2"]
-env_list = ["fix", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "pkg_meta"]
+env_list = ["fix", "3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "pkg_meta"]
 skip_missing_interpreters = true
 
 [env_run_base]

--- a/tox-toml-fmt/tox.toml
+++ b/tox-toml-fmt/tox.toml
@@ -1,5 +1,5 @@
 requires = ["tox>=4.56.4", "tox-uv>=1.35.2"]
-env_list = ["fix", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
+env_list = ["fix", "3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
 skip_missing_interpreters = true
 
 [env_run_base]


### PR DESCRIPTION
Python 3.15 is at `3.15.0b3`, so testing against it now leaves time to report breakage upstream before the release. `pyproject-fmt` and `tox-toml-fmt` already listed `3.15` and `3.15t` in their workflow matrices, but the tox definitions behind those matrices had no matching env, and `toml-fmt-common` covered nothing past `3.14`.

I added `3.15` to the `env_list` of all three `tox.toml` files and to the `env` matrix of the `toml-fmt-common` workflow, so every CI entry has the tox env it calls. `toml-fmt-common` now also carries the `Programming Language :: Python :: 3.15` classifier and `max_supported_python = "3.15"`, matching what `pyproject-fmt` and `tox-toml-fmt` declare. The version string matches the form of the `3.14` entry beside it, with no prerelease flags, since GitHub Actions and uv already resolve the newest available release.

The change is additive. `requires-python` stays at `>=3.10`, I dropped no version, and I left the Rust toolchain pins and the abi3 build targets alone. Since 3.15 is a beta, failures in that column may come from the interpreter itself.
