### PR TITLE
✨ feat(pyproject-fmt): order tool.pyproject-fmt config keys

### DIFF
--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -1874,6 +1874,41 @@ of tables, last).
 
 **Sorted arrays:** ``ignore`` (file globs to skip).
 
+``[tool.pyproject-fmt]``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The formatter's own configuration table.
+
+
+Keys are ordered to match the documented configuration sequence; the ``expand_tables``, ``collapse_tables``, and
+``skip_wrap_for_keys`` lists are sorted and deduplicated.
+
+
+**Key ordering:** ``column_width`` → ``indent`` → ``keep_full_version`` →
+``generate_python_version_classifiers`` → ``max_supported_python`` → ``table_format`` → ``sub_table_spacing`` →
+``separate_root_table`` → ``expand_tables`` → ``collapse_tables`` → ``skip_wrap_for_keys``. Unrecognized keys are
+appended alphabetically.
+
+**Sorted arrays:** ``expand_tables``, ``collapse_tables``, ``skip_wrap_for_keys``. Each is matched as a set, so
+sorting and dropping byte-identical duplicates leaves behavior unchanged. Duplicate removal keeps case variants
+distinct, matching the case-sensitive lookups these lists feed.
+
+.. code-block:: toml
+
+   # Before
+   [tool.pyproject-fmt]
+   keep_full_version = true
+   column_width = 120
+   skip_wrap_for_keys = ["b", "a", "a"]
+   indent = 4
+
+   # After
+   [tool.pyproject-fmt]
+   column_width = 120
+   indent = 4
+   keep_full_version = true
+   skip_wrap_for_keys = [ "a", "b" ]
+
 Other Tables
 ~~~~~~~~~~~~
 

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1414,6 +1414,33 @@ glob list is sorted, while changelog display order is preserved.
 
     **Sorted arrays:** ``ignore`` (file globs to skip).
 
+``[tool.pyproject-fmt]``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The formatter's own configuration table. See :doc:`configuration` for what each key controls.
+
+Keys are ordered to match the documented configuration sequence; the ``expand_tables``, ``collapse_tables``, and
+``skip_wrap_for_keys`` lists are sorted and deduplicated.
+
+.. dropdown:: Formatting details
+
+    **Key ordering:** ``column_width`` → ``indent`` → ``keep_full_version`` →
+    ``generate_python_version_classifiers`` → ``max_supported_python`` → ``table_format`` → ``sub_table_spacing`` →
+    ``separate_root_table`` → ``expand_tables`` → ``collapse_tables`` → ``skip_wrap_for_keys``. Unrecognized keys are
+    appended alphabetically.
+
+    **Sorted arrays:** ``expand_tables``, ``collapse_tables``, ``skip_wrap_for_keys``. Each is matched as a set, so
+    sorting and dropping byte-identical duplicates leaves behavior unchanged. Duplicate removal keeps case variants
+    distinct, matching the case-sensitive lookups these lists feed.
+
+    .. fmt-example::
+
+        [tool.pyproject-fmt]
+        keep_full_version = true
+        column_width = 120
+        skip_wrap_for_keys = ["b", "a", "a"]
+        indent = 4
+
 Other Tables
 ~~~~~~~~~~~~
 

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -1417,7 +1417,9 @@ glob list is sorted, while changelog display order is preserved.
 ``[tool.pyproject-fmt]``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The formatter's own configuration table. See :doc:`configuration` for what each key controls.
+The formatter's own configuration table.
+
+See :doc:`configuration` for what each key controls.
 
 Keys are ordered to match the documented configuration sequence; the ``expand_tables``, ``collapse_tables``, and
 ``skip_wrap_for_keys`` lists are sorted and deduplicated.

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -35,6 +35,7 @@ mod pdm;
 mod pixi;
 mod poetry;
 mod pylint;
+mod pyproject_fmt;
 mod pyrefly;
 mod pyright;
 mod pytest;
@@ -226,6 +227,7 @@ fn format_core(content: &str, opt: &Settings) -> String {
     deptry::fix(&mut tables);
     ty::fix(&mut tables);
     coverage::fix(&mut tables);
+    pyproject_fmt::fix(&mut tables);
     reorder_tables(&root_ast, &tables, &opt.separate_root_table, &opt.sub_table_spacing);
     // Must follow reorder_tables: only then have AoT entries collapsed to inline arrays of inline tables
     // (e.g. [[tool.poetry.source]] → source = [{...}]) and become INLINE_TABLE descendants of root_ast.

--- a/pyproject-fmt/rust/src/pyproject_fmt.rs
+++ b/pyproject-fmt/rust/src/pyproject_fmt.rs
@@ -1,0 +1,37 @@
+use common::array::{dedupe_strings, sort_strings};
+use common::table::{for_entries, reorder_table_keys, Tables};
+use lexical_sort::natural_lexical_cmp;
+
+const KEY_ORDER: &[&str] = &[
+    "",
+    "column_width",
+    "indent",
+    "keep_full_version",
+    "generate_python_version_classifiers",
+    "max_supported_python",
+    "table_format",
+    "sub_table_spacing",
+    "separate_root_table",
+    "expand_tables",
+    "collapse_tables",
+    "skip_wrap_for_keys",
+];
+
+// Consumed as sets: expand/collapse via HashSet::contains, skip_wrap via matches_pattern under .any().
+// Element order never reaches the logic, so sorting is display-only and dropping a byte-identical
+// duplicate is inert. Dedup stays case-sensitive because those lookups are case-sensitive.
+const SORT_ARRAYS: &[&str] = &["expand_tables", "collapse_tables", "skip_wrap_for_keys"];
+
+pub fn fix(tables: &mut Tables) {
+    let Some(elements) = tables.get("tool.pyproject-fmt") else {
+        return;
+    };
+    let table = &mut elements.first().unwrap().borrow_mut();
+    for_entries(table, &mut |key, entry| {
+        if SORT_ARRAYS.contains(&key.as_str()) {
+            dedupe_strings(entry, str::to_string);
+            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+        }
+    });
+    reorder_table_keys(table, KEY_ORDER);
+}

--- a/pyproject-fmt/rust/src/tests/mod.rs
+++ b/pyproject-fmt/rust/src/tests/mod.rs
@@ -29,6 +29,7 @@ mod pixi_tests;
 mod poetry_tests;
 mod project_tests;
 mod pylint_tests;
+mod pyproject_fmt_tests;
 mod pyrefly_tests;
 mod pyright_tests;
 mod pytest_tests;

--- a/pyproject-fmt/rust/src/tests/pyproject_fmt_tests.rs
+++ b/pyproject-fmt/rust/src/tests/pyproject_fmt_tests.rs
@@ -1,0 +1,117 @@
+use common::array::ensure_all_arrays_multiline;
+use common::table::{apply_table_formatting, Tables};
+
+use super::{assert_valid_toml, collect_entries, format_syntax, parse};
+use crate::pyproject_fmt::fix;
+
+fn evaluate(start: &str) -> String {
+    let root_ast = parse(start);
+    let count = root_ast.children_with_tokens().count();
+    let mut tables = Tables::from_ast(&root_ast);
+    apply_table_formatting(&mut tables, |_| true, &["tool.pyproject-fmt"], 120);
+    fix(&mut tables);
+    let entries = collect_entries(&tables);
+    root_ast.splice_children(0..count, entries);
+    ensure_all_arrays_multiline(&root_ast, 120);
+    let result = format_syntax(root_ast, 120);
+    assert_valid_toml(&result);
+    result
+}
+
+#[test]
+fn test_pyproject_fmt_reorders_keys() {
+    let start = indoc::indoc! {r#"
+    [tool.pyproject-fmt]
+    skip_wrap_for_keys = ["a"]
+    keep_full_version = true
+    table_format = "short"
+    indent = 4
+    column_width = 120
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyproject-fmt]
+    column_width = 120
+    indent = 4
+    keep_full_version = true
+    table_format = "short"
+    skip_wrap_for_keys = [ "a" ]
+    "#);
+}
+
+#[test]
+fn test_pyproject_fmt_unknown_keys_last() {
+    let start = indoc::indoc! {r#"
+    [tool.pyproject-fmt]
+    zzz = 1
+    indent = 2
+    aaa = 2
+    column_width = 120
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyproject-fmt]
+    column_width = 120
+    indent = 2
+    aaa = 2
+    zzz = 1
+    "#);
+}
+
+#[test]
+fn test_pyproject_fmt_sorts_and_dedupes_arrays() {
+    let start = indoc::indoc! {r#"
+    [tool.pyproject-fmt]
+    expand_tables = ["tool.ruff", "tool.black", "tool.ruff"]
+    collapse_tables = ["b", "a"]
+    skip_wrap_for_keys = ["z.parse", "a.parse", "z.parse"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyproject-fmt]
+    expand_tables = [ "tool.black", "tool.ruff" ]
+    collapse_tables = [ "a", "b" ]
+    skip_wrap_for_keys = [ "a.parse", "z.parse" ]
+    "#);
+}
+
+#[test]
+fn test_pyproject_fmt_dedup_case_sensitive() {
+    let start = indoc::indoc! {r#"
+    [tool.pyproject-fmt]
+    expand_tables = ["tool.Ruff", "tool.ruff"]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyproject-fmt]
+    expand_tables = [ "tool.Ruff", "tool.ruff" ]
+    "#);
+}
+
+#[test]
+fn test_pyproject_fmt_preserves_escape_strings() {
+    let start = indoc::indoc! {r#"
+    [tool.pyproject-fmt]
+    separate_root_table = "\n"
+    sub_table_spacing = ""
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.pyproject-fmt]
+    sub_table_spacing = ""
+    separate_root_table = "\n"
+    "#);
+}
+
+#[test]
+fn test_pyproject_fmt_absent_table_noop() {
+    let start = indoc::indoc! {r#"
+    [project]
+    name = "foo"
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    name = "foo"
+    "#);
+}

--- a/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__main_tests__issue_217_full_pyproject_idempotent.snap
+++ b/pyproject-fmt/rust/src/tests/snapshots/_pyproject_fmt__tests__main_tests__issue_217_full_pyproject_idempotent.snap
@@ -241,8 +241,8 @@ skip = [
 ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
 keep_full_version = true
+max_supported_python = "3.14"
 
 [tool.typos]
 default.extend-ignore-re = [

--- a/pyproject-fmt/tests/test_main.py
+++ b/pyproject-fmt/tests/test_main.py
@@ -411,3 +411,36 @@ def test_collapse_tables_override(tmp_path: Path) -> None:
     # Verify sub-tables are collapsed due to collapse override
     assert "urls.homepage =" in got
     assert "[project.urls]" not in got
+
+
+def test_pyproject_fmt_self_config_normalized(tmp_path: Path) -> None:
+    """The tool.pyproject-fmt table is key-ordered and its list values sorted and deduplicated."""
+    txt = """\
+    [project]
+    name = "myproject"
+
+    [tool.pyproject-fmt]
+    skip_wrap_for_keys = ["z.parse", "a.parse", "a.parse"]
+    indent = 2
+    column_width = 120
+    expand_tables = ["tool.ruff", "tool.black", "tool.ruff"]
+    keep_full_version = true
+    """
+    filename = tmp_path / "pyproject.toml"
+    filename.write_text(dedent(txt))
+    res = run([str(filename), "--no-generate-python-version-classifiers"])
+
+    assert res == 1
+
+    expected = """\
+    [project]
+    name = "myproject"
+
+    [tool.pyproject-fmt]
+    column_width = 120
+    indent = 2
+    keep_full_version = true
+    expand_tables = [ "tool.black", "tool.ruff" ]
+    skip_wrap_for_keys = [ "a.parse", "z.parse" ]
+    """
+    assert filename.read_text() == dedent(expected)


### PR DESCRIPTION
pyproject-fmt reorders and normalizes the keys of every tool table it recognizes, from `tool.ruff` to `tool.ty`, yet left its own `[tool.pyproject-fmt]` table in whatever order the author typed. Anyone editing the config by hand drifted away from the ordering the tool enforces everywhere else, which is what [#420](https://github.com/tox-dev/toml-fmt/issues/420) asks to fix.

This gives `[tool.pyproject-fmt]` the same table-specific handling as the rest. Keys follow the sequence documented in the configuration reference (`column_width`, `indent`, `keep_full_version`, and so on), and the `expand_tables`, `collapse_tables`, and `skip_wrap_for_keys` lists are sorted and deduplicated. Those lists reach the formatter as sets: `expand_tables` and `collapse_tables` go through `HashSet` membership in `should_collapse`, and `skip_wrap_for_keys` is matched with `matches_pattern` under `any()`. Element order never reaches the logic, so sorting and dropping duplicates cannot change what the formatter does. 🔒 Deduplication compares byte-for-byte and keeps case variants apart, because those same lookups are case-sensitive.

Reviewers will see one snapshot move in `issue_217_full_pyproject_idempotent`, where a real-world config now emits `keep_full_version` ahead of `max_supported_python`. That is the new ordering applied to an existing fixture. The scalar keys and the escape-carrying `sub_table_spacing` and `separate_root_table` values are left untouched, since requoting a `"\n"` would change its meaning.
