### PR TITLE
🧪 test: run 3.15t everywhere by default

### DIFF
--- a/.github/workflows/toml_fmt_common_test.yaml
+++ b/.github/workflows/toml_fmt_common_test.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10", type, pkg_meta]
+        env: ["3.15", "3.15t", "3.14", "3.13", "3.12", "3.11", "3.10", type, pkg_meta]
     defaults:
       run:
         working-directory: toml-fmt-common

--- a/pyproject-fmt/tox.toml
+++ b/pyproject-fmt/tox.toml
@@ -1,5 +1,5 @@
 requires = ["tox>=4.56.4", "tox-uv>=1.35.2"]
-env_list = ["fix", "3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
+env_list = ["fix", "3.15", "3.15t", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
 skip_missing_interpreters = true
 
 [env_run_base]

--- a/toml-fmt-common/tox.toml
+++ b/toml-fmt-common/tox.toml
@@ -1,5 +1,5 @@
 requires = ["tox>=4.56.4", "tox-uv>=1.35.2"]
-env_list = ["fix", "3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "pkg_meta"]
+env_list = ["fix", "3.15", "3.15t", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "pkg_meta"]
 skip_missing_interpreters = true
 
 [env_run_base]

--- a/tox-toml-fmt/tox.toml
+++ b/tox-toml-fmt/tox.toml
@@ -1,5 +1,5 @@
 requires = ["tox>=4.56.4", "tox-uv>=1.35.2"]
-env_list = ["fix", "3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
+env_list = ["fix", "3.15", "3.15t", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
 skip_missing_interpreters = true
 
 [env_run_base]


### PR DESCRIPTION
Free-threaded coverage after #415 was uneven: `toml-fmt-common`, the one pure-Python package, tested no free-threaded interpreter, while `pyproject-fmt` and `tox-toml-fmt` defined `[env."3.15t"]` sections (with the no-abi3 maturin flags) that were missing from `env_list`, so a bare `tox` run skipped them.

`toml-fmt-common` gains a `3.15t` leg in both its `env_list` and its CI matrix, and the Rust packages' existing `3.15t` envs join their `env_list` so a plain `tox` run covers them. The Rust packages' CI already runs `3.15t` through the shared test workflow, so only the common workflow needed a matrix entry.
