### PR TITLE
✨ feat(pyproject-fmt): normalize and validate project.version

### DIFF
--- a/common/src/disabled.rs
+++ b/common/src/disabled.rs
@@ -53,6 +53,16 @@ pub fn with_disabled_keys(content: &str, format: impl FnOnce(&str) -> String) ->
     restore_disabled_keys(&format(&enabled))
 }
 
+/// [`with_disabled_keys`] for a formatter that may reject its input; a rejected pass restores nothing.
+///
+/// # Errors
+///
+/// Propagates whatever `format` rejected the content with.
+pub fn try_with_disabled_keys<E>(content: &str, format: impl FnOnce(&str) -> Result<String, E>) -> Result<String, E> {
+    let enabled = enable_disabled_keys(content);
+    Ok(restore_disabled_keys(&format(&enabled)?))
+}
+
 /// Drops one space after `#` to mirror how [`comment_disabled_line`] writes it back, keeping the round-trip stable.
 fn split_comment(line: &str) -> Option<(&str, &str)> {
     let trimmed = line.trim_start();

--- a/common/src/pep508/version_op.rs
+++ b/common/src/pep508/version_op.rs
@@ -1,5 +1,6 @@
 pub(crate) use crate::pep508::version_op::operator::Operator;
 pub(crate) use crate::pep508::version_op::version::Version;
+pub use crate::pep508::version_op::version::normalize_version;
 
 mod operator;
 mod version;

--- a/common/src/pep508/version_op/version.rs
+++ b/common/src/pep508/version_op/version.rs
@@ -1,3 +1,52 @@
+use std::sync::LazyLock;
+
+use regex::{Captures, Regex};
+
+/// Canonical [PEP 440](https://peps.python.org/pep-0440/) form of `raw`, or `None` when `raw` is not a valid version.
+pub fn normalize_version(raw: &str) -> Option<String> {
+    Version::parse(raw).map(|version| version.to_string())
+}
+
+static PEP440: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?xi)
+        ^
+        v?
+        (?:(?P<epoch>[0-9]+)!)?
+        (?P<release>[0-9]+(?:\.[0-9]+)*)
+        (?:[-_.]?(?P<pre_l>alpha|a|beta|b|preview|pre|c|rc)[-_.]?(?P<pre_n>[0-9]+)?)?
+        (?:-(?P<post_n1>[0-9]+)|[-_.]?(?P<post_l>post|rev|r)[-_.]?(?P<post_n2>[0-9]+)?)?
+        (?P<dev>[-_.]?dev[-_.]?(?P<dev_n>[0-9]+)?)?
+        (?:\+(?P<local>[a-z0-9]+(?:[-_.][a-z0-9]+)*))?
+        $",
+    )
+    .unwrap()
+});
+
+/// Outer `None` rejects the whole version when the captured digits overflow, inner `None` means the group was absent.
+fn optional_number(caps: &Captures, name: &str) -> Option<Option<u64>> {
+    caps.name(name)
+        .map_or(Some(None), |number| number.as_str().parse().ok().map(Some))
+}
+
+fn normalize_local(raw: &str) -> String {
+    let lowered = raw.to_ascii_lowercase();
+    lowered
+        .split(['-', '_', '.'])
+        .map(|part| {
+            if part.chars().all(|c| c.is_ascii_digit()) {
+                match part.trim_start_matches('0') {
+                    "" => "0",
+                    trimmed => trimmed,
+                }
+            } else {
+                part
+            }
+        })
+        .collect::<Vec<&str>>()
+        .join(".")
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Version {
     pub epoch: Option<u64>,
@@ -10,6 +59,42 @@ pub struct Version {
 }
 
 impl Version {
+    /// Strict counterpart of [`Version::new`]: rejects what PEP 440 does not accept instead of salvaging it.
+    pub fn parse(raw: &str) -> Option<Self> {
+        let caps = PEP440.captures(raw.trim())?;
+        let release = caps["release"]
+            .split('.')
+            .map(str::parse::<u64>)
+            .collect::<Result<Vec<u64>, _>>()
+            .ok()?;
+        let pre = match caps.name("pre_l") {
+            Some(label) => Some((label.as_str().to_ascii_lowercase(), optional_number(&caps, "pre_n")?)),
+            None => None,
+        };
+        let post = if let Some(implicit) = caps.name("post_n1") {
+            Some((Some("post".to_string()), Some(implicit.as_str().parse().ok()?)))
+        } else if caps.name("post_l").is_some() {
+            Some((Some("post".to_string()), optional_number(&caps, "post_n2")?))
+        } else {
+            None
+        };
+        let dev = if caps.name("dev").is_some() {
+            Some(("dev".to_string(), optional_number(&caps, "dev_n")?))
+        } else {
+            None
+        };
+        Some(Self {
+            // A zero epoch is dropped in the canonical form.
+            epoch: optional_number(&caps, "epoch")?.filter(|epoch| *epoch != 0),
+            release,
+            pre,
+            post,
+            dev,
+            local: caps.name("local").map(|local| normalize_local(local.as_str())),
+            has_wildcard: false,
+        })
+    }
+
     pub fn new(raw: &str) -> Self {
         let mut input = raw.trim();
         let mut has_wildcard = false;

--- a/common/src/string.rs
+++ b/common/src/string.rs
@@ -197,6 +197,14 @@ pub fn get_string_token(node: &SyntaxNode) -> Option<tombi_syntax::SyntaxToken> 
         .find(|token| token.kind() == kind)
 }
 
+/// Decoded content of a scalar value node, or `None` when that value is not a string.
+pub fn get_string_value(node: &SyntaxNode) -> Option<String> {
+    if !is_string_kind(node.kind()) {
+        return None;
+    }
+    get_string_token(node).map(|token| load_text(token.text(), node.kind()))
+}
+
 pub fn load_text(value: &str, kind: SyntaxKind) -> String {
     let offset = if [BASIC_STRING, LITERAL_STRING].contains(&kind) {
         1

--- a/common/src/tests/disabled_tests.rs
+++ b/common/src/tests/disabled_tests.rs
@@ -1,4 +1,6 @@
-use crate::disabled::{MARKER, enable_disabled_keys, restore_disabled_keys, with_disabled_keys};
+use crate::disabled::{
+    MARKER, enable_disabled_keys, restore_disabled_keys, try_with_disabled_keys, with_disabled_keys,
+};
 
 #[test]
 fn test_with_disabled_keys_brackets_the_format_pass() {
@@ -258,4 +260,19 @@ fn test_commented_table_section_stays_commented() {
         out, source,
         "a commented table header and its keys stay verbatim comments"
     );
+}
+
+#[test]
+fn test_try_with_disabled_keys_restores_on_success() {
+    let out = try_with_disabled_keys::<()>("# x = 1\n", |enabled| {
+        assert!(enabled.contains(MARKER), "the format pass sees the enabled key");
+        Ok(enabled.to_string())
+    });
+    assert_eq!(out.unwrap(), "# x = 1\n");
+}
+
+#[test]
+fn test_try_with_disabled_keys_propagates_rejection() {
+    let out = try_with_disabled_keys::<&str>("# x = 1\n", |_| Err("rejected"));
+    assert_eq!(out.unwrap_err(), "rejected");
 }

--- a/common/src/tests/pep508_tests.rs
+++ b/common/src/tests/pep508_tests.rs
@@ -579,3 +579,23 @@ fn test_normalize_version_rejects_release_overflow() {
 fn test_normalize_version_rejects_pre_release_number_overflow() {
     assert!(normalize_version("1.0a99999999999999999999").is_none());
 }
+
+#[test]
+fn test_normalize_version_rejects_epoch_overflow() {
+    assert!(normalize_version("99999999999999999999!1.0").is_none());
+}
+
+#[test]
+fn test_normalize_version_rejects_implicit_post_release_overflow() {
+    assert!(normalize_version("1.0-99999999999999999999").is_none());
+}
+
+#[test]
+fn test_normalize_version_rejects_post_release_number_overflow() {
+    assert!(normalize_version("1.0.post99999999999999999999").is_none());
+}
+
+#[test]
+fn test_normalize_version_rejects_dev_release_number_overflow() {
+    assert!(normalize_version("1.0.dev99999999999999999999").is_none());
+}

--- a/common/src/tests/pep508_tests.rs
+++ b/common/src/tests/pep508_tests.rs
@@ -1,4 +1,4 @@
-use crate::pep508::{MarkerExpr, Requirement};
+use crate::pep508::{MarkerExpr, Requirement, normalize_version};
 
 fn format_requirement_helper(start: &str, keep_full_version: bool) -> String {
     Requirement::new(start)
@@ -479,4 +479,103 @@ fn test_is_name_only_url() {
 #[test]
 fn test_is_name_only_private() {
     assert!(!Requirement::new("wheel; private").unwrap().is_name_only());
+}
+
+fn normalize_version_helper(raw: &str) -> String {
+    normalize_version(raw).unwrap()
+}
+
+#[test]
+fn test_normalize_version_already_canonical() {
+    insta::assert_snapshot!(normalize_version_helper("1.9.0"), @"1.9.0");
+}
+
+#[test]
+fn test_normalize_version_strips_surrounding_whitespace() {
+    insta::assert_snapshot!(normalize_version_helper(" 1.9.0 "), @"1.9.0");
+}
+
+#[test]
+fn test_normalize_version_strips_v_prefix() {
+    insta::assert_snapshot!(normalize_version_helper("v1.9"), @"1.9");
+}
+
+#[test]
+fn test_normalize_version_strips_release_leading_zeros() {
+    insta::assert_snapshot!(normalize_version_helper("1.09.007"), @"1.9.7");
+}
+
+#[test]
+fn test_normalize_version_drops_zero_epoch() {
+    insta::assert_snapshot!(normalize_version_helper("0!1.0"), @"1.0");
+}
+
+#[test]
+fn test_normalize_version_keeps_non_zero_epoch() {
+    insta::assert_snapshot!(normalize_version_helper("2!1.0"), @"2!1.0");
+}
+
+#[test]
+fn test_normalize_version_pre_release_spelling() {
+    insta::assert_snapshot!(normalize_version_helper("1.0-ALPHA.1"), @"1.0a1");
+}
+
+#[test]
+fn test_normalize_version_pre_release_implicit_number() {
+    insta::assert_snapshot!(normalize_version_helper("1.0preview"), @"1.0rc0");
+}
+
+#[test]
+fn test_normalize_version_implicit_post_release() {
+    insta::assert_snapshot!(normalize_version_helper("1.0-1"), @"1.0.post1");
+}
+
+#[test]
+fn test_normalize_version_post_release_alias() {
+    insta::assert_snapshot!(normalize_version_helper("1.0_rev_3"), @"1.0.post3");
+}
+
+#[test]
+fn test_normalize_version_dev_release_implicit_number() {
+    insta::assert_snapshot!(normalize_version_helper("1.0dev"), @"1.0.dev0");
+}
+
+#[test]
+fn test_normalize_version_local_segment() {
+    insta::assert_snapshot!(normalize_version_helper("1.0+Ubuntu_007-x"), @"1.0+ubuntu.7.x");
+}
+
+#[test]
+fn test_normalize_version_local_zero_segment() {
+    insta::assert_snapshot!(normalize_version_helper("1.0+000"), @"1.0+0");
+}
+
+#[test]
+fn test_normalize_version_all_segments() {
+    insta::assert_snapshot!(normalize_version_helper("v1.0.c1.post.dev+A"), @"1.0rc1.post0.dev0+a");
+}
+
+#[test]
+fn test_normalize_version_rejects_non_numeric_release() {
+    assert!(normalize_version("1.9.xyz").is_none());
+}
+
+#[test]
+fn test_normalize_version_rejects_empty() {
+    assert!(normalize_version("").is_none());
+}
+
+#[test]
+fn test_normalize_version_rejects_trailing_separator() {
+    assert!(normalize_version("1.0.0-").is_none());
+}
+
+#[test]
+fn test_normalize_version_rejects_release_overflow() {
+    assert!(normalize_version("99999999999999999999.0").is_none());
+}
+
+#[test]
+fn test_normalize_version_rejects_pre_release_number_overflow() {
+    assert!(normalize_version("1.0a99999999999999999999").is_none());
 }

--- a/common/src/tests/string_tests.rs
+++ b/common/src/tests/string_tests.rs
@@ -1,10 +1,11 @@
 use tombi_syntax::SyntaxKind::{
-    BARE_KEY, BASIC_STRING, KEY_VALUE, KEY_VALUE_GROUP, LITERAL_STRING, MULTI_LINE_BASIC_STRING,
+    BARE_KEY, BASIC_STRING, KEY_VALUE, KEY_VALUE_GROUP, KEYS, LITERAL_STRING, MULTI_LINE_BASIC_STRING,
     MULTI_LINE_LITERAL_STRING,
 };
 
 use crate::string::{
-    load_text, normalize_key_quotes, strip_quotes, update_content, update_content_wrapped, wrap_all_long_strings,
+    get_string_value, load_text, normalize_key_quotes, strip_quotes, update_content, update_content_wrapped,
+    wrap_all_long_strings,
 };
 
 fn parse(source: &str) -> tombi_syntax::SyntaxNode {
@@ -1166,4 +1167,27 @@ value = "This is a very long string that should be wrapped because it does not m
         wrapped because it does not match pattern\
         """
     "#);
+}
+
+fn first_value_node(toml: &str) -> tombi_syntax::SyntaxNode {
+    parse(toml)
+        .descendants()
+        .find(|node| node.kind() == KEY_VALUE)
+        .and_then(|entry| entry.children().find(|node| node.kind() != KEYS))
+        .unwrap()
+}
+
+#[test]
+fn test_get_string_value_basic_string() {
+    assert_eq!(get_string_value(&first_value_node("a = \"b\"\n")).unwrap(), "b");
+}
+
+#[test]
+fn test_get_string_value_literal_string() {
+    assert_eq!(get_string_value(&first_value_node("a = 'b'\n")).unwrap(), "b");
+}
+
+#[test]
+fn test_get_string_value_non_string() {
+    assert!(get_string_value(&first_value_node("a = 1\n")).is_none());
 }

--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -685,7 +685,8 @@ directly), or when ``setuptools`` itself is missing from ``requires``.
 The :pep:`621` core metadata table. See the
 `packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-project-table>`_.
 
-Keys follow the canonical metadata order; name, dependencies, classifiers, and keywords are normalized and sorted.
+Keys follow the canonical metadata order; name, version, dependencies, classifiers, and keywords are normalized and
+sorted.
 
 
 **Key ordering:** ``name`` → ``version`` → ``import-names`` → ``import-namespaces`` → ``description`` →
@@ -697,6 +698,11 @@ Keys follow the canonical metadata order; name, dependencies, classifiers, and k
 
 ``name``
     Converted to canonical format (lowercase with hyphens): ``My_Package`` → ``my-package``
+
+``version``
+    Converted to the canonical :pep:`440` form: ``V1.0-Alpha.2`` → ``1.0a2``. A value that is not a valid
+    :pep:`440` version is rejected: the formatter reports it on standard error, leaves the file untouched, and
+    exits with a non-zero status.
 
 ``description``
     Whitespace normalized: multiple spaces collapsed, consistent spacing after periods.

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -290,7 +290,8 @@ redundant ``wheel`` requirement is removed when the build backend is setuptools.
 The :pep:`621` core metadata table. See the
 `packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-project-table>`_.
 
-Keys follow the canonical metadata order; name, dependencies, classifiers, and keywords are normalized and sorted.
+Keys follow the canonical metadata order; name, version, dependencies, classifiers, and keywords are normalized and
+sorted.
 
 .. dropdown:: Formatting details
 
@@ -303,6 +304,11 @@ Keys follow the canonical metadata order; name, dependencies, classifiers, and k
 
     ``name``
         Converted to canonical format (lowercase with hyphens): ``My_Package`` → ``my-package``
+
+    ``version``
+        Converted to the canonical :pep:`440` form: ``V1.0-Alpha.2`` → ``1.0a2``. A value that is not a valid
+        :pep:`440` version is rejected: the formatter reports it on standard error, leaves the file untouched, and
+        exits with a non-zero status.
 
     ``description``
         Whitespace normalized: multiple spaces collapsed, consistent spacing after periods.

--- a/pyproject-fmt/rust/src/main.rs
+++ b/pyproject-fmt/rust/src/main.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::string::String;
 
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::{PyModule, PyModuleMethods};
 use pyo3::{pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, Bound, PyResult, Python};
 
@@ -150,16 +151,18 @@ async fn format_with_tombi(content: &str, column_width: usize, indent: usize) ->
 
 #[pyfunction]
 #[pyo3(name = "format_toml")]
-fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> String {
-    py.detach(|| format_toml(content, opt))
+fn format_toml_py(py: Python<'_>, content: &str, opt: &Settings) -> PyResult<String> {
+    py.detach(|| format_toml(content, opt)).map_err(PyValueError::new_err)
 }
 
-#[must_use]
-pub fn format_toml(content: &str, opt: &Settings) -> String {
-    common::disabled::with_disabled_keys(content, |content| format_core(content, opt))
+/// # Errors
+///
+/// Will return a message describing why the content was rejected, e.g. an invalid `project.version`.
+pub fn format_toml(content: &str, opt: &Settings) -> Result<String, String> {
+    common::disabled::try_with_disabled_keys(content, |content| format_core(content, opt))
 }
 
-fn format_core(content: &str, opt: &Settings) -> String {
+fn format_core(content: &str, opt: &Settings) -> Result<String, String> {
     let root_ast = parse(content);
     common::string::normalize_key_quotes(&root_ast);
     let mut tables = Tables::from_ast(&root_ast);
@@ -191,7 +194,7 @@ fn format_core(content: &str, opt: &Settings) -> String {
         opt.min_supported_python,
         opt.generate_python_version_classifiers,
         &table_config,
-    );
+    )?;
     dependency_groups::fix(&mut tables, opt.keep_full_version);
     ruff::fix(&mut tables);
     uv::fix(&mut tables);
@@ -252,7 +255,7 @@ fn format_core(content: &str, opt: &Settings) -> String {
 
     let sub_spacing = (opt.table_format == "long").then_some(opt.sub_table_spacing.as_str());
     let result = common::table::normalize_table_spacing(&formatted, &["tool"], &opt.separate_root_table, sub_spacing);
-    common::util::limit_blank_lines(&result, 2)
+    Ok(common::util::limit_blank_lines(&result, 2))
 }
 
 /// # Errors

--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -16,8 +16,8 @@ use common::create::{
     make_array, make_array_entry, make_comma, make_entry_of_string, make_key, make_newline,
     make_table_array_with_entries, make_whitespace_n,
 };
-use common::pep508::Requirement;
-use common::string::{get_string_token, load_text, update_content};
+use common::pep508::{normalize_version, Requirement};
+use common::string::{get_string_token, get_string_value, load_text, update_content};
 use common::table::{for_entries, reorder_table_keys, Tables};
 
 use crate::TableFormatConfig;
@@ -45,6 +45,9 @@ fn normalize_and_sort_requirements(entry: &SyntaxNode, keep_full_version: bool) 
     );
 }
 
+/// # Errors
+///
+/// Will return the offending value if `project.version` is not a valid PEP 440 version.
 pub fn fix(
     tables: &mut Tables,
     keep_full_version: bool,
@@ -52,7 +55,7 @@ pub fn fix(
     min_supported_python: (u8, u8),
     generate_python_version_classifiers: bool,
     table_config: &TableFormatConfig,
-) {
+) -> Result<(), String> {
     let key_order = &["name", "email"];
 
     if !table_config.should_collapse("project.authors") {
@@ -64,16 +67,25 @@ pub fn fix(
 
     let table_element = tables.get("project");
     if table_element.is_none() {
-        return;
+        return Ok(());
     }
     let table = &mut table_element.unwrap().first().unwrap().borrow_mut();
 
     static RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r" \.(\W)").unwrap());
     expand_entry_points_inline_tables(table);
 
+    let mut invalid_version = None;
     for_entries(table, &mut |key, entry| match key.split('.').next().unwrap() {
         "name" => {
             update_content(entry, |s| Requirement::new(s).unwrap().canonical_name());
+        }
+        "version" => {
+            if let Some(raw) = get_string_value(entry) {
+                match normalize_version(&raw) {
+                    Some(canonical) => update_content(entry, |_| canonical.clone()),
+                    None => invalid_version = Some(raw),
+                }
+            }
         }
         "license" => {
             static LICENSE_RE: LazyLock<Regex> =
@@ -131,6 +143,9 @@ pub fn fix(
         "authors" | "maintainers" => {}
         _ => {}
     });
+    if let Some(raw) = invalid_version {
+        return Err(format!("project.version `{raw}` is not a valid PEP 440 version"));
+    }
 
     generate_classifiers(
         table,
@@ -184,6 +199,7 @@ pub fn fix(
             });
         }
     }
+    Ok(())
 }
 
 fn expand_entry_points_inline_tables(table: &mut RefMut<Vec<SyntaxElement>>) {

--- a/pyproject-fmt/rust/src/tests/autopep8_tests.rs
+++ b/pyproject-fmt/rust/src/tests/autopep8_tests.rs
@@ -44,7 +44,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_settings());
+    let result = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/rust/src/tests/bandit_tests.rs
+++ b/pyproject-fmt/rust/src/tests/bandit_tests.rs
@@ -44,7 +44,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_settings());
+    let result = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/rust/src/tests/cibuildwheel_tests.rs
+++ b/pyproject-fmt/rust/src/tests/cibuildwheel_tests.rs
@@ -44,7 +44,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_settings());
+    let result = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/rust/src/tests/deptry_tests.rs
+++ b/pyproject-fmt/rust/src/tests/deptry_tests.rs
@@ -44,7 +44,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_settings());
+    let result = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/rust/src/tests/disabled_tests.rs
+++ b/pyproject-fmt/rust/src/tests/disabled_tests.rs
@@ -22,7 +22,7 @@ fn settings() -> Settings {
 }
 
 fn evaluate(start: &str) -> String {
-    let result = format_toml(start, &settings());
+    let result = format_toml(start, &settings()).unwrap();
     assert_valid_toml(&result);
     assert!(
         !result.contains(MARKER),

--- a/pyproject-fmt/rust/src/tests/hatch_tests.rs
+++ b/pyproject-fmt/rust/src/tests/hatch_tests.rs
@@ -34,7 +34,7 @@ fn evaluate_full(start: &str) -> String {
         collapse_tables: vec![],
         skip_wrap_for_keys: vec![],
     };
-    let r = format_toml(start, &s);
+    let r = format_toml(start, &s).unwrap();
     assert_valid_toml(&r);
     r
 }
@@ -219,7 +219,7 @@ fn evaluate_long(start: &str) -> String {
         collapse_tables: vec![],
         skip_wrap_for_keys: vec![],
     };
-    let r = format_toml(start, &s);
+    let r = format_toml(start, &s).unwrap();
     assert_valid_toml(&r);
     r
 }

--- a/pyproject-fmt/rust/src/tests/interrogate_tests.rs
+++ b/pyproject-fmt/rust/src/tests/interrogate_tests.rs
@@ -44,7 +44,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_settings());
+    let result = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -42,7 +42,7 @@ fn format_toml_helper(
         generate_python_version_classifiers,
         ..default_settings()
     };
-    let result = format_toml(start, &settings);
+    let result = format_toml(start, &settings).unwrap();
     assert_valid_toml(&result);
     result
 }
@@ -123,7 +123,7 @@ fn test_expand_tables_with_project() {
         expand_tables: vec![String::from("project")],
         ..default_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "example"
@@ -149,7 +149,7 @@ fn test_collapse_project_authors() {
         collapse_tables: vec![String::from("project.authors")],
         ..long_format_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "example"
@@ -170,7 +170,7 @@ fn test_collapse_project_maintainers() {
         collapse_tables: vec![String::from("project.maintainers")],
         ..long_format_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "example"
@@ -186,7 +186,7 @@ fn test_table_format_long_with_entry_points() {
         entry-points."console_scripts".mycli = "pkg:main"
         entry-points."console_scripts".othercli = "pkg:other"
         "#};
-    let got = format_toml(start, &long_format_settings());
+    let got = format_toml(start, &long_format_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "example"
@@ -210,7 +210,7 @@ fn test_expand_project_authors() {
         expand_tables: vec![String::from("project.authors")],
         ..default_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "example"
@@ -239,7 +239,7 @@ fn test_expand_project_maintainers() {
         expand_tables: vec![String::from("project.maintainers")],
         ..default_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "example"
@@ -267,7 +267,7 @@ fn test_expand_single_author() {
         expand_tables: vec![String::from("project.authors")],
         ..default_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "example"
@@ -290,7 +290,7 @@ fn test_collapse_authors_with_url_field() {
         name = "Alice"
         email = "alice@example.com"
         "#};
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "test"
@@ -308,7 +308,7 @@ fn test_collapse_empty_authors() {
         [[project.authors]]
         [[project.authors]]
         "#};
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "test"
@@ -322,7 +322,7 @@ fn test_collapse_empty_authors() {
 #[test]
 fn test_collapse_authors_without_trailing_newline() {
     let start = "[project]\nname = \"test\"\n[[project.authors]]\nname = \"Alice\"\nemail = \"alice@example.com\"";
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     assert!(got.contains("authors = ["));
     assert!(got.contains("{ name = \"Alice\", email = \"alice@example.com\" }"));
 }
@@ -331,7 +331,7 @@ fn test_collapse_authors_without_trailing_newline() {
 fn test_collapse_authors_compact_parent() {
     let start =
         "[project]\nname=\"test\"\nversion=\"1.0\"\n[[project.authors]]\nname=\"Alice\"\nemail=\"alice@example.com\"";
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     assert!(got.contains("authors = ["));
 }
 
@@ -348,7 +348,7 @@ fn test_expand_authors_already_expanded() {
         expand_tables: vec![String::from("project.authors")],
         ..long_format_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert!(got.contains("[[project.authors]]"));
     assert!(got.contains("name = \"John Doe\""));
 }
@@ -372,7 +372,7 @@ fn test_issue_146_expand_specific_subtable() {
         expand_tables: vec![String::from("project.optional-dependencies")],
         ..default_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert!(
         got.contains("[project.optional-dependencies]"),
         "optional-dependencies should stay expanded"
@@ -397,7 +397,7 @@ fn test_css_specificity_more_specific_wins() {
         collapse_tables: vec![String::from("project")],
         ..long_format_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert!(
         got.contains("[project.urls]"),
         "project.urls should be expanded (specific)"
@@ -495,7 +495,7 @@ fn test_issue_146_deeply_nested_ruff_table() {
         expand_tables: vec![String::from("tool.ruff.lint.flake8-tidy-imports.banned-api")],
         ..default_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert!(
         got.contains("[tool.ruff.lint.flake8-tidy-imports.banned-api]"),
         "deeply nested ruff table should stay expanded. Got:\n{got}"
@@ -509,7 +509,7 @@ fn test_no_duplicate_requires() {
         build-backend = "backend"
         requires = ["c", "d"]
     "#};
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     let count = got.matches("requires").count();
     assert_eq!(count, 1, "requires should appear exactly once, but got:\n{}", got);
 }
@@ -526,7 +526,7 @@ fn test_table_format_long_removes_blank_lines_between_same_group() {
         [project.optional-dependencies]
         dev = ["pytest"]
         "#};
-    let got = format_toml(start, &long_format_settings());
+    let got = format_toml(start, &long_format_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "test"
@@ -549,7 +549,7 @@ fn test_table_format_long_with_tool_tables() {
         [tool.mypy]
         strict = true
         "#};
-    let got = format_toml(start, &long_format_settings());
+    let got = format_toml(start, &long_format_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [tool.ruff]
     line-length = 120
@@ -570,7 +570,7 @@ fn test_table_format_long_preserves_blank_lines_between_different_groups() {
         [project]
         name = "test"
         "#};
-    let got = format_toml(start, &long_format_settings());
+    let got = format_toml(start, &long_format_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [build-system]
     requires = [ "setuptools" ]
@@ -593,7 +593,7 @@ fn test_extract_table_names_from_array_tables() {
         expand_tables: vec![String::from("project.authors")],
         ..long_format_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "test"
@@ -605,7 +605,7 @@ fn test_extract_table_names_from_array_tables() {
 #[test]
 fn test_format_with_trailing_newline_preserved() {
     let start = "[project]\nname = \"test\"\n";
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "test"
@@ -621,7 +621,7 @@ fn test_tool_prefix_extraction_with_dotted_keys() {
         [tool.coverage.report]
         precision = 2
         "#};
-    let got = format_toml(start, &long_format_settings());
+    let got = format_toml(start, &long_format_settings()).unwrap();
     assert_snapshot!(got, @"
     [tool.coverage.report]
     precision = 2
@@ -655,7 +655,7 @@ fn test_format_with_non_table_lines_between_headers() {
         [project.urls]
         homepage = "https://example.com"
         "#};
-    let got = format_toml(start, &long_format_settings());
+    let got = format_toml(start, &long_format_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "test"
@@ -740,9 +740,9 @@ fn test_idempotent_formatting() {
         description = "This is a long description string that needs to exceed the default column width of one hundred and twenty characters to trigger wrapping."
     "#};
     let settings = default_settings();
-    let first = format_toml(start, &settings);
-    let second = format_toml(&first, &settings);
-    let third = format_toml(&second, &settings);
+    let first = format_toml(start, &settings).unwrap();
+    let second = format_toml(&first, &settings).unwrap();
+    let third = format_toml(&second, &settings).unwrap();
     assert_eq!(first, second, "formatting should be idempotent (first->second)");
     assert_eq!(second, third, "formatting should be idempotent (second->third)");
 }
@@ -757,7 +757,7 @@ fn test_issue_186_single_quote_with_comments() {
         'second',
     ]
     "#};
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [tool.something]
     items = [
@@ -780,7 +780,7 @@ fn test_remove_blank_lines_between_same_group_tables_long_format() {
     [tool.ruff.format]
     quote-style = "double"
     "#};
-    let got = format_toml(start, &long_format_settings());
+    let got = format_toml(start, &long_format_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [tool.ruff]
     line-length = 100
@@ -800,7 +800,7 @@ fn test_table_key_without_prefix_match_long_format() {
     [custom.nested]
     other = "data"
     "#};
-    let got = format_toml(start, &long_format_settings());
+    let got = format_toml(start, &long_format_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [custom]
     key = "value"
@@ -825,7 +825,7 @@ fn test_sub_table_spacing_blank_line() {
         sub_table_spacing: String::from("\n"),
         ..long_format_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [tool.ruff]
     line-length = 120
@@ -854,7 +854,7 @@ fn test_sub_table_spacing_with_project_tables() {
         sub_table_spacing: String::from("\n"),
         ..long_format_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [project]
     name = "test"
@@ -883,7 +883,7 @@ fn test_issue_402_sub_table_spacing_two_blank_lines() {
         sub_table_spacing: String::from("\n\n"),
         ..long_format_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [tool.uv.sources]
     pkg = { workspace = true }
@@ -910,7 +910,7 @@ fn test_issue_402_separate_root_table_two_blank_lines() {
         separate_root_table: String::from("\n\n"),
         ..default_settings()
     };
-    let got = format_toml(start, &settings);
+    let got = format_toml(start, &settings).unwrap();
     assert_snapshot!(got, @r#"
     [build-system]
     requires = [ "hatchling" ]
@@ -943,9 +943,9 @@ fn test_issue_217_mixed_quotes_idempotent() {
         min_supported_python: (3, 14),
         ..default_settings()
     };
-    let first = format_toml(start, &settings);
+    let first = format_toml(start, &settings).unwrap();
     assert_valid_toml(&first);
-    let second = format_toml(&first, &settings);
+    let second = format_toml(&first, &settings).unwrap();
     assert_eq!(first, second, "formatting should be idempotent");
     assert_snapshot!(first, @r#"
     [project]
@@ -975,9 +975,9 @@ fn test_issue_217_full_pyproject_idempotent() {
         min_supported_python: (3, 10),
         ..default_settings()
     };
-    let first = format_toml(&start, &settings);
+    let first = format_toml(&start, &settings).unwrap();
     assert_valid_toml(&first);
-    let second = format_toml(&first, &settings);
+    let second = format_toml(&first, &settings).unwrap();
     assert_eq!(first, second, "formatting should be idempotent");
     assert_snapshot!(first);
 }
@@ -992,7 +992,7 @@ fn test_issue_299_pixi_workspace_collapse_with_keys() {
     [tool.pixi.workspace]
     name = "my-project"
     "#};
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     assert_valid_toml(&got);
     assert_snapshot!(got, @r#"
     [project]
@@ -1013,7 +1013,7 @@ fn test_issue_299_pixi_workspace_collapse_empty() {
 
     [tool.pixi.workspace]
     "#};
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     assert_valid_toml(&got);
     assert_snapshot!(got, @r#"
     [project]
@@ -1031,7 +1031,7 @@ fn test_issue_202_preserve_inline_comment_after_array() {
     [tool.uv]
     lint.per-file-ignores."docs/**/*.py" = [ "INP001" ] # No __init__.py in docs
     "#};
-    let got = format_toml(start, &default_settings());
+    let got = format_toml(start, &default_settings()).unwrap();
     assert_snapshot!(got, @r#"
     [tool.uv]
     lint.per-file-ignores."docs/**/*.py" = [ "INP001" ]  # No __init__.py in docs
@@ -1056,7 +1056,7 @@ fn test_issue_376_collapse_with_comments_stays_valid() {
     "#};
     let mut settings = default_settings();
     settings.collapse_tables = vec![String::from("tool.uv.index")];
-    let result = format_toml(start, &settings);
+    let result = format_toml(start, &settings).unwrap();
     assert_valid_toml(&result);
     insta::assert_snapshot!(result, @r#"
     [[tool.uv.index]]
@@ -1080,7 +1080,7 @@ fn test_wide_array_of_tables_under_implicit_parent() {
         [[tool.demo.labels.file-rules]]
         any-glob-to-any-file = ["src/managers/apt*", "src/managers/dpkg*", "src/managers/opkg*", "tests/*apt*", "tests/*dpkg*", "tests/*opkg*"]
     "#};
-    let result = format_toml(start, &default_settings());
+    let result = format_toml(start, &default_settings()).unwrap();
     assert_valid_toml(&result);
     insta::assert_snapshot!(result, @r#"
     [[tool.demo.labels.file-rules]]
@@ -1102,7 +1102,7 @@ fn test_wide_array_of_tables_under_explicit_empty_parent() {
         [[tool.demo.labels.file-rules]]
         any-glob-to-any-file = ["src/managers/apt*", "src/managers/dpkg*", "src/managers/opkg*", "tests/*apt*", "tests/*dpkg*", "tests/*opkg*"]
     "#};
-    let result = format_toml(start, &default_settings());
+    let result = format_toml(start, &default_settings()).unwrap();
     assert_valid_toml(&result);
     insta::assert_snapshot!(result, @r#"
     [tool.demo.labels]
@@ -1116,4 +1116,15 @@ fn test_wide_array_of_tables_under_explicit_empty_parent() {
       "tests/*opkg*"
     ]
     "#);
+}
+
+#[test]
+fn test_format_toml_rejects_invalid_project_version() {
+    let start = indoc! {r#"
+    [project]
+    name = "alpha"
+    version = "1.9.xyz"
+    "#};
+    let error = format_toml(start, &default_settings()).unwrap_err();
+    assert_snapshot!(error, @"project.version `1.9.xyz` is not a valid PEP 440 version");
 }

--- a/pyproject-fmt/rust/src/tests/main_tests.rs
+++ b/pyproject-fmt/rust/src/tests/main_tests.rs
@@ -1128,3 +1128,49 @@ fn test_format_toml_rejects_invalid_project_version() {
     let error = format_toml(start, &default_settings()).unwrap_err();
     assert_snapshot!(error, @"project.version `1.9.xyz` is not a valid PEP 440 version");
 }
+
+#[test]
+fn test_lib_format_toml_returns_formatted_content() {
+    use pyo3::types::PyAnyMethods;
+
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
+        let module = pyo3::types::PyModule::new(py, "_lib").unwrap();
+        crate::_lib(&module.as_borrowed()).unwrap();
+        let settings = pyo3::Py::new(py, default_settings()).unwrap();
+
+        let got = module
+            .getattr("format_toml")
+            .unwrap()
+            .call1(("[project]\nname=\"My_Package\"\n", settings))
+            .unwrap()
+            .extract::<String>()
+            .unwrap();
+
+        assert_snapshot!(got, @r#"
+        [project]
+        name = "my-package"
+        "#);
+    });
+}
+
+#[test]
+fn test_lib_format_toml_raises_on_invalid_version() {
+    use pyo3::types::PyAnyMethods;
+
+    pyo3::Python::initialize();
+    pyo3::Python::attach(|py| {
+        let module = pyo3::types::PyModule::new(py, "_lib").unwrap();
+        crate::_lib(&module.as_borrowed()).unwrap();
+        let settings = pyo3::Py::new(py, default_settings()).unwrap();
+
+        let error = module
+            .getattr("format_toml")
+            .unwrap()
+            .call1(("[project]\nversion=\"1.9.xyz\"\n", settings))
+            .unwrap_err();
+
+        assert!(error.is_instance_of::<pyo3::exceptions::PyValueError>(py));
+        assert_snapshot!(error.value(py).to_string(), @"project.version `1.9.xyz` is not a valid PEP 440 version");
+    });
+}

--- a/pyproject-fmt/rust/src/tests/mypy_tests.rs
+++ b/pyproject-fmt/rust/src/tests/mypy_tests.rs
@@ -38,7 +38,7 @@ fn default_settings() -> Settings {
 }
 
 fn evaluate_full(start: &str) -> String {
-    let r = format_toml(start, &default_settings());
+    let r = format_toml(start, &default_settings()).unwrap();
     assert_valid_toml(&r);
     r
 }
@@ -340,7 +340,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let r = format_toml(start, &long_settings());
+    let r = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&r);
     r
 }

--- a/pyproject-fmt/rust/src/tests/pdm_tests.rs
+++ b/pyproject-fmt/rust/src/tests/pdm_tests.rs
@@ -137,7 +137,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_settings());
+    let result = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/rust/src/tests/poetry_tests.rs
+++ b/pyproject-fmt/rust/src/tests/poetry_tests.rs
@@ -40,7 +40,7 @@ fn default_poetry_settings() -> Settings {
 }
 
 fn evaluate_full(start: &str) -> String {
-    let result = format_toml(start, &default_poetry_settings());
+    let result = format_toml(start, &default_poetry_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }
@@ -53,7 +53,7 @@ fn long_format_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_format_settings());
+    let result = format_toml(start, &long_format_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -14,6 +14,25 @@ fn evaluate_project(
     max_supported_python: (u8, u8),
     generate_python_version_classifiers: bool,
 ) -> String {
+    run_project_fix(
+        start,
+        keep_full_version,
+        max_supported_python,
+        generate_python_version_classifiers,
+    )
+    .unwrap()
+}
+
+fn evaluate_project_error(start: &str) -> String {
+    run_project_fix(start, false, (3, 12), false).unwrap_err()
+}
+
+fn run_project_fix(
+    start: &str,
+    keep_full_version: bool,
+    max_supported_python: (u8, u8),
+    generate_python_version_classifiers: bool,
+) -> Result<String, String> {
     let root_ast = parse(start);
     let count = root_ast.children_with_tokens().count();
     let mut tables = Tables::from_ast(&root_ast);
@@ -35,14 +54,14 @@ fn evaluate_project(
         (3, 9),
         generate_python_version_classifiers,
         &table_config,
-    );
+    )?;
 
     let entries = collect_entries(&tables);
     root_ast.splice_children(0..count, entries);
     ensure_all_arrays_multiline(&root_ast, 120);
     let result = format_syntax(root_ast, 120);
     assert_valid_toml(&result);
-    result
+    Ok(result)
 }
 
 #[test]
@@ -1032,7 +1051,7 @@ fn test_project_with_table_format_expand() {
         &["project"],
         120,
     );
-    fix(&mut tables, false, (3, 12), (3, 9), true, &table_config);
+    fix(&mut tables, false, (3, 12), (3, 9), true, &table_config).unwrap();
     let intermediate = root_ast.to_string();
     let result = format_toml_str(&intermediate, 120);
     insta::assert_snapshot!(result, @r#"
@@ -1071,7 +1090,7 @@ fn test_project_with_collapse_specific_table() {
         &["project"],
         120,
     );
-    fix(&mut tables, false, (3, 11), (3, 9), true, &table_config);
+    fix(&mut tables, false, (3, 11), (3, 9), true, &table_config).unwrap();
     let intermediate = root_ast.to_string();
     let result = format_toml_str(&intermediate, 120);
     insta::assert_snapshot!(result, @r#"
@@ -1107,7 +1126,7 @@ fn test_project_with_expand_specific_table() {
         &["project"],
         120,
     );
-    fix(&mut tables, false, (3, 11), (3, 9), true, &table_config);
+    fix(&mut tables, false, (3, 11), (3, 9), true, &table_config).unwrap();
     let intermediate = root_ast.to_string();
     let result = format_toml_str(&intermediate, 120);
     insta::assert_snapshot!(result, @r#"
@@ -1854,6 +1873,42 @@ fn test_project_version_field() {
 }
 
 #[test]
+fn test_project_version_normalization() {
+    let start = indoc! {r#"
+        [project]
+        version = "V1.0-Alpha.2-1.DEV+Ubuntu_01"
+    "#};
+    let result = evaluate_project(start, false, (3, 12), false);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    version = "1.0a2.post1.dev0+ubuntu.1"
+    "#);
+}
+
+#[test]
+fn test_project_version_invalid() {
+    let start = indoc! {r#"
+        [project]
+        version = "1.9.xyz"
+    "#};
+    let error = evaluate_project_error(start);
+    insta::assert_snapshot!(error, @"project.version `1.9.xyz` is not a valid PEP 440 version");
+}
+
+#[test]
+fn test_project_version_not_a_string() {
+    let start = indoc! {r#"
+        [project]
+        version = 19
+    "#};
+    let result = evaluate_project(start, false, (3, 12), false);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    version = 19
+    "#);
+}
+
+#[test]
 fn test_project_dependencies_empty_markers() {
     let start = indoc! {r#"
         [project]
@@ -2078,7 +2133,7 @@ fn test_project_expand_authors_to_array_of_tables() {
         &["project"],
         120,
     );
-    fix(&mut tables, false, (3, 12), (3, 9), false, &table_config);
+    fix(&mut tables, false, (3, 12), (3, 9), false, &table_config).unwrap();
     let intermediate = root_ast.to_string();
     let result = format_toml_str(&intermediate, 120);
     insta::assert_snapshot!(result, @r#"
@@ -2110,7 +2165,7 @@ fn test_project_expand_maintainers_to_array_of_tables() {
         &["project"],
         120,
     );
-    fix(&mut tables, false, (3, 12), (3, 9), false, &table_config);
+    fix(&mut tables, false, (3, 12), (3, 9), false, &table_config).unwrap();
     let intermediate = root_ast.to_string();
     let result = format_toml_str(&intermediate, 120);
     insta::assert_snapshot!(result, @r#"

--- a/pyproject-fmt/rust/src/tests/pyrefly_tests.rs
+++ b/pyproject-fmt/rust/src/tests/pyrefly_tests.rs
@@ -44,7 +44,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_settings());
+    let result = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/rust/src/tests/scikit_build_tests.rs
+++ b/pyproject-fmt/rust/src/tests/scikit_build_tests.rs
@@ -44,7 +44,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_settings());
+    let result = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/rust/src/tests/setuptools_tests.rs
+++ b/pyproject-fmt/rust/src/tests/setuptools_tests.rs
@@ -38,7 +38,7 @@ fn default_settings() -> Settings {
 }
 
 fn evaluate_full(start: &str) -> String {
-    let r = format_toml(start, &default_settings());
+    let r = format_toml(start, &default_settings()).unwrap();
     assert_valid_toml(&r);
     r
 }
@@ -308,7 +308,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let r = format_toml(start, &long_settings());
+    let r = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&r);
     r
 }

--- a/pyproject-fmt/rust/src/tests/towncrier_tests.rs
+++ b/pyproject-fmt/rust/src/tests/towncrier_tests.rs
@@ -44,7 +44,7 @@ fn long_settings() -> Settings {
 }
 
 fn evaluate_long(start: &str) -> String {
-    let result = format_toml(start, &long_settings());
+    let result = format_toml(start, &long_settings()).unwrap();
     assert_valid_toml(&result);
     result
 }

--- a/pyproject-fmt/tests/test_main.py
+++ b/pyproject-fmt/tests/test_main.py
@@ -444,3 +444,36 @@ def test_pyproject_fmt_self_config_normalized(tmp_path: Path) -> None:
     skip_wrap_for_keys = [ "a.parse", "z.parse" ]
     """
     assert filename.read_text() == dedent(expected)
+
+
+def test_invalid_project_version(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    txt = """\
+    [project]
+    version = "1.9.xyz"
+    """
+    filename = tmp_path / "pyproject.toml"
+    filename.write_text(dedent(txt))
+
+    assert run([str(filename)]) == 1
+
+    assert filename.read_text() == dedent(txt)
+    out, err = capsys.readouterr()
+    assert not out
+    assert err == f"{filename}: project.version `1.9.xyz` is not a valid PEP 440 version\n"
+
+
+def test_project_version_normalized(tmp_path: Path) -> None:
+    txt = """\
+    [project]
+    version = "V1.0-Alpha.2"
+    """
+    filename = tmp_path / "pyproject.toml"
+    filename.write_text(dedent(txt))
+
+    assert run([str(filename), "--no-print-diff", "--no-generate-python-version-classifiers"]) == 1
+
+    expected = """\
+    [project]
+    version = "1.0a2"
+    """
+    assert filename.read_text() == dedent(expected)

--- a/toml-fmt-common/src/toml_fmt_common/__init__.py
+++ b/toml-fmt-common/src/toml_fmt_common/__init__.py
@@ -118,7 +118,7 @@ def run(info: TOMLFormatter[T], args: Sequence[str] | None = None) -> int:
     """
     configs = _cli_args(info, sys.argv[1:] if args is None else args)
     results = [_handle_one(info, config) for config in configs]
-    return 1 if any(results) else 0  # exit with non success on change
+    return 1 if any(results) else 0  # exit with non success on change or rejection
 
 
 @dataclass(frozen=True)
@@ -356,8 +356,21 @@ def _toml_path_creator(filename: str, argument: str) -> Path | None:
     return path
 
 
+def _display_name(path: Path | None) -> str:
+    if path is None:
+        return "<stdin>"
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
 def _handle_one(info: TOMLFormatter[T], config: _Config[T]) -> bool:
-    formatted = info.format(config.toml, config.opt)
+    try:
+        formatted = info.format(config.toml, config.opt)
+    except ValueError as exc:  # the formatter rejected the content, e.g. an invalid project.version
+        print(f"{_display_name(config.toml_filename)}: {exc}", file=sys.stderr)  # noqa: T201
+        return True
     before = config.toml
     changed = before != formatted
     if config.toml_filename is None or config.stdout:  # when reading from stdin or writing to stdout, print new format
@@ -368,10 +381,7 @@ def _handle_one(info: TOMLFormatter[T], config: _Config[T]) -> bool:
         config.toml_filename.write_text(formatted, encoding="utf-8", newline="\n")
     if config.no_print_diff:
         return changed
-    try:
-        name = str(config.toml_filename.relative_to(Path.cwd()))
-    except ValueError:
-        name = str(config.toml_filename)
+    name = _display_name(config.toml_filename)
     diff: Iterable[str] = []
     if changed:
         diff = difflib.unified_diff(before.splitlines(), formatted.splitlines(), fromfile=name, tofile=name)

--- a/toml-fmt-common/src/toml_fmt_common/__init__.py
+++ b/toml-fmt-common/src/toml_fmt_common/__init__.py
@@ -369,7 +369,7 @@ def _handle_one(info: TOMLFormatter[T], config: _Config[T]) -> bool:
     try:
         formatted = info.format(config.toml, config.opt)
     except ValueError as exc:  # the formatter rejected the content, e.g. an invalid project.version
-        print(f"{_display_name(config.toml_filename)}: {exc}", file=sys.stderr)  # noqa: T201
+        print(f"{_display_name(config.toml_filename)}: {exc}", file=sys.stderr)  # ruff: ignore[print]
         return True
     before = config.toml
     changed = before != formatted

--- a/toml-fmt-common/tests/test_app.py
+++ b/toml-fmt-common/tests/test_app.py
@@ -520,3 +520,34 @@ def test_legacy_consumer_reregistering_flags_does_not_crash(tmp_path: Path) -> N
     dumb.write_text("")
     # Must not raise argparse.ArgumentError on the duplicate --table-format/--expand-tables.
     assert run(LegacyDumb(), ["E", str(dumb), "--table-format", "long"]) == 1
+
+
+def test_format_rejection_reported(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "dumb.toml").write_text("ok = 1")
+    mocker.patch.object(Dumb, "format", side_effect=ValueError("bad version"))
+
+    assert run(Dumb(), ["E", "dumb.toml"]) == 1
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert err == "dumb.toml: bad version\n"
+
+
+def test_format_rejection_reported_for_stdin(
+    capsys: pytest.CaptureFixture[str],
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("sys.stdin", StringIO("ok = 1"))
+    mocker.patch.object(Dumb, "format", side_effect=ValueError("bad version"))
+
+    assert run(Dumb(), ["E", "-"]) == 1
+
+    out, err = capsys.readouterr()
+    assert not out
+    assert err == "<stdin>: bad version\n"


### PR DESCRIPTION
`pyproject-fmt` left `project.version` untouched, so a string PEP 440 does not accept printed `no change for pyproject.toml` and looked valid, as reported in [#425](https://github.com/tox-dev/toml-fmt/issues/425). `pyproject-fmt` already normalizes most other `[project]` fields.

`project.version` now normalizes to the canonical form. 🔍 `V1.0-Alpha.2` becomes `1.0a2`, with the `v` prefix and a zero epoch dropped, release leading zeros stripped, pre/post/dev labels and their implicit numbers spelled out, and local segments lowercased and dot-separated. For a value that does not parse, `pyproject-fmt` reports it on stderr, exits non-zero, and leaves the file as it was. `Version::new` stays lenient, since dependency specifiers have to salvage whatever a user writes; the strict `Version::parse` next to it follows the regex from the [PEP 440 appendix](https://peps.python.org/pep-0440/#appendix-parsing-version-strings-with-regular-expressions) and returns `None` instead of guessing.

Rejecting input needs an error channel the formatter lacked. `format_toml` returns a `Result`, pyo3 maps the failure to `ValueError`, and `toml_fmt_common` prints it with the file name in front. Reviewers may want to weigh the compatibility cost. A project whose version used to pass in silence now fails the run, which shows up in CI for anyone formatting with `--check`.
