### PR TITLE
🐛 fix(pyproject-fmt): stop normalizing project.version

### DIFF
--- a/common/src/pep508/version_op.rs
+++ b/common/src/pep508/version_op.rs
@@ -1,6 +1,6 @@
 pub(crate) use crate::pep508::version_op::operator::Operator;
 pub(crate) use crate::pep508::version_op::version::Version;
-pub use crate::pep508::version_op::version::normalize_version;
+pub use crate::pep508::version_op::version::is_valid_version;
 
 mod operator;
 mod version;

--- a/common/src/pep508/version_op/version.rs
+++ b/common/src/pep508/version_op/version.rs
@@ -1,10 +1,10 @@
 use std::sync::LazyLock;
 
-use regex::{Captures, Regex};
+use regex::Regex;
 
-/// Canonical [PEP 440](https://peps.python.org/pep-0440/) form of `raw`, or `None` when `raw` is not a valid version.
-pub fn normalize_version(raw: &str) -> Option<String> {
-    Version::parse(raw).map(|version| version.to_string())
+/// Whether `raw` is a valid [PEP 440](https://peps.python.org/pep-0440/) version.
+pub fn is_valid_version(raw: &str) -> bool {
+    PEP440.is_match(raw.trim())
 }
 
 static PEP440: LazyLock<Regex> = LazyLock::new(|| {
@@ -23,30 +23,6 @@ static PEP440: LazyLock<Regex> = LazyLock::new(|| {
     .unwrap()
 });
 
-/// Outer `None` rejects the whole version when the captured digits overflow, inner `None` means the group was absent.
-fn optional_number(caps: &Captures, name: &str) -> Option<Option<u64>> {
-    caps.name(name)
-        .map_or(Some(None), |number| number.as_str().parse().ok().map(Some))
-}
-
-fn normalize_local(raw: &str) -> String {
-    let lowered = raw.to_ascii_lowercase();
-    lowered
-        .split(['-', '_', '.'])
-        .map(|part| {
-            if part.chars().all(|c| c.is_ascii_digit()) {
-                match part.trim_start_matches('0') {
-                    "" => "0",
-                    trimmed => trimmed,
-                }
-            } else {
-                part
-            }
-        })
-        .collect::<Vec<&str>>()
-        .join(".")
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Version {
     pub epoch: Option<u64>,
@@ -59,42 +35,6 @@ pub struct Version {
 }
 
 impl Version {
-    /// Strict counterpart of [`Version::new`]: rejects what PEP 440 does not accept instead of salvaging it.
-    pub fn parse(raw: &str) -> Option<Self> {
-        let caps = PEP440.captures(raw.trim())?;
-        let release = caps["release"]
-            .split('.')
-            .map(str::parse::<u64>)
-            .collect::<Result<Vec<u64>, _>>()
-            .ok()?;
-        let pre = match caps.name("pre_l") {
-            Some(label) => Some((label.as_str().to_ascii_lowercase(), optional_number(&caps, "pre_n")?)),
-            None => None,
-        };
-        let post = if let Some(implicit) = caps.name("post_n1") {
-            Some((Some("post".to_string()), Some(implicit.as_str().parse().ok()?)))
-        } else if caps.name("post_l").is_some() {
-            Some((Some("post".to_string()), optional_number(&caps, "post_n2")?))
-        } else {
-            None
-        };
-        let dev = if caps.name("dev").is_some() {
-            Some(("dev".to_string(), optional_number(&caps, "dev_n")?))
-        } else {
-            None
-        };
-        Some(Self {
-            // A zero epoch is dropped in the canonical form.
-            epoch: optional_number(&caps, "epoch")?.filter(|epoch| *epoch != 0),
-            release,
-            pre,
-            post,
-            dev,
-            local: caps.name("local").map(|local| normalize_local(local.as_str())),
-            has_wildcard: false,
-        })
-    }
-
     pub fn new(raw: &str) -> Self {
         let mut input = raw.trim();
         let mut has_wildcard = false;

--- a/common/src/tests/pep508_tests.rs
+++ b/common/src/tests/pep508_tests.rs
@@ -1,4 +1,4 @@
-use crate::pep508::{MarkerExpr, Requirement, normalize_version};
+use crate::pep508::{MarkerExpr, Requirement, is_valid_version};
 
 fn format_requirement_helper(start: &str, keep_full_version: bool) -> String {
     Requirement::new(start)
@@ -481,121 +481,67 @@ fn test_is_name_only_private() {
     assert!(!Requirement::new("wheel; private").unwrap().is_name_only());
 }
 
-fn normalize_version_helper(raw: &str) -> String {
-    normalize_version(raw).unwrap()
+#[test]
+fn test_is_valid_version_plain_release() {
+    assert!(is_valid_version("1.9.0"));
 }
 
 #[test]
-fn test_normalize_version_already_canonical() {
-    insta::assert_snapshot!(normalize_version_helper("1.9.0"), @"1.9.0");
+fn test_is_valid_version_calver_leading_zeros() {
+    assert!(is_valid_version("2026.08.10"));
 }
 
 #[test]
-fn test_normalize_version_strips_surrounding_whitespace() {
-    insta::assert_snapshot!(normalize_version_helper(" 1.9.0 "), @"1.9.0");
+fn test_is_valid_version_surrounding_whitespace() {
+    assert!(is_valid_version(" 1.9.0 "));
 }
 
 #[test]
-fn test_normalize_version_strips_v_prefix() {
-    insta::assert_snapshot!(normalize_version_helper("v1.9"), @"1.9");
+fn test_is_valid_version_v_prefix() {
+    assert!(is_valid_version("v1.9"));
 }
 
 #[test]
-fn test_normalize_version_strips_release_leading_zeros() {
-    insta::assert_snapshot!(normalize_version_helper("1.09.007"), @"1.9.7");
+fn test_is_valid_version_epoch() {
+    assert!(is_valid_version("2!1.0"));
 }
 
 #[test]
-fn test_normalize_version_drops_zero_epoch() {
-    insta::assert_snapshot!(normalize_version_helper("0!1.0"), @"1.0");
+fn test_is_valid_version_pre_release_spelling() {
+    assert!(is_valid_version("1.0-ALPHA.1"));
 }
 
 #[test]
-fn test_normalize_version_keeps_non_zero_epoch() {
-    insta::assert_snapshot!(normalize_version_helper("2!1.0"), @"2!1.0");
+fn test_is_valid_version_implicit_post_release() {
+    assert!(is_valid_version("1.0-1"));
 }
 
 #[test]
-fn test_normalize_version_pre_release_spelling() {
-    insta::assert_snapshot!(normalize_version_helper("1.0-ALPHA.1"), @"1.0a1");
+fn test_is_valid_version_all_segments() {
+    assert!(is_valid_version("v1.0.c1.post.dev+Ubuntu_007-x"));
 }
 
 #[test]
-fn test_normalize_version_pre_release_implicit_number() {
-    insta::assert_snapshot!(normalize_version_helper("1.0preview"), @"1.0rc0");
+fn test_is_valid_version_large_numbers() {
+    assert!(is_valid_version("99999999999999999999.0"));
 }
 
 #[test]
-fn test_normalize_version_implicit_post_release() {
-    insta::assert_snapshot!(normalize_version_helper("1.0-1"), @"1.0.post1");
+fn test_is_valid_version_rejects_non_numeric_release() {
+    assert!(!is_valid_version("1.9.xyz"));
 }
 
 #[test]
-fn test_normalize_version_post_release_alias() {
-    insta::assert_snapshot!(normalize_version_helper("1.0_rev_3"), @"1.0.post3");
+fn test_is_valid_version_rejects_empty() {
+    assert!(!is_valid_version(""));
 }
 
 #[test]
-fn test_normalize_version_dev_release_implicit_number() {
-    insta::assert_snapshot!(normalize_version_helper("1.0dev"), @"1.0.dev0");
+fn test_is_valid_version_rejects_trailing_separator() {
+    assert!(!is_valid_version("1.0.0-"));
 }
 
 #[test]
-fn test_normalize_version_local_segment() {
-    insta::assert_snapshot!(normalize_version_helper("1.0+Ubuntu_007-x"), @"1.0+ubuntu.7.x");
-}
-
-#[test]
-fn test_normalize_version_local_zero_segment() {
-    insta::assert_snapshot!(normalize_version_helper("1.0+000"), @"1.0+0");
-}
-
-#[test]
-fn test_normalize_version_all_segments() {
-    insta::assert_snapshot!(normalize_version_helper("v1.0.c1.post.dev+A"), @"1.0rc1.post0.dev0+a");
-}
-
-#[test]
-fn test_normalize_version_rejects_non_numeric_release() {
-    assert!(normalize_version("1.9.xyz").is_none());
-}
-
-#[test]
-fn test_normalize_version_rejects_empty() {
-    assert!(normalize_version("").is_none());
-}
-
-#[test]
-fn test_normalize_version_rejects_trailing_separator() {
-    assert!(normalize_version("1.0.0-").is_none());
-}
-
-#[test]
-fn test_normalize_version_rejects_release_overflow() {
-    assert!(normalize_version("99999999999999999999.0").is_none());
-}
-
-#[test]
-fn test_normalize_version_rejects_pre_release_number_overflow() {
-    assert!(normalize_version("1.0a99999999999999999999").is_none());
-}
-
-#[test]
-fn test_normalize_version_rejects_epoch_overflow() {
-    assert!(normalize_version("99999999999999999999!1.0").is_none());
-}
-
-#[test]
-fn test_normalize_version_rejects_implicit_post_release_overflow() {
-    assert!(normalize_version("1.0-99999999999999999999").is_none());
-}
-
-#[test]
-fn test_normalize_version_rejects_post_release_number_overflow() {
-    assert!(normalize_version("1.0.post99999999999999999999").is_none());
-}
-
-#[test]
-fn test_normalize_version_rejects_dev_release_number_overflow() {
-    assert!(normalize_version("1.0.dev99999999999999999999").is_none());
+fn test_is_valid_version_rejects_wildcard() {
+    assert!(!is_valid_version("1.0.*"));
 }

--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -689,8 +689,8 @@ directly), or when ``setuptools`` itself is missing from ``requires``.
 The :pep:`621` core metadata table. See the
 `packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-project-table>`_.
 
-Keys follow the canonical metadata order; name, version, dependencies, classifiers, and keywords are normalized and
-sorted.
+Keys follow the canonical metadata order; name, dependencies, classifiers, and keywords are normalized and sorted;
+version is validated.
 
 
 **Key ordering:** ``name`` → ``version`` → ``import-names`` → ``import-namespaces`` → ``description`` →
@@ -704,9 +704,9 @@ sorted.
     Converted to canonical format (lowercase with hyphens): ``My_Package`` → ``my-package``
 
 ``version``
-    Converted to the canonical :pep:`440` form: ``V1.0-Alpha.2`` → ``1.0a2``. A value that is not a valid
-    :pep:`440` version is rejected: the formatter reports it on standard error, leaves the file untouched, and
-    exits with a non-zero status.
+    Kept verbatim, because it is the exact version published in the package metadata — normalizing would rewrite
+    e.g. CalVer ``2026.08.10`` to ``2026.8.10``. A value that is not a valid :pep:`440` version is rejected: the
+    formatter reports it on standard error, leaves the file untouched, and exits with a non-zero status.
 
 ``description``
     Whitespace normalized: multiple spaces collapsed, consistent spacing after periods.

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -290,8 +290,8 @@ redundant ``wheel`` requirement is removed when the build backend is setuptools.
 The :pep:`621` core metadata table. See the
 `packaging specification <https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-project-table>`_.
 
-Keys follow the canonical metadata order; name, version, dependencies, classifiers, and keywords are normalized and
-sorted.
+Keys follow the canonical metadata order; name, dependencies, classifiers, and keywords are normalized and sorted;
+version is validated.
 
 .. dropdown:: Formatting details
 
@@ -306,9 +306,9 @@ sorted.
         Converted to canonical format (lowercase with hyphens): ``My_Package`` → ``my-package``
 
     ``version``
-        Converted to the canonical :pep:`440` form: ``V1.0-Alpha.2`` → ``1.0a2``. A value that is not a valid
-        :pep:`440` version is rejected: the formatter reports it on standard error, leaves the file untouched, and
-        exits with a non-zero status.
+        Kept verbatim, because it is the exact version published in the package metadata — normalizing would rewrite
+        e.g. CalVer ``2026.08.10`` to ``2026.8.10``. A value that is not a valid :pep:`440` version is rejected: the
+        formatter reports it on standard error, leaves the file untouched, and exits with a non-zero status.
 
     ``description``
         Whitespace normalized: multiple spaces collapsed, consistent spacing after periods.

--- a/pyproject-fmt/rust/src/project.rs
+++ b/pyproject-fmt/rust/src/project.rs
@@ -16,7 +16,7 @@ use common::create::{
     make_array, make_array_entry, make_comma, make_entry_of_string, make_key, make_newline,
     make_table_array_with_entries, make_whitespace_n,
 };
-use common::pep508::{normalize_version, Requirement};
+use common::pep508::{is_valid_version, Requirement};
 use common::string::{get_string_token, get_string_value, load_text, update_content};
 use common::table::{for_entries, reorder_table_keys, Tables};
 
@@ -81,9 +81,8 @@ pub fn fix(
         }
         "version" => {
             if let Some(raw) = get_string_value(entry) {
-                match normalize_version(&raw) {
-                    Some(canonical) => update_content(entry, |_| canonical.clone()),
-                    None => invalid_version = Some(raw),
+                if !is_valid_version(&raw) {
+                    invalid_version = Some(raw);
                 }
             }
         }

--- a/pyproject-fmt/rust/src/tests/project_tests.rs
+++ b/pyproject-fmt/rust/src/tests/project_tests.rs
@@ -1873,7 +1873,20 @@ fn test_project_version_field() {
 }
 
 #[test]
-fn test_project_version_normalization() {
+fn test_project_version_calver_kept_verbatim() {
+    let start = indoc! {r#"
+        [project]
+        version = "2026.08.10"
+    "#};
+    let result = evaluate_project(start, false, (3, 12), false);
+    insta::assert_snapshot!(result, @r#"
+    [project]
+    version = "2026.08.10"
+    "#);
+}
+
+#[test]
+fn test_project_version_non_canonical_kept_verbatim() {
     let start = indoc! {r#"
         [project]
         version = "V1.0-Alpha.2-1.DEV+Ubuntu_01"
@@ -1881,7 +1894,7 @@ fn test_project_version_normalization() {
     let result = evaluate_project(start, false, (3, 12), false);
     insta::assert_snapshot!(result, @r#"
     [project]
-    version = "1.0a2.post1.dev0+ubuntu.1"
+    version = "V1.0-Alpha.2-1.DEV+Ubuntu_01"
     "#);
 }
 

--- a/pyproject-fmt/tests/test_main.py
+++ b/pyproject-fmt/tests/test_main.py
@@ -462,18 +462,14 @@ def test_invalid_project_version(tmp_path: Path, capsys: pytest.CaptureFixture[s
     assert err == f"{filename}: project.version `1.9.xyz` is not a valid PEP 440 version\n"
 
 
-def test_project_version_normalized(tmp_path: Path) -> None:
+def test_project_version_kept_verbatim(tmp_path: Path) -> None:
     txt = """\
     [project]
-    version = "V1.0-Alpha.2"
+    version = "2026.08.10"
     """
     filename = tmp_path / "pyproject.toml"
     filename.write_text(dedent(txt))
 
-    assert run([str(filename), "--no-print-diff", "--no-generate-python-version-classifiers"]) == 1
+    assert run([str(filename), "--no-print-diff", "--no-generate-python-version-classifiers"]) == 0
 
-    expected = """\
-    [project]
-    version = "1.0a2"
-    """
-    assert filename.read_text() == dedent(expected)
+    assert filename.read_text() == dedent(txt)


### PR DESCRIPTION
Since 2.27.0 the formatter rewrites `project.version` to its canonical PEP 440 form, turning CalVer `2026.08.10` into `2026.8.10`. The stored value is the exact version published in the package metadata and on PyPI, so the rewrite changes what users release (#430). Per the [agreement in the issue](https://github.com/tox-dev/toml-fmt/issues/430#issuecomment-5268401773), this keeps the validation added in #428 (requested in #425) and drops the normalization: an invalid version still aborts the run with the offending value on standard error, while any valid value passes through verbatim.

Validity is a match of the PEP 440 pattern, so the strict `Version::parse` from #428 collapses into a regex test. The numeric overflow rejections went with it: they existed only to fit segments into `u64` for producing canonical output, and arbitrarily large numbers are valid versions.

Fixes #430.
