### PR TITLE
🐛 fix(build): write Requires-Dist into the METADATA header

### DIFF
--- a/pyproject-fmt/build_backend.py
+++ b/pyproject-fmt/build_backend.py
@@ -102,11 +102,12 @@ def vendor_into_wheel(wheel: Path) -> None:
         out[entry] = sub(rf"\b{_VENDOR}\b", f"{_MODULE}._vendor.{_VENDOR}", out[entry].decode()).encode()
     meta = f"{dist_info}/METADATA"
     deps_block = search(r"(?ms)^dependencies = \[(.*?)\]", (_COMMON / "pyproject.toml").read_text())
-    requires = (
-        "".join(f"Requires-Dist: {d}\n" for d in findall(r'"([^"]*)"', deps_block.group(1))) if deps_block else ""
-    )
+    deps = findall(r'"([^"]*)"', deps_block.group(1)) if deps_block else []
     stripped = sub(r"(?m)^Requires-Dist: toml-fmt-common.*\n", "", out[meta].decode())
-    out[meta] = (stripped + requires).encode()
+    # Requires-Dist belongs in the header block; everything past the first blank line is the description
+    headers, sep, description = stripped.partition("\n\n")
+    parts = [headers.rstrip("\n"), *(f"\nRequires-Dist: {d}" for d in deps), sep, description]
+    out[meta] = "".join(parts).encode()
 
     out[f"{_MODULE}/_vendor/__init__.py"] = b""
     # vendor only the package's Python sources; local build artifacts (bytecode, caches, ext modules) never leak

--- a/pyproject-fmt/tests/test_build_backend.py
+++ b/pyproject-fmt/tests/test_build_backend.py
@@ -4,16 +4,27 @@ from pathlib import Path
 from runpy import run_path
 from sys import modules
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import Final
 from zipfile import ZipFile
 
-if TYPE_CHECKING:
-    import pytest
+import pytest
 
-_BACKEND = Path(__file__).parents[1] / "build_backend.py"
+_BACKEND: Final[Path] = Path(__file__).parents[1] / "build_backend.py"
+_METADATA: Final[str] = """\
+Metadata-Version: 2.4
+Name: pyproject-fmt
+Version: 0
+Requires-Dist: toml-fmt-common
+Description-Content-Type: text/markdown
+
+# pyproject-fmt
+
+Format your TOML.
+"""
 
 
-def test_vendor_into_wheel_ships_only_python_sources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setitem(modules, "maturin", SimpleNamespace())
     vendor = run_path(str(_BACKEND))["vendor_into_wheel"]
 
@@ -33,15 +44,18 @@ def test_vendor_into_wheel_ships_only_python_sources(tmp_path: Path, monkeypatch
     (src / "_speedups.so").write_bytes(b"\x7fELF")
     (src / ".DS_Store").write_bytes(b"junk")
 
-    wheel = tmp_path / "pyproject_fmt-0-py3-none-any.whl"
-    with ZipFile(wheel, "w") as zf:
+    path = tmp_path / "pyproject_fmt-0-py3-none-any.whl"
+    with ZipFile(path, "w") as zf:
         zf.writestr("pyproject_fmt/__main__.py", "import toml_fmt_common\n")
-        zf.writestr("pyproject_fmt-0.dist-info/METADATA", "Requires-Dist: toml-fmt-common\n")
+        zf.writestr("pyproject_fmt-0.dist-info/METADATA", _METADATA)
         zf.writestr("pyproject_fmt-0.dist-info/RECORD", "")
 
     monkeypatch.setitem(vendor.__globals__, "_COMMON", common)
-    vendor(wheel)
+    vendor(path)
+    return path
 
+
+def test_vendor_into_wheel_ships_only_python_sources(wheel: Path) -> None:
     with ZipFile(wheel) as zf:
         vendored = {n for n in zf.namelist() if n.startswith("pyproject_fmt/_vendor/")}
     assert vendored == {
@@ -50,3 +64,18 @@ def test_vendor_into_wheel_ships_only_python_sources(tmp_path: Path, monkeypatch
         "pyproject_fmt/_vendor/toml_fmt_common/_lib.pyi",
         "pyproject_fmt/_vendor/toml_fmt_common/py.typed",
     }
+
+
+def test_vendor_into_wheel_requires_dist_in_header(wheel: Path) -> None:
+    with ZipFile(wheel) as zf:
+        metadata = zf.read("pyproject_fmt-0.dist-info/METADATA").decode()
+
+    headers, _, description = metadata.partition("\n\n")
+    assert headers.splitlines() == [
+        "Metadata-Version: 2.4",
+        "Name: pyproject-fmt",
+        "Version: 0",
+        "Description-Content-Type: text/markdown",
+        "Requires-Dist: tomlkit>=0.13",
+    ]
+    assert description == "# pyproject-fmt\n\nFormat your TOML.\n"

--- a/tox-toml-fmt/build_backend.py
+++ b/tox-toml-fmt/build_backend.py
@@ -102,11 +102,12 @@ def vendor_into_wheel(wheel: Path) -> None:
         out[entry] = sub(rf"\b{_VENDOR}\b", f"{_MODULE}._vendor.{_VENDOR}", out[entry].decode()).encode()
     meta = f"{dist_info}/METADATA"
     deps_block = search(r"(?ms)^dependencies = \[(.*?)\]", (_COMMON / "pyproject.toml").read_text())
-    requires = (
-        "".join(f"Requires-Dist: {d}\n" for d in findall(r'"([^"]*)"', deps_block.group(1))) if deps_block else ""
-    )
+    deps = findall(r'"([^"]*)"', deps_block.group(1)) if deps_block else []
     stripped = sub(r"(?m)^Requires-Dist: toml-fmt-common.*\n", "", out[meta].decode())
-    out[meta] = (stripped + requires).encode()
+    # Requires-Dist belongs in the header block; everything past the first blank line is the description
+    headers, sep, description = stripped.partition("\n\n")
+    parts = [headers.rstrip("\n"), *(f"\nRequires-Dist: {d}" for d in deps), sep, description]
+    out[meta] = "".join(parts).encode()
 
     out[f"{_MODULE}/_vendor/__init__.py"] = b""
     # vendor only the package's Python sources; local build artifacts (bytecode, caches, ext modules) never leak

--- a/tox-toml-fmt/tests/test_build_backend.py
+++ b/tox-toml-fmt/tests/test_build_backend.py
@@ -4,16 +4,27 @@ from pathlib import Path
 from runpy import run_path
 from sys import modules
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import Final
 from zipfile import ZipFile
 
-if TYPE_CHECKING:
-    import pytest
+import pytest
 
-_BACKEND = Path(__file__).parents[1] / "build_backend.py"
+_BACKEND: Final[Path] = Path(__file__).parents[1] / "build_backend.py"
+_METADATA: Final[str] = """\
+Metadata-Version: 2.4
+Name: tox-toml-fmt
+Version: 0
+Requires-Dist: toml-fmt-common
+Description-Content-Type: text/markdown
+
+# tox-toml-fmt
+
+Format your TOML.
+"""
 
 
-def test_vendor_into_wheel_ships_only_python_sources(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setitem(modules, "maturin", SimpleNamespace())
     vendor = run_path(str(_BACKEND))["vendor_into_wheel"]
 
@@ -33,15 +44,18 @@ def test_vendor_into_wheel_ships_only_python_sources(tmp_path: Path, monkeypatch
     (src / "_speedups.so").write_bytes(b"\x7fELF")
     (src / ".DS_Store").write_bytes(b"junk")
 
-    wheel = tmp_path / "tox_toml_fmt-0-py3-none-any.whl"
-    with ZipFile(wheel, "w") as zf:
+    path = tmp_path / "tox_toml_fmt-0-py3-none-any.whl"
+    with ZipFile(path, "w") as zf:
         zf.writestr("tox_toml_fmt/__main__.py", "import toml_fmt_common\n")
-        zf.writestr("tox_toml_fmt-0.dist-info/METADATA", "Requires-Dist: toml-fmt-common\n")
+        zf.writestr("tox_toml_fmt-0.dist-info/METADATA", _METADATA)
         zf.writestr("tox_toml_fmt-0.dist-info/RECORD", "")
 
     monkeypatch.setitem(vendor.__globals__, "_COMMON", common)
-    vendor(wheel)
+    vendor(path)
+    return path
 
+
+def test_vendor_into_wheel_ships_only_python_sources(wheel: Path) -> None:
     with ZipFile(wheel) as zf:
         vendored = {n for n in zf.namelist() if n.startswith("tox_toml_fmt/_vendor/")}
     assert vendored == {
@@ -50,3 +64,18 @@ def test_vendor_into_wheel_ships_only_python_sources(tmp_path: Path, monkeypatch
         "tox_toml_fmt/_vendor/toml_fmt_common/_lib.pyi",
         "tox_toml_fmt/_vendor/toml_fmt_common/py.typed",
     }
+
+
+def test_vendor_into_wheel_requires_dist_in_header(wheel: Path) -> None:
+    with ZipFile(wheel) as zf:
+        metadata = zf.read("tox_toml_fmt-0.dist-info/METADATA").decode()
+
+    headers, _, description = metadata.partition("\n\n")
+    assert headers.splitlines() == [
+        "Metadata-Version: 2.4",
+        "Name: tox-toml-fmt",
+        "Version: 0",
+        "Description-Content-Type: text/markdown",
+        "Requires-Dist: tomlkit>=0.13",
+    ]
+    assert description == "# tox-toml-fmt\n\nFormat your TOML.\n"


### PR DESCRIPTION
Since #363 the wheels vendor `toml-fmt-common` and copy its dependencies into the wheel `METADATA`, but those `Requires-Dist` lines went to the end of the file, past the description, where installers ignore them. 🐛 As [#441](https://github.com/tox-dev/toml-fmt/issues/441) reports, `pyproject-fmt` 2.22.0 and later ship without a `tomli` requirement, so on Python 3.10 the installed console script dies at import with `ModuleNotFoundError: No module named 'tomli'`.

`METADATA` is an email-style document with headers, a blank line, and then the description. The patcher now splits on that first blank line and adds the `Requires-Dist` entries to the header block, keeping the description intact behind it. Both `pyproject-fmt` and `tox-toml-fmt` carry the same backend, so both get the fix.

The next `pyproject-fmt` release will declare `tomli>=2.4.1; python_version<'3.11'`. Anyone on 2.22.0 through 2.28.0 with Python 3.10 needs `tomli` installed by hand until then. Thanks to @nathanjmcdougall for tracing it to the line. 🙏

Closes #441
