### PR TITLE
✨ feat(common): keep the file's own line endings

### DIFF
--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -655,6 +655,14 @@ The formatter sorts the entries inside each group:
 A ``# Group:`` marker works the same way before a key in a table or before a ``[tool.*]`` header: the formatter sorts the
 keys or sections up to the next marker, and never moves them across the boundary.
 
+Line Endings
+~~~~~~~~~~~~
+
+The formatter writes a file back with the line ending it already used, so a ``\r\n`` file stays ``\r\n`` and Git on
+Windows does not flag it as modified. A file mixing both endings gets whichever one it uses more, with a tie going to
+``\n``. Line endings alone never count as a change, so a file that is already formatted is left alone whichever ending
+it uses. Output written to stdout always uses ``\n``.
+
 Table-Specific Handling
 -----------------------
 

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -259,6 +259,14 @@ The formatter sorts the entries inside each group:
 A ``# Group:`` marker works the same way before a key in a table or before a ``[tool.*]`` header: the formatter sorts the
 keys or sections up to the next marker, and never moves them across the boundary.
 
+Line Endings
+~~~~~~~~~~~~
+
+The formatter writes a file back with the line ending it already used, so a ``\r\n`` file stays ``\r\n`` and Git on
+Windows does not flag it as modified. A file mixing both endings gets whichever one it uses more, with a tie going to
+``\n``. Line endings alone never count as a change, so a file that is already formatted is left alone whichever ending
+it uses. Output written to stdout always uses ``\n``.
+
 Table-Specific Handling
 -----------------------
 

--- a/toml-fmt-common/src/toml_fmt_common/__init__.py
+++ b/toml-fmt-common/src/toml_fmt_common/__init__.py
@@ -131,6 +131,7 @@ class _Config(Generic[T]):
     check: bool  # check only
     no_print_diff: bool  # don't print diff
     opt: T
+    eol: str  # line ending to write the file back with
 
 
 def _check_write_permission(parser: ArgumentParser, opt: FmtNamespace) -> None:
@@ -156,7 +157,7 @@ def _cli_args(info: TOMLFormatter[T], args: Sequence[str]) -> list[_Config[T]]:
     _check_write_permission(parser, info.opt)
     res = []
     for pyproject_toml in info.opt.inputs:
-        raw_pyproject_toml = sys.stdin.read() if pyproject_toml is None else pyproject_toml.read_text(encoding="utf-8")
+        raw_pyproject_toml, eol = _read_input(pyproject_toml)
         config: dict[str, Any] | None = tomllib.loads(raw_pyproject_toml)
 
         parts = deque(info.override_cli_from_section)
@@ -182,10 +183,21 @@ def _cli_args(info: TOMLFormatter[T], args: Sequence[str]) -> list[_Config[T]]:
                 check=info.opt.check,
                 no_print_diff=info.opt.no_print_diff,
                 opt=override_opt,
+                eol=eol,
             )
         )
 
     return res
+
+
+def _read_input(path: Path | None) -> tuple[str, str]:
+    if path is None:
+        return sys.stdin.read(), "\n"
+    with path.open(encoding="utf-8", newline="") as file_handler:
+        raw = file_handler.read()
+    crlf = raw.count("\r\n")
+    # a mixed file gets the ending it uses most, ties go to LF
+    return raw.replace("\r\n", "\n").replace("\r", "\n"), "\r\n" if crlf > raw.count("\n") - crlf else "\n"
 
 
 _NON_FORMAT_KEYS = frozenset({"inputs", "stdout", "check", "no_print_diff", "config"})
@@ -378,7 +390,7 @@ def _handle_one(info: TOMLFormatter[T], config: _Config[T]) -> bool:
         return changed
 
     if before != formatted and not config.check:
-        config.toml_filename.write_text(formatted, encoding="utf-8", newline="\n")
+        config.toml_filename.write_text(formatted, encoding="utf-8", newline=config.eol)
     if config.no_print_diff:
         return changed
     name = _display_name(config.toml_filename)

--- a/toml-fmt-common/tests/test_app.py
+++ b/toml-fmt-common/tests/test_app.py
@@ -551,3 +551,32 @@ def test_format_rejection_reported_for_stdin(
     out, err = capsys.readouterr()
     assert not out
     assert err == "<stdin>: bad version\n"
+
+
+@pytest.mark.parametrize("eol", [pytest.param("\r\n", id="crlf"), pytest.param("\n", id="lf")])
+def test_dumb_format_keeps_line_ending(tmp_path: Path, eol: str) -> None:
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_bytes(f"[start.sub]{eol}extra = 'B'".encode())
+
+    assert run(Dumb(), ["E", str(dumb), "--no-print-diff"]) == 1
+
+    assert dumb.read_bytes() == f"[start.sub]{eol}extra = 'B'{eol}extras = 'B'".encode()
+
+
+def test_dumb_format_mixed_line_endings_take_the_majority(tmp_path: Path) -> None:
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_bytes(b"[start.sub]\r\nextra = 'B'\r\nother = 1\nmore = 2")
+
+    assert run(Dumb(), ["E", str(dumb), "--no-print-diff"]) == 1
+
+    assert dumb.read_bytes() == b"[start.sub]\r\nextra = 'B'\r\nother = 1\r\nmore = 2\r\nextras = 'B'"
+
+
+def test_dumb_format_crlf_alone_is_not_a_change(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_FMT", "1")
+    dumb = tmp_path / "dumb.toml"
+    dumb.write_bytes(b"[start.sub]\r\nextra = 'B'")
+
+    assert run(Dumb(), ["E", str(dumb), "--no-print-diff"]) == 0
+
+    assert dumb.read_bytes() == b"[start.sub]\r\nextra = 'B'"

--- a/tox-toml-fmt/README.rst
+++ b/tox-toml-fmt/README.rst
@@ -410,6 +410,14 @@ Files without a ``# Group:`` marker format the same as before, so the feature st
      "pytest-cov",
    ]
 
+Line Endings
+~~~~~~~~~~~~
+
+The formatter writes a file back with the line ending it already used, so a ``\r\n`` file stays ``\r\n`` and Git on
+Windows does not flag it as modified. A file mixing both endings gets whichever one it uses more, with a tie going to
+``\n``. Line endings alone never count as a change, so a file that is already formatted is left alone whichever ending
+it uses. Output written to stdout always uses ``\n``.
+
 Table-Specific Handling
 -----------------------
 

--- a/tox-toml-fmt/docs/formatting.rst
+++ b/tox-toml-fmt/docs/formatting.rst
@@ -221,6 +221,14 @@ Files without a ``# Group:`` marker format the same as before, so the feature st
       "pytest",
     ]
 
+Line Endings
+~~~~~~~~~~~~
+
+The formatter writes a file back with the line ending it already used, so a ``\r\n`` file stays ``\r\n`` and Git on
+Windows does not flag it as modified. A file mixing both endings gets whichever one it uses more, with a tie going to
+``\n``. Line endings alone never count as a change, so a file that is already formatted is left alone whichever ending
+it uses. Output written to stdout always uses ``\n``.
+
 Table-Specific Handling
 -----------------------
 


### PR DESCRIPTION
Git for Windows checks out `pyproject.toml` with CRLF under its default `core.autocrlf`, and the formatter wrote every file back with LF. As [#446](https://github.com/tox-dev/toml-fmt/issues/446) describes, the editor then marks an otherwise untouched file as modified, and git prints `warning: in the working copy of 'pyproject.toml', LF will be replaced by CRLF the next time Git touches it`. 🪟

Reading the file with newline translation off keeps the original endings visible, and the content drops to LF before it reaches the formatter. On write, the file gets the ending it already used. A file mixing both endings takes whichever it uses more, with a tie going to LF, which keeps the choice stable for files a mixed team has edited. Output on stdout stays LF.

The comparison against the formatted result runs on LF-normalized text, so a CRLF file that needs no formatting still reports no change, stays untouched on disk, and passes `--check`. Thanks to @zedzhen for the report and for [sketching the implementation](https://github.com/tox-dev/toml-fmt/compare/main...zedzhen:toml-fmt:eol). 🙏

Closes #446
