### PR TITLE
🐛 fix(pyproject-fmt): order collapsed cibuildwheel overrides

### DIFF
--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -1239,9 +1239,9 @@ Keys are ordered selection → build config → build phases → test phases →
 (``manylinux-*-image``, ``musllinux-*-image``) → ``container-engine`` → per-platform sub-tables (``linux``,
 ``macos``, ``windows``, ``android``, ``ios``, ``pyodide``) → ``overrides`` last.
 
-Per-platform sub-tables follow the same inner ordering. ``[[tool.cibuildwheel.overrides]]`` entries place
-``select`` first (required), then the regular cibuildwheel keys; the array order itself is preserved (later
-overrides win).
+Per-platform sub-tables follow the same inner ordering. ``overrides`` entries, whether written as
+``[[tool.cibuildwheel.overrides]]`` or as inline tables in ``overrides = [...]``, place ``select`` first
+(required), then the regular cibuildwheel keys; the array order itself is preserved (later overrides win).
 
 **Sorted arrays:** ``enable``, ``test-extras``, ``test-groups``.
 

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -793,9 +793,9 @@ Keys are ordered selection → build config → build phases → test phases →
     (``manylinux-*-image``, ``musllinux-*-image``) → ``container-engine`` → per-platform sub-tables (``linux``,
     ``macos``, ``windows``, ``android``, ``ios``, ``pyodide``) → ``overrides`` last.
 
-    Per-platform sub-tables follow the same inner ordering. ``[[tool.cibuildwheel.overrides]]`` entries place
-    ``select`` first (required), then the regular cibuildwheel keys; the array order itself is preserved (later
-    overrides win).
+    Per-platform sub-tables follow the same inner ordering. ``overrides`` entries, whether written as
+    ``[[tool.cibuildwheel.overrides]]`` or as inline tables in ``overrides = [...]``, place ``select`` first
+    (required), then the regular cibuildwheel keys; the array order itself is preserved (later overrides win).
 
     **Sorted arrays:** ``enable``, ``test-extras``, ``test-groups``.
 

--- a/pyproject-fmt/rust/src/cibuildwheel.rs
+++ b/pyproject-fmt/rust/src/cibuildwheel.rs
@@ -1,6 +1,10 @@
+use std::sync::LazyLock;
+
 use common::array::sort_strings;
-use common::table::{for_entries, reorder_table_keys, Tables};
+use common::table::{for_entries, reorder_inline_table_keys, reorder_table_keys, InlineTableSchema, Tables};
 use lexical_sort::natural_lexical_cmp;
+use tombi_syntax::SyntaxKind::{ARRAY, INLINE_TABLE, KEYS, KEY_VALUE};
+use tombi_syntax::SyntaxNode;
 
 const KEY_ORDER: &[&str] = &[
     "",
@@ -53,6 +57,13 @@ const KEY_ORDER: &[&str] = &[
 // Most arrays are CLI argv (order matters); only these are set semantics.
 const SORT_ARRAYS: &[&str] = &["enable", "test-extras", "test-groups"];
 
+// `select` leads because cibuildwheel requires it on every override entry.
+static OVERRIDES_KEY_ORDER: LazyLock<Vec<&str>> = LazyLock::new(|| {
+    let mut order = vec!["", "select"];
+    order.extend(KEY_ORDER.iter().filter(|k| !k.is_empty() && **k != "overrides"));
+    order
+});
+
 pub fn fix(tables: &mut Tables) {
     fix_one(tables, "tool.cibuildwheel");
     // Per-platform tables reuse KEY_ORDER for when they stay expanded instead of collapsing into the parent.
@@ -69,10 +80,41 @@ fn fix_one(tables: &mut Tables, table_name: &str) {
     let table = &mut elements.first().unwrap().borrow_mut();
     for_entries(table, &mut |key, entry| {
         if SORT_ARRAYS.contains(&key.as_str()) {
-            sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+            sort_array(entry);
+        } else if key == "overrides" && entry.kind() == ARRAY {
+            fix_overrides_inline(entry);
         }
     });
     reorder_table_keys(table, KEY_ORDER);
+}
+
+fn sort_array(entry: &SyntaxNode) {
+    sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+}
+
+/// `[[tool.cibuildwheel.overrides]]` collapses to `overrides = [{ ... }]` before `fix` runs in the short table format,
+/// so the inline entries need the same treatment as the array-of-tables form.
+fn fix_overrides_inline(array: &SyntaxNode) {
+    for inline in array.descendants().filter(|n| n.kind() == INLINE_TABLE) {
+        for kv in inline.descendants().filter(|n| n.kind() == KEY_VALUE) {
+            let Some(keys) = kv.children().find(|c| c.kind() == KEYS) else {
+                continue;
+            };
+            if !SORT_ARRAYS.contains(&keys.text().to_string().trim()) {
+                continue;
+            }
+            if let Some(inner) = kv.children().find(|c| c.kind() == ARRAY) {
+                sort_array(&inner);
+            }
+        }
+    }
+    reorder_inline_table_keys(
+        array,
+        &[InlineTableSchema {
+            discriminator: "select",
+            key_order: &OVERRIDES_KEY_ORDER,
+        }],
+    );
 }
 
 fn fix_overrides_aot(tables: &mut Tables) {
@@ -83,12 +125,9 @@ fn fix_overrides_aot(tables: &mut Tables) {
         let table = &mut entry_ref.borrow_mut();
         for_entries(table, &mut |key, entry| {
             if SORT_ARRAYS.contains(&key.as_str()) {
-                sort_strings::<String, _, _>(entry, |s| s.to_lowercase(), &|lhs, rhs| natural_lexical_cmp(lhs, rhs));
+                sort_array(entry);
             }
         });
-        // `select` leads because cibuildwheel requires it on every override entry.
-        let mut order: Vec<&str> = vec!["", "select"];
-        order.extend(KEY_ORDER.iter().filter(|k| !k.is_empty() && **k != "overrides"));
-        reorder_table_keys(table, &order);
+        reorder_table_keys(table, &OVERRIDES_KEY_ORDER);
     }
 }

--- a/pyproject-fmt/rust/src/tests/cibuildwheel_tests.rs
+++ b/pyproject-fmt/rust/src/tests/cibuildwheel_tests.rs
@@ -125,7 +125,39 @@ fn test_cibw_overrides_aot_select_first() {
     let result = evaluate(start);
     insta::assert_snapshot!(result, @r#"
     [tool.cibuildwheel]
-    overrides = [ { test-command = "pytest {project}/tests/cpython", select = "cp3{10,11}-*" } ]
+    overrides = [ { select = "cp3{10,11}-*", test-command = "pytest {project}/tests/cpython" } ]
+    "#);
+}
+
+#[test]
+fn test_cibw_overrides_inline_select_first() {
+    let start = indoc::indoc! {r#"
+    [tool.cibuildwheel]
+    overrides = [
+      { test-extras = ["z", "a"], test-command = "pytest", select = "cp310-*" },
+      { before-all = "make", select = "cp311-*" },
+    ]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.cibuildwheel]
+    overrides = [
+      { select = "cp310-*", test-command = "pytest", test-extras = [ "a", "z" ] },
+      { select = "cp311-*", before-all = "make" },
+    ]
+    "#);
+}
+
+#[test]
+fn test_cibw_overrides_inline_without_select_untouched() {
+    let start = indoc::indoc! {r#"
+    [tool.cibuildwheel]
+    overrides = [ { test-command = "pytest", before-all = "make" } ]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.cibuildwheel]
+    overrides = [ { test-command = "pytest", before-all = "make" } ]
     "#);
 }
 


### PR DESCRIPTION
`fix_overrides_aot` only handled `[[tool.cibuildwheel.overrides]]` tables, but with the default short table format the array of tables has already collapsed to `overrides = [{ ... }]` by the time `cibuildwheel::fix` runs, so `select` was never moved first and the set arrays inside entries were not sorted (the existing `test_cibw_overrides_aot_select_first` snapshot was recording that).

The inline entries now go through the same key order (`select` first, then the regular list) and array sorting; entries without `select` are left alone. Docs mention both forms; README regenerated.