### PR TITLE
🧪 test(pyproject-fmt): cover scalar cibuildwheel sort keys

### DIFF
--- a/pyproject-fmt/rust/src/cibuildwheel.rs
+++ b/pyproject-fmt/rust/src/cibuildwheel.rs
@@ -97,13 +97,12 @@ fn sort_array(entry: &SyntaxNode) {
 fn fix_overrides_inline(array: &SyntaxNode) {
     for inline in array.descendants().filter(|n| n.kind() == INLINE_TABLE) {
         for kv in inline.descendants().filter(|n| n.kind() == KEY_VALUE) {
-            let Some(keys) = kv.children().find(|c| c.kind() == KEYS) else {
-                continue;
-            };
+            let keys = kv.children().find(|c| c.kind() == KEYS).expect("a key-value has a key");
             if !SORT_ARRAYS.contains(&keys.text().to_string().trim()) {
                 continue;
             }
-            if let Some(inner) = kv.children().find(|c| c.kind() == ARRAY) {
+            // A sortable key holds a scalar when the config is wrong for cibuildwheel; leave such a value alone.
+            for inner in kv.children().filter(|c| c.kind() == ARRAY) {
                 sort_array(&inner);
             }
         }

--- a/pyproject-fmt/rust/src/tests/cibuildwheel_tests.rs
+++ b/pyproject-fmt/rust/src/tests/cibuildwheel_tests.rs
@@ -149,6 +149,19 @@ fn test_cibw_overrides_inline_select_first() {
 }
 
 #[test]
+fn test_cibw_overrides_inline_scalar_sort_key_kept() {
+    let start = indoc::indoc! {r#"
+    [tool.cibuildwheel]
+    overrides = [ { test-extras = "test", select = "cp310-*" } ]
+    "#};
+    let result = evaluate(start);
+    insta::assert_snapshot!(result, @r#"
+    [tool.cibuildwheel]
+    overrides = [ { select = "cp310-*", test-extras = "test" } ]
+    "#);
+}
+
+#[test]
 fn test_cibw_overrides_inline_without_select_untouched() {
     let start = indoc::indoc! {r#"
     [tool.cibuildwheel]


### PR DESCRIPTION
Follow-up to #437, which merged before this landed (it was the reason codecov/patch failed there).

`fix_overrides_inline` sorted a key from `SORT_ARRAYS` only when its value is an array. The `else` was an untested branch, and the `KEY_VALUE` without a `KEYS` child it also guarded cannot happen. Drop that guard for an `expect`, iterate the array children instead of branching on one, and pin the behaviour for a scalar `test-extras` — a misconfigured value is left as written rather than dropped.