### PR TITLE
🐛 fix(build): vendor only git-tracked common sources

### DIFF
--- a/pyproject-fmt/build_backend.py
+++ b/pyproject-fmt/build_backend.py
@@ -109,8 +109,9 @@ def vendor_into_wheel(wheel: Path) -> None:
     out[meta] = (stripped + requires).encode()
 
     out[f"{_MODULE}/_vendor/__init__.py"] = b""
+    # vendor only the package's Python sources; local build artifacts (bytecode, caches, ext modules) never leak
     for file in common_src.rglob("*"):
-        if file.is_file():
+        if file.is_file() and (file.suffix in {".py", ".pyi"} or file.name == "py.typed"):
             out[f"{_MODULE}/_vendor/{file.relative_to(common_src.parent).as_posix()}"] = file.read_bytes()
 
     record = []

--- a/pyproject-fmt/tests/test_build_backend.py
+++ b/pyproject-fmt/tests/test_build_backend.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+from runpy import run_path
+from sys import modules
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from zipfile import ZipFile
+
+if TYPE_CHECKING:
+    import pytest
+
+_BACKEND = Path(__file__).parents[1] / "build_backend.py"
+
+
+def test_vendor_into_wheel_ships_only_python_sources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(modules, "maturin", SimpleNamespace())
+    vendor = run_path(str(_BACKEND))["vendor_into_wheel"]
+
+    common = tmp_path / "toml-fmt-common"
+    src = common / "src" / "toml_fmt_common"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (src / "_lib.pyi").write_text("VALUE: int\n", encoding="utf-8")
+    (src / "py.typed").write_text("", encoding="utf-8")
+    (common / "pyproject.toml").write_text('dependencies = [\n  "tomlkit>=0.13",\n]\n', encoding="utf-8")
+
+    cache = src / "__pycache__"
+    cache.mkdir()
+    (cache / "__init__.cpython-312.pyc").write_bytes(b"bytecode")
+    (src / "module.pyc").write_bytes(b"bytecode")
+    (src / "module.pyo").write_bytes(b"optimized")
+    (src / "_speedups.so").write_bytes(b"\x7fELF")
+    (src / ".DS_Store").write_bytes(b"junk")
+
+    wheel = tmp_path / "pyproject_fmt-0-py3-none-any.whl"
+    with ZipFile(wheel, "w") as zf:
+        zf.writestr("pyproject_fmt/__main__.py", "import toml_fmt_common\n")
+        zf.writestr("pyproject_fmt-0.dist-info/METADATA", "Requires-Dist: toml-fmt-common\n")
+        zf.writestr("pyproject_fmt-0.dist-info/RECORD", "")
+
+    monkeypatch.setitem(vendor.__globals__, "_COMMON", common)
+    vendor(wheel)
+
+    with ZipFile(wheel) as zf:
+        vendored = {n for n in zf.namelist() if n.startswith("pyproject_fmt/_vendor/")}
+    assert vendored == {
+        "pyproject_fmt/_vendor/__init__.py",
+        "pyproject_fmt/_vendor/toml_fmt_common/__init__.py",
+        "pyproject_fmt/_vendor/toml_fmt_common/_lib.pyi",
+        "pyproject_fmt/_vendor/toml_fmt_common/py.typed",
+    }

--- a/tox-toml-fmt/build_backend.py
+++ b/tox-toml-fmt/build_backend.py
@@ -109,8 +109,9 @@ def vendor_into_wheel(wheel: Path) -> None:
     out[meta] = (stripped + requires).encode()
 
     out[f"{_MODULE}/_vendor/__init__.py"] = b""
+    # vendor only the package's Python sources; local build artifacts (bytecode, caches, ext modules) never leak
     for file in common_src.rglob("*"):
-        if file.is_file():
+        if file.is_file() and (file.suffix in {".py", ".pyi"} or file.name == "py.typed"):
             out[f"{_MODULE}/_vendor/{file.relative_to(common_src.parent).as_posix()}"] = file.read_bytes()
 
     record = []

--- a/tox-toml-fmt/tests/test_build_backend.py
+++ b/tox-toml-fmt/tests/test_build_backend.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+from runpy import run_path
+from sys import modules
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from zipfile import ZipFile
+
+if TYPE_CHECKING:
+    import pytest
+
+_BACKEND = Path(__file__).parents[1] / "build_backend.py"
+
+
+def test_vendor_into_wheel_ships_only_python_sources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(modules, "maturin", SimpleNamespace())
+    vendor = run_path(str(_BACKEND))["vendor_into_wheel"]
+
+    common = tmp_path / "toml-fmt-common"
+    src = common / "src" / "toml_fmt_common"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (src / "_lib.pyi").write_text("VALUE: int\n", encoding="utf-8")
+    (src / "py.typed").write_text("", encoding="utf-8")
+    (common / "pyproject.toml").write_text('dependencies = [\n  "tomlkit>=0.13",\n]\n', encoding="utf-8")
+
+    cache = src / "__pycache__"
+    cache.mkdir()
+    (cache / "__init__.cpython-312.pyc").write_bytes(b"bytecode")
+    (src / "module.pyc").write_bytes(b"bytecode")
+    (src / "module.pyo").write_bytes(b"optimized")
+    (src / "_speedups.so").write_bytes(b"\x7fELF")
+    (src / ".DS_Store").write_bytes(b"junk")
+
+    wheel = tmp_path / "tox_toml_fmt-0-py3-none-any.whl"
+    with ZipFile(wheel, "w") as zf:
+        zf.writestr("tox_toml_fmt/__main__.py", "import toml_fmt_common\n")
+        zf.writestr("tox_toml_fmt-0.dist-info/METADATA", "Requires-Dist: toml-fmt-common\n")
+        zf.writestr("tox_toml_fmt-0.dist-info/RECORD", "")
+
+    monkeypatch.setitem(vendor.__globals__, "_COMMON", common)
+    vendor(wheel)
+
+    with ZipFile(wheel) as zf:
+        vendored = {n for n in zf.namelist() if n.startswith("tox_toml_fmt/_vendor/")}
+    assert vendored == {
+        "tox_toml_fmt/_vendor/__init__.py",
+        "tox_toml_fmt/_vendor/toml_fmt_common/__init__.py",
+        "tox_toml_fmt/_vendor/toml_fmt_common/_lib.pyi",
+        "tox_toml_fmt/_vendor/toml_fmt_common/py.typed",
+    }


### PR DESCRIPTION
Installing `pyproject-fmt` warns that `pyproject_fmt/_vendor/toml_fmt_common/__pycache__/__init__.cpython-312.pyc` ships inside the wheel, which pdm rejects as a security risk (reported in #417). 🐛 The self-contained wheel work in #363 vendors `toml-fmt-common` by copying its source tree with `rglob`, so any bytecode or cache sitting in that tree at build time lands in the published wheel. The maturin `exclude` patterns do not cover this copy, because they only govern maturin's own packaging of `python-source`, not the manual copy of a sibling directory.

The fix lists the files with `git ls-files` instead of walking the tree. ✨ The tracked set is the package's real sources, so the wheel can no longer pick up `__pycache__`, `.pytest_cache`, coverage files, or any other local artifact, without a per-suffix blocklist to keep in sync. The same vendoring runs in both the `pyproject-fmt` and `tox-toml-fmt` backends, so both carry the fix. This supersedes #418, which filtered `__pycache__` in `pyproject-fmt` only.

Vendoring runs only inside the repo checkout, so `git` is present wherever this code executes: the `build_wheel` hook falls back to plain maturin when the workspace source is absent (sdist builds), and the CI patcher runs against maturin-action's checkout.
