### PR TITLE
👷 ci: use setup-rust-toolchain for the readme job

### DIFF
--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -137,11 +137,7 @@ jobs:
         if: matrix.py != '3.14'
         run: uv python install --python-preference only-managed ${{ matrix.py }}
       - name: 🦀 Setup Rust
-        uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1
-        with:
-          cache-base: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       - name: 📝 Generate README.rst
         run: tox run -e readme
         working-directory: pyproject-fmt

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -137,11 +137,7 @@ jobs:
         if: matrix.py != '3.14'
         run: uv python install --python-preference only-managed ${{ matrix.py }}
       - name: 🦀 Setup Rust
-        uses: moonrepo/setup-rust@abb2d32350334249b178c401e5ec5836e0cd88d3 # v1
-        with:
-          cache-base: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
       - name: 📝 Generate README.rst
         run: tox run -e readme
         working-directory: tox-toml-fmt


### PR DESCRIPTION
The `readme` job was the only one still on `moonrepo/setup-rust`, which downloads `cargo-binstall` from GitHub releases on every run and failed with `socket hang up` and `503` in https://github.com/tox-dev/toml-fmt/actions/runs/31639713410 and https://github.com/tox-dev/toml-fmt/actions/runs/31639713493. The job only needs a stable toolchain for `cargo run`, so both `pyproject_fmt_test.yaml` and `tox_toml_fmt_test.yaml` now use the same SHA-pinned `actions-rust-lang/setup-rust-toolchain` step as every other job, dropping the extra download and the `GITHUB_TOKEN` it needed.
