### PR TITLE
🐛 fix(build): carry toml-fmt-common in the sdist

### DIFF
--- a/.github/workflows/pyproject_fmt_test.yaml
+++ b/.github/workflows/pyproject_fmt_test.yaml
@@ -163,7 +163,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [type, dev, pkg_meta]
+        env: [type, dev, pkg_meta, pkg_sdist]
     defaults:
       run:
         working-directory: pyproject-fmt

--- a/.github/workflows/tox_toml_fmt_test.yaml
+++ b/.github/workflows/tox_toml_fmt_test.yaml
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [type, dev, pkg_meta]
+        env: [type, dev, pkg_meta, pkg_sdist]
     defaults:
       run:
         working-directory: tox-toml-fmt

--- a/pyproject-fmt/build_backend.py
+++ b/pyproject-fmt/build_backend.py
@@ -1,8 +1,8 @@
 """
-Vendor toml-fmt-common into the wheel, as a PEP 517 backend and as a CLI patcher.
+Vendor toml-fmt-common into what we build, as a PEP 517 backend and as a CLI patcher.
 
 A new toml-fmt-common release must never break an already published consumer
-(tox-dev/toml-fmt#355), so the wheel is made self-contained instead of depending on it.
+(tox-dev/toml-fmt#355), so every artifact is made self-contained instead of depending on it.
 
 The CLI entry point exists because CI builds wheels with ``maturin build``, which never
 invokes a PEP 517 backend; the same patch then runs on maturin-action's output.
@@ -17,11 +17,14 @@ from __future__ import annotations
 
 from base64 import urlsafe_b64encode
 from hashlib import sha256
+from io import BytesIO
 from os import environ
 from pathlib import Path
 from re import findall, search, sub
 from shutil import copy2
 from sys import argv
+from tarfile import TarInfo
+from tarfile import open as tar_open
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -29,7 +32,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 import maturin
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Iterator, Mapping
 
     ConfigSettings = Mapping[str, str | list[str]]
 
@@ -37,9 +40,10 @@ if TYPE_CHECKING:
 environ.setdefault("MATURIN_NO_MISSING_BUILD_BACKEND_WARNING", "1")
 
 _HERE = Path(__file__).resolve().parent
-_MODULE = _HERE.name.replace("-", "_")
-_COMMON = _HERE.parent / "toml-fmt-common"
+_MODULE = findall(r'(?m)^name = "(.*)"', (_HERE / "pyproject.toml").read_text())[0].replace("-", "_")
 _VENDOR = "toml_fmt_common"
+# a checkout keeps toml-fmt-common beside the package; the sdist carries it within
+_COMMON = _HERE / "toml-fmt-common" if (_HERE / "toml-fmt-common").is_dir() else _HERE.parent / "toml-fmt-common"
 
 
 def build_wheel(
@@ -47,17 +51,14 @@ def build_wheel(
     config_settings: ConfigSettings | None = None,
     metadata_directory: str | None = None,
 ) -> str:
-    if not (_COMMON / "src" / _VENDOR).is_dir():  # no workspace (e.g. building from sdist)
-        return maturin.build_wheel(wheel_directory, config_settings, metadata_directory)
-    tmp = Path(mkdtemp())
-    name = maturin.build_wheel(str(tmp), config_settings, metadata_directory)
-    vendor_into_wheel(tmp / name)
-    copy2(tmp / name, Path(wheel_directory) / name)
-    return name
+    return built(maturin.build_wheel, wheel_directory, config_settings, metadata_directory, vendor_into_wheel)
 
 
 def build_sdist(sdist_directory: str, config_settings: ConfigSettings | None = None) -> str:
-    return maturin.build_sdist(sdist_directory, config_settings)
+    name = maturin.build_sdist(sdist_directory, config_settings)
+    if common_is_present():
+        vendor_into_sdist(Path(sdist_directory) / name)
+    return name
 
 
 def build_editable(
@@ -65,7 +66,7 @@ def build_editable(
     config_settings: ConfigSettings | None = None,
     metadata_directory: str | None = None,
 ) -> str:
-    return maturin.build_editable(wheel_directory, config_settings, metadata_directory)
+    return built(maturin.build_editable, wheel_directory, config_settings, metadata_directory, link_common_into_wheel)
 
 
 def get_requires_for_build_wheel(config_settings: ConfigSettings | None = None) -> list[str]:
@@ -80,6 +81,26 @@ def get_requires_for_build_editable(config_settings: ConfigSettings | None = Non
     return maturin.get_requires_for_build_editable(config_settings)
 
 
+def built(
+    build: Callable[[str, ConfigSettings | None, str | None], str],
+    wheel_directory: str,
+    config_settings: ConfigSettings | None,
+    metadata_directory: str | None,
+    carry: Callable[[Path], None],
+) -> str:
+    if not common_is_present():
+        return build(wheel_directory, config_settings, metadata_directory)
+    tmp = Path(mkdtemp())
+    name = build(str(tmp), config_settings, metadata_directory)
+    carry(tmp / name)
+    copy2(tmp / name, Path(wheel_directory) / name)
+    return name
+
+
+def common_is_present() -> bool:
+    return (_COMMON / "src" / _VENDOR).is_dir()
+
+
 def main() -> None:
     target = Path(argv[1])
     if not (wheels := sorted(target.glob("*.whl")) if target.is_dir() else [target]):
@@ -91,29 +112,27 @@ def main() -> None:
 
 
 def vendor_into_wheel(wheel: Path) -> None:
-    common_src = _COMMON / "src" / _VENDOR
+    at = f"{_MODULE}/_vendor/"
+    changed = {f"{at}__init__.py": b""} | {f"{at}{name}": data for name, data in common_sources()}
+    with ZipFile(wheel) as src:
+        if (entry := f"{_MODULE}/__main__.py") in src.namelist():
+            spelled = sub(rf"\b{_VENDOR}\b", f"{_MODULE}._vendor.{_VENDOR}", src.read(entry).decode())
+            changed[entry] = spelled.encode()
+    rewrite(wheel, changed)
 
+
+def link_common_into_wheel(wheel: Path) -> None:
+    # an editable install reads the package from the source tree, where the import stays unvendored
+    rewrite(wheel, {f"{_MODULE}_{_VENDOR}.pth": f"{_COMMON / 'src'}\n".encode()})
+
+
+def rewrite(wheel: Path, changed: dict[str, bytes]) -> None:
     with ZipFile(wheel) as src:
         names = src.namelist()
         dist_info = next(n for n in names if n.endswith(".dist-info/METADATA")).split("/")[0]
         out = {n: src.read(n) for n in names if not n.endswith("/RECORD")}
-
-    if (entry := f"{_MODULE}/__main__.py") in out:
-        out[entry] = sub(rf"\b{_VENDOR}\b", f"{_MODULE}._vendor.{_VENDOR}", out[entry].decode()).encode()
-    meta = f"{dist_info}/METADATA"
-    deps_block = search(r"(?ms)^dependencies = \[(.*?)\]", (_COMMON / "pyproject.toml").read_text())
-    deps = findall(r'"([^"]*)"', deps_block.group(1)) if deps_block else []
-    stripped = sub(r"(?m)^Requires-Dist: toml-fmt-common.*\n", "", out[meta].decode())
-    # Requires-Dist belongs in the header block; everything past the first blank line is the description
-    headers, sep, description = stripped.partition("\n\n")
-    parts = [headers.rstrip("\n"), *(f"\nRequires-Dist: {d}" for d in deps), sep, description]
-    out[meta] = "".join(parts).encode()
-
-    out[f"{_MODULE}/_vendor/__init__.py"] = b""
-    # vendor only the package's Python sources; local build artifacts (bytecode, caches, ext modules) never leak
-    for file in common_src.rglob("*"):
-        if file.is_file() and (file.suffix in {".py", ".pyi"} or file.name == "py.typed"):
-            out[f"{_MODULE}/_vendor/{file.relative_to(common_src.parent).as_posix()}"] = file.read_bytes()
+    out.update(changed)
+    out[f"{dist_info}/METADATA"] = own_metadata(out[f"{dist_info}/METADATA"])
 
     record = []
     for name, data in out.items():
@@ -125,6 +144,44 @@ def vendor_into_wheel(wheel: Path) -> None:
     with ZipFile(wheel, "w", ZIP_DEFLATED) as zf:
         for name, data in out.items():
             zf.writestr(name, data)
+
+
+def vendor_into_sdist(sdist: Path) -> None:
+    held = []
+    with tar_open(sdist) as src:
+        for member in src.getmembers():
+            content = src.extractfile(member)
+            held.append((member, content.read() if content else b""))
+    root = held[0][0].name.split("/")[0]
+
+    added = [(f"{root}/{_COMMON.name}/pyproject.toml", (_COMMON / "pyproject.toml").read_bytes())]
+    added += [(f"{root}/{_COMMON.name}/src/{name}", data) for name, data in common_sources()]
+
+    with tar_open(sdist, "w:gz") as out:
+        for member, data in held:
+            out.addfile(member, BytesIO(data) if member.isfile() else None)
+        for name, data in added:
+            info = TarInfo(name)
+            info.size = len(data)
+            info.mode = 0o644
+            out.addfile(info, BytesIO(data))
+
+
+def own_metadata(metadata: bytes) -> bytes:
+    deps_block = search(r"(?ms)^dependencies = \[(.*?)\]", (_COMMON / "pyproject.toml").read_text())
+    if not (deps := findall(r'"([^"]*)"', deps_block.group(1)) if deps_block else []):
+        return metadata
+    # Requires-Dist belongs in the header block; everything past the first blank line is the description
+    headers, sep, description = metadata.decode().partition("\n\n")
+    return "".join([headers.rstrip("\n"), *(f"\nRequires-Dist: {d}" for d in deps), sep, description]).encode()
+
+
+def common_sources() -> Iterator[tuple[str, bytes]]:
+    src = _COMMON / "src" / _VENDOR
+    # vendor only the package's Python sources; local build artifacts (bytecode, caches, ext modules) never leak
+    for file in sorted(src.rglob("*")):
+        if file.is_file() and (file.suffix in {".py", ".pyi"} or file.name == "py.typed"):
+            yield file.relative_to(src.parent).as_posix(), file.read_bytes()
 
 
 if __name__ == "__main__":

--- a/pyproject-fmt/pyproject.toml
+++ b/pyproject-fmt/pyproject.toml
@@ -34,9 +34,6 @@ classifiers = [
 dynamic = [
   "version",
 ]
-dependencies = [
-  "toml-fmt-common",
-]
 urls."Bug Tracker" = "https://github.com/tox-dev/toml-fmt/issues"
 urls."Source Code" = "https://github.com/tox-dev/toml-fmt/tree/main/pyproject-fmt"
 urls.Changelog = "https://github.com/tox-dev/toml-fmt/releases?q=pyproject-fmt"

--- a/pyproject-fmt/tests/test_build_backend.py
+++ b/pyproject-fmt/tests/test_build_backend.py
@@ -1,40 +1,52 @@
 from __future__ import annotations
 
+from io import BytesIO
 from pathlib import Path
 from runpy import run_path
 from sys import modules
+from tarfile import DIRTYPE, TarInfo
+from tarfile import open as tar_open
 from types import SimpleNamespace
-from typing import Final
+from typing import TYPE_CHECKING, Final, NamedTuple
 from zipfile import ZipFile
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _BACKEND: Final[Path] = Path(__file__).parents[1] / "build_backend.py"
 _METADATA: Final[str] = """\
 Metadata-Version: 2.4
 Name: pyproject-fmt
 Version: 0
-Requires-Dist: toml-fmt-common
 Description-Content-Type: text/markdown
 
 # pyproject-fmt
 
 Format your TOML.
 """
+_SDIST_HELD: Final[bytes] = b'[project]\nname = "pyproject-fmt"\n'
+
+
+class Backend(NamedTuple):
+    vendor_into_wheel: Callable[[Path], None]
+    link_common_into_wheel: Callable[[Path], None]
+    vendor_into_sdist: Callable[[Path], None]
 
 
 @pytest.fixture
-def wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+def backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Backend:
     monkeypatch.setitem(modules, "maturin", SimpleNamespace())
-    vendor = run_path(str(_BACKEND))["vendor_into_wheel"]
+    loaded = run_path(str(_BACKEND))
 
     common = tmp_path / "toml-fmt-common"
     src = common / "src" / "toml_fmt_common"
     src.mkdir(parents=True)
-    (src / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
-    (src / "_lib.pyi").write_text("VALUE: int\n", encoding="utf-8")
+    (src / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8", newline="")
+    (src / "_lib.pyi").write_text("VALUE: int\n", encoding="utf-8", newline="")
     (src / "py.typed").write_text("", encoding="utf-8")
-    (common / "pyproject.toml").write_text('dependencies = [\n  "tomlkit>=0.13",\n]\n', encoding="utf-8")
+    (common / "pyproject.toml").write_text('dependencies = [\n  "tomlkit>=0.13",\n]\n', encoding="utf-8", newline="")
 
     cache = src / "__pycache__"
     cache.mkdir()
@@ -44,14 +56,44 @@ def wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     (src / "_speedups.so").write_bytes(b"\x7fELF")
     (src / ".DS_Store").write_bytes(b"junk")
 
+    monkeypatch.setitem(loaded["vendor_into_wheel"].__globals__, "_COMMON", common)
+    return Backend(loaded["vendor_into_wheel"], loaded["link_common_into_wheel"], loaded["vendor_into_sdist"])
+
+
+@pytest.fixture
+def unvendored(tmp_path: Path) -> Path:
     path = tmp_path / "pyproject_fmt-0-py3-none-any.whl"
     with ZipFile(path, "w") as zf:
         zf.writestr("pyproject_fmt/__main__.py", "import toml_fmt_common\n")
         zf.writestr("pyproject_fmt-0.dist-info/METADATA", _METADATA)
         zf.writestr("pyproject_fmt-0.dist-info/RECORD", "")
+    return path
 
-    monkeypatch.setitem(vendor.__globals__, "_COMMON", common)
-    vendor(path)
+
+@pytest.fixture
+def wheel(backend: Backend, unvendored: Path) -> Path:
+    backend.vendor_into_wheel(unvendored)
+    return unvendored
+
+
+@pytest.fixture
+def editable(backend: Backend, unvendored: Path) -> Path:
+    backend.link_common_into_wheel(unvendored)
+    return unvendored
+
+
+@pytest.fixture
+def sdist(backend: Backend, tmp_path: Path) -> Path:
+    path = tmp_path / "pyproject_fmt-0.tar.gz"
+    root = TarInfo("pyproject_fmt-0")
+    root.type = DIRTYPE
+    held = TarInfo("pyproject_fmt-0/pyproject.toml")
+    held.size = len(_SDIST_HELD)
+    with tar_open(path, "w:gz") as tar:
+        tar.addfile(root)
+        tar.addfile(held, BytesIO(_SDIST_HELD))
+
+    backend.vendor_into_sdist(path)
     return path
 
 
@@ -79,3 +121,44 @@ def test_vendor_into_wheel_requires_dist_in_header(wheel: Path) -> None:
         "Requires-Dist: tomlkit>=0.13",
     ]
     assert description == "# pyproject-fmt\n\nFormat your TOML.\n"
+
+
+def test_vendor_into_wheel_spells_the_entry_point_import_vendored(wheel: Path) -> None:
+    with ZipFile(wheel) as zf:
+        assert zf.read("pyproject_fmt/__main__.py") == b"import pyproject_fmt._vendor.toml_fmt_common\n"
+
+
+def test_link_common_into_wheel_points_at_the_source_tree(editable: Path, tmp_path: Path) -> None:
+    with ZipFile(editable) as zf:
+        assert zf.read("pyproject_fmt_toml_fmt_common.pth").decode() == f"{tmp_path / 'toml-fmt-common' / 'src'}\n"
+
+
+def test_link_common_into_wheel_copies_nothing(editable: Path) -> None:
+    with ZipFile(editable) as zf:
+        assert [n for n in zf.namelist() if n.startswith("toml_fmt_common/")] == []
+
+
+def test_vendor_into_sdist_carries_common(sdist: Path) -> None:
+    with tar_open(sdist) as tar:
+        assert set(tar.getnames()) == {
+            "pyproject_fmt-0",
+            "pyproject_fmt-0/pyproject.toml",
+            "pyproject_fmt-0/toml-fmt-common/pyproject.toml",
+            "pyproject_fmt-0/toml-fmt-common/src/toml_fmt_common/__init__.py",
+            "pyproject_fmt-0/toml-fmt-common/src/toml_fmt_common/_lib.pyi",
+            "pyproject_fmt-0/toml-fmt-common/src/toml_fmt_common/py.typed",
+        }
+
+
+@pytest.mark.parametrize(
+    ("member", "content"),
+    [
+        pytest.param("pyproject.toml", _SDIST_HELD, id="held"),
+        pytest.param("toml-fmt-common/src/toml_fmt_common/__init__.py", b"VALUE = 1\n", id="added"),
+    ],
+)
+def test_vendor_into_sdist_content(sdist: Path, member: str, content: bytes) -> None:
+    with tar_open(sdist) as tar:
+        read = tar.extractfile(f"pyproject_fmt-0/{member}")
+        assert read is not None
+        assert read.read() == content

--- a/pyproject-fmt/tox.toml
+++ b/pyproject-fmt/tox.toml
@@ -1,5 +1,5 @@
 requires = ["tox>=4.60", "tox-uv>=1.36"]
-env_list = ["fix", "3.15", "3.15t", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
+env_list = ["fix", "3.15", "3.15t", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta", "pkg_sdist"]
 skip_missing_interpreters = true
 
 [env_run_base]
@@ -50,6 +50,7 @@ set_env.MATURIN_PEP517_ARGS = "--no-default-features --features extension-module
 [env.type]
 description = "run type check on code base"
 dependency_groups = ["type"]
+set_env.MYPYPATH = "{tox_root}{/}..{/}toml-fmt-common{/}src"
 commands = [["mypy", "src{/}pyproject_fmt"], ["mypy", "tests"]]
 
 [env.docs]
@@ -118,4 +119,16 @@ commands = [["python", "tasks{/}generate_readme.py", "pyproject-fmt"]]
 description = "dev environment with all deps at {envdir}"
 package = "editable"
 dependency_groups = ["dev"]
-commands = [["uv", "pip", "tree"], ["python", "-c", 'print(r"{env_python}")']]
+commands = [
+    ["uv", "pip", "tree"],
+    ["python", "-c", "import toml_fmt_common"],
+    ["python", "-c", 'print(r"{env_python}")'],
+]
+
+[env.pkg_sdist]
+description = "build a wheel from the sdist and check it carries toml-fmt-common"
+runner = "uv-venv-runner"
+skip_install = true
+dependency_groups = []
+change_dir = "{tox_root}{/}.."
+commands = [["python", "tasks{/}check_sdist.py", "pyproject-fmt"]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [tool.uv]
-sources.toml-fmt-common = { workspace = true }
 workspace.members = [ "pyproject-fmt", "toml-fmt-common", "tox-toml-fmt" ]
 
 [tool.ruff]
@@ -46,6 +45,9 @@ lint.per-file-ignores."**/toxfile.py" = [
 lint.per-file-ignores."tasks/**.py" = [
   "D",      # don't care about documentation in tests
   "INP001", # is not a namespace
+  "S404",   # subprocess is required to drive the build
+  "S603",   # the build commands are ours, not untrusted input
+  "S607",   # uv is resolved from PATH
   "T201",   # allow print
 ]
 lint.isort = { known-first-party = [

--- a/tasks/check_sdist.py
+++ b/tasks/check_sdist.py
@@ -1,0 +1,41 @@
+"""Build a package from its own sdist and check the wheel that comes out carries toml-fmt-common."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def main(package: str) -> None:
+    with TemporaryDirectory() as folder:
+        out = Path(folder)
+        subprocess.check_call(["uv", "build", "--sdist", "--out-dir", str(out), str(_ROOT / package)])
+        sdist = next(out.glob("*.tar.gz"))
+        subprocess.check_call(["uv", "build", "--wheel", "--out-dir", str(out), str(sdist)])
+        check(next(out.glob("*.whl")), package.replace("-", "_"))
+
+
+def check(wheel: Path, module: str) -> None:
+    with ZipFile(wheel) as zf:
+        names = zf.namelist()
+        metadata = zf.read(next(n for n in names if n.endswith(".dist-info/METADATA"))).decode()
+
+    if (vendored := f"{module}/_vendor/toml_fmt_common/__init__.py") not in names:
+        print(f"{wheel.name} built from the sdist holds no {vendored}")
+        sys.exit(1)
+    if "Requires-Dist: toml-fmt-common" in metadata:
+        print(f"{wheel.name} built from the sdist still requires toml-fmt-common")
+        sys.exit(1)
+    print(f"{wheel.name} built from the sdist carries toml-fmt-common")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:  # ruff: ignore[magic-value-comparison]
+        print("Usage: check_sdist.py <package>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/tox-toml-fmt/build_backend.py
+++ b/tox-toml-fmt/build_backend.py
@@ -1,8 +1,8 @@
 """
-Vendor toml-fmt-common into the wheel, as a PEP 517 backend and as a CLI patcher.
+Vendor toml-fmt-common into what we build, as a PEP 517 backend and as a CLI patcher.
 
 A new toml-fmt-common release must never break an already published consumer
-(tox-dev/toml-fmt#355), so the wheel is made self-contained instead of depending on it.
+(tox-dev/toml-fmt#355), so every artifact is made self-contained instead of depending on it.
 
 The CLI entry point exists because CI builds wheels with ``maturin build``, which never
 invokes a PEP 517 backend; the same patch then runs on maturin-action's output.
@@ -17,11 +17,14 @@ from __future__ import annotations
 
 from base64 import urlsafe_b64encode
 from hashlib import sha256
+from io import BytesIO
 from os import environ
 from pathlib import Path
 from re import findall, search, sub
 from shutil import copy2
 from sys import argv
+from tarfile import TarInfo
+from tarfile import open as tar_open
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -29,7 +32,7 @@ from zipfile import ZIP_DEFLATED, ZipFile
 import maturin
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Iterator, Mapping
 
     ConfigSettings = Mapping[str, str | list[str]]
 
@@ -37,9 +40,10 @@ if TYPE_CHECKING:
 environ.setdefault("MATURIN_NO_MISSING_BUILD_BACKEND_WARNING", "1")
 
 _HERE = Path(__file__).resolve().parent
-_MODULE = _HERE.name.replace("-", "_")
-_COMMON = _HERE.parent / "toml-fmt-common"
+_MODULE = findall(r'(?m)^name = "(.*)"', (_HERE / "pyproject.toml").read_text())[0].replace("-", "_")
 _VENDOR = "toml_fmt_common"
+# a checkout keeps toml-fmt-common beside the package; the sdist carries it within
+_COMMON = _HERE / "toml-fmt-common" if (_HERE / "toml-fmt-common").is_dir() else _HERE.parent / "toml-fmt-common"
 
 
 def build_wheel(
@@ -47,17 +51,14 @@ def build_wheel(
     config_settings: ConfigSettings | None = None,
     metadata_directory: str | None = None,
 ) -> str:
-    if not (_COMMON / "src" / _VENDOR).is_dir():  # no workspace (e.g. building from sdist)
-        return maturin.build_wheel(wheel_directory, config_settings, metadata_directory)
-    tmp = Path(mkdtemp())
-    name = maturin.build_wheel(str(tmp), config_settings, metadata_directory)
-    vendor_into_wheel(tmp / name)
-    copy2(tmp / name, Path(wheel_directory) / name)
-    return name
+    return built(maturin.build_wheel, wheel_directory, config_settings, metadata_directory, vendor_into_wheel)
 
 
 def build_sdist(sdist_directory: str, config_settings: ConfigSettings | None = None) -> str:
-    return maturin.build_sdist(sdist_directory, config_settings)
+    name = maturin.build_sdist(sdist_directory, config_settings)
+    if common_is_present():
+        vendor_into_sdist(Path(sdist_directory) / name)
+    return name
 
 
 def build_editable(
@@ -65,7 +66,7 @@ def build_editable(
     config_settings: ConfigSettings | None = None,
     metadata_directory: str | None = None,
 ) -> str:
-    return maturin.build_editable(wheel_directory, config_settings, metadata_directory)
+    return built(maturin.build_editable, wheel_directory, config_settings, metadata_directory, link_common_into_wheel)
 
 
 def get_requires_for_build_wheel(config_settings: ConfigSettings | None = None) -> list[str]:
@@ -80,6 +81,26 @@ def get_requires_for_build_editable(config_settings: ConfigSettings | None = Non
     return maturin.get_requires_for_build_editable(config_settings)
 
 
+def built(
+    build: Callable[[str, ConfigSettings | None, str | None], str],
+    wheel_directory: str,
+    config_settings: ConfigSettings | None,
+    metadata_directory: str | None,
+    carry: Callable[[Path], None],
+) -> str:
+    if not common_is_present():
+        return build(wheel_directory, config_settings, metadata_directory)
+    tmp = Path(mkdtemp())
+    name = build(str(tmp), config_settings, metadata_directory)
+    carry(tmp / name)
+    copy2(tmp / name, Path(wheel_directory) / name)
+    return name
+
+
+def common_is_present() -> bool:
+    return (_COMMON / "src" / _VENDOR).is_dir()
+
+
 def main() -> None:
     target = Path(argv[1])
     if not (wheels := sorted(target.glob("*.whl")) if target.is_dir() else [target]):
@@ -91,29 +112,27 @@ def main() -> None:
 
 
 def vendor_into_wheel(wheel: Path) -> None:
-    common_src = _COMMON / "src" / _VENDOR
+    at = f"{_MODULE}/_vendor/"
+    changed = {f"{at}__init__.py": b""} | {f"{at}{name}": data for name, data in common_sources()}
+    with ZipFile(wheel) as src:
+        if (entry := f"{_MODULE}/__main__.py") in src.namelist():
+            spelled = sub(rf"\b{_VENDOR}\b", f"{_MODULE}._vendor.{_VENDOR}", src.read(entry).decode())
+            changed[entry] = spelled.encode()
+    rewrite(wheel, changed)
 
+
+def link_common_into_wheel(wheel: Path) -> None:
+    # an editable install reads the package from the source tree, where the import stays unvendored
+    rewrite(wheel, {f"{_MODULE}_{_VENDOR}.pth": f"{_COMMON / 'src'}\n".encode()})
+
+
+def rewrite(wheel: Path, changed: dict[str, bytes]) -> None:
     with ZipFile(wheel) as src:
         names = src.namelist()
         dist_info = next(n for n in names if n.endswith(".dist-info/METADATA")).split("/")[0]
         out = {n: src.read(n) for n in names if not n.endswith("/RECORD")}
-
-    if (entry := f"{_MODULE}/__main__.py") in out:
-        out[entry] = sub(rf"\b{_VENDOR}\b", f"{_MODULE}._vendor.{_VENDOR}", out[entry].decode()).encode()
-    meta = f"{dist_info}/METADATA"
-    deps_block = search(r"(?ms)^dependencies = \[(.*?)\]", (_COMMON / "pyproject.toml").read_text())
-    deps = findall(r'"([^"]*)"', deps_block.group(1)) if deps_block else []
-    stripped = sub(r"(?m)^Requires-Dist: toml-fmt-common.*\n", "", out[meta].decode())
-    # Requires-Dist belongs in the header block; everything past the first blank line is the description
-    headers, sep, description = stripped.partition("\n\n")
-    parts = [headers.rstrip("\n"), *(f"\nRequires-Dist: {d}" for d in deps), sep, description]
-    out[meta] = "".join(parts).encode()
-
-    out[f"{_MODULE}/_vendor/__init__.py"] = b""
-    # vendor only the package's Python sources; local build artifacts (bytecode, caches, ext modules) never leak
-    for file in common_src.rglob("*"):
-        if file.is_file() and (file.suffix in {".py", ".pyi"} or file.name == "py.typed"):
-            out[f"{_MODULE}/_vendor/{file.relative_to(common_src.parent).as_posix()}"] = file.read_bytes()
+    out.update(changed)
+    out[f"{dist_info}/METADATA"] = own_metadata(out[f"{dist_info}/METADATA"])
 
     record = []
     for name, data in out.items():
@@ -125,6 +144,44 @@ def vendor_into_wheel(wheel: Path) -> None:
     with ZipFile(wheel, "w", ZIP_DEFLATED) as zf:
         for name, data in out.items():
             zf.writestr(name, data)
+
+
+def vendor_into_sdist(sdist: Path) -> None:
+    held = []
+    with tar_open(sdist) as src:
+        for member in src.getmembers():
+            content = src.extractfile(member)
+            held.append((member, content.read() if content else b""))
+    root = held[0][0].name.split("/")[0]
+
+    added = [(f"{root}/{_COMMON.name}/pyproject.toml", (_COMMON / "pyproject.toml").read_bytes())]
+    added += [(f"{root}/{_COMMON.name}/src/{name}", data) for name, data in common_sources()]
+
+    with tar_open(sdist, "w:gz") as out:
+        for member, data in held:
+            out.addfile(member, BytesIO(data) if member.isfile() else None)
+        for name, data in added:
+            info = TarInfo(name)
+            info.size = len(data)
+            info.mode = 0o644
+            out.addfile(info, BytesIO(data))
+
+
+def own_metadata(metadata: bytes) -> bytes:
+    deps_block = search(r"(?ms)^dependencies = \[(.*?)\]", (_COMMON / "pyproject.toml").read_text())
+    if not (deps := findall(r'"([^"]*)"', deps_block.group(1)) if deps_block else []):
+        return metadata
+    # Requires-Dist belongs in the header block; everything past the first blank line is the description
+    headers, sep, description = metadata.decode().partition("\n\n")
+    return "".join([headers.rstrip("\n"), *(f"\nRequires-Dist: {d}" for d in deps), sep, description]).encode()
+
+
+def common_sources() -> Iterator[tuple[str, bytes]]:
+    src = _COMMON / "src" / _VENDOR
+    # vendor only the package's Python sources; local build artifacts (bytecode, caches, ext modules) never leak
+    for file in sorted(src.rglob("*")):
+        if file.is_file() and (file.suffix in {".py", ".pyi"} or file.name == "py.typed"):
+            yield file.relative_to(src.parent).as_posix(), file.read_bytes()
 
 
 if __name__ == "__main__":

--- a/tox-toml-fmt/pyproject.toml
+++ b/tox-toml-fmt/pyproject.toml
@@ -34,9 +34,6 @@ classifiers = [
 dynamic = [
   "version",
 ]
-dependencies = [
-  "toml-fmt-common",
-]
 urls."Bug Tracker" = "https://github.com/tox-dev/toml-fmt/issues"
 urls."Source Code" = "https://github.com/tox-dev/toml-fmt/tree/main/tox-toml-fmt"
 urls.Changelog = "https://github.com/tox-dev/toml-fmt/releases?q=tox-toml-fmt"

--- a/tox-toml-fmt/tests/test_build_backend.py
+++ b/tox-toml-fmt/tests/test_build_backend.py
@@ -1,40 +1,52 @@
 from __future__ import annotations
 
+from io import BytesIO
 from pathlib import Path
 from runpy import run_path
 from sys import modules
+from tarfile import DIRTYPE, TarInfo
+from tarfile import open as tar_open
 from types import SimpleNamespace
-from typing import Final
+from typing import TYPE_CHECKING, Final, NamedTuple
 from zipfile import ZipFile
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 _BACKEND: Final[Path] = Path(__file__).parents[1] / "build_backend.py"
 _METADATA: Final[str] = """\
 Metadata-Version: 2.4
 Name: tox-toml-fmt
 Version: 0
-Requires-Dist: toml-fmt-common
 Description-Content-Type: text/markdown
 
 # tox-toml-fmt
 
 Format your TOML.
 """
+_SDIST_HELD: Final[bytes] = b'[project]\nname = "tox-toml-fmt"\n'
+
+
+class Backend(NamedTuple):
+    vendor_into_wheel: Callable[[Path], None]
+    link_common_into_wheel: Callable[[Path], None]
+    vendor_into_sdist: Callable[[Path], None]
 
 
 @pytest.fixture
-def wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+def backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Backend:
     monkeypatch.setitem(modules, "maturin", SimpleNamespace())
-    vendor = run_path(str(_BACKEND))["vendor_into_wheel"]
+    loaded = run_path(str(_BACKEND))
 
     common = tmp_path / "toml-fmt-common"
     src = common / "src" / "toml_fmt_common"
     src.mkdir(parents=True)
-    (src / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8")
-    (src / "_lib.pyi").write_text("VALUE: int\n", encoding="utf-8")
+    (src / "__init__.py").write_text("VALUE = 1\n", encoding="utf-8", newline="")
+    (src / "_lib.pyi").write_text("VALUE: int\n", encoding="utf-8", newline="")
     (src / "py.typed").write_text("", encoding="utf-8")
-    (common / "pyproject.toml").write_text('dependencies = [\n  "tomlkit>=0.13",\n]\n', encoding="utf-8")
+    (common / "pyproject.toml").write_text('dependencies = [\n  "tomlkit>=0.13",\n]\n', encoding="utf-8", newline="")
 
     cache = src / "__pycache__"
     cache.mkdir()
@@ -44,14 +56,44 @@ def wheel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     (src / "_speedups.so").write_bytes(b"\x7fELF")
     (src / ".DS_Store").write_bytes(b"junk")
 
+    monkeypatch.setitem(loaded["vendor_into_wheel"].__globals__, "_COMMON", common)
+    return Backend(loaded["vendor_into_wheel"], loaded["link_common_into_wheel"], loaded["vendor_into_sdist"])
+
+
+@pytest.fixture
+def unvendored(tmp_path: Path) -> Path:
     path = tmp_path / "tox_toml_fmt-0-py3-none-any.whl"
     with ZipFile(path, "w") as zf:
         zf.writestr("tox_toml_fmt/__main__.py", "import toml_fmt_common\n")
         zf.writestr("tox_toml_fmt-0.dist-info/METADATA", _METADATA)
         zf.writestr("tox_toml_fmt-0.dist-info/RECORD", "")
+    return path
 
-    monkeypatch.setitem(vendor.__globals__, "_COMMON", common)
-    vendor(path)
+
+@pytest.fixture
+def wheel(backend: Backend, unvendored: Path) -> Path:
+    backend.vendor_into_wheel(unvendored)
+    return unvendored
+
+
+@pytest.fixture
+def editable(backend: Backend, unvendored: Path) -> Path:
+    backend.link_common_into_wheel(unvendored)
+    return unvendored
+
+
+@pytest.fixture
+def sdist(backend: Backend, tmp_path: Path) -> Path:
+    path = tmp_path / "tox_toml_fmt-0.tar.gz"
+    root = TarInfo("tox_toml_fmt-0")
+    root.type = DIRTYPE
+    held = TarInfo("tox_toml_fmt-0/pyproject.toml")
+    held.size = len(_SDIST_HELD)
+    with tar_open(path, "w:gz") as tar:
+        tar.addfile(root)
+        tar.addfile(held, BytesIO(_SDIST_HELD))
+
+    backend.vendor_into_sdist(path)
     return path
 
 
@@ -79,3 +121,44 @@ def test_vendor_into_wheel_requires_dist_in_header(wheel: Path) -> None:
         "Requires-Dist: tomlkit>=0.13",
     ]
     assert description == "# tox-toml-fmt\n\nFormat your TOML.\n"
+
+
+def test_vendor_into_wheel_spells_the_entry_point_import_vendored(wheel: Path) -> None:
+    with ZipFile(wheel) as zf:
+        assert zf.read("tox_toml_fmt/__main__.py") == b"import tox_toml_fmt._vendor.toml_fmt_common\n"
+
+
+def test_link_common_into_wheel_points_at_the_source_tree(editable: Path, tmp_path: Path) -> None:
+    with ZipFile(editable) as zf:
+        assert zf.read("tox_toml_fmt_toml_fmt_common.pth").decode() == f"{tmp_path / 'toml-fmt-common' / 'src'}\n"
+
+
+def test_link_common_into_wheel_copies_nothing(editable: Path) -> None:
+    with ZipFile(editable) as zf:
+        assert [n for n in zf.namelist() if n.startswith("toml_fmt_common/")] == []
+
+
+def test_vendor_into_sdist_carries_common(sdist: Path) -> None:
+    with tar_open(sdist) as tar:
+        assert set(tar.getnames()) == {
+            "tox_toml_fmt-0",
+            "tox_toml_fmt-0/pyproject.toml",
+            "tox_toml_fmt-0/toml-fmt-common/pyproject.toml",
+            "tox_toml_fmt-0/toml-fmt-common/src/toml_fmt_common/__init__.py",
+            "tox_toml_fmt-0/toml-fmt-common/src/toml_fmt_common/_lib.pyi",
+            "tox_toml_fmt-0/toml-fmt-common/src/toml_fmt_common/py.typed",
+        }
+
+
+@pytest.mark.parametrize(
+    ("member", "content"),
+    [
+        pytest.param("pyproject.toml", _SDIST_HELD, id="held"),
+        pytest.param("toml-fmt-common/src/toml_fmt_common/__init__.py", b"VALUE = 1\n", id="added"),
+    ],
+)
+def test_vendor_into_sdist_content(sdist: Path, member: str, content: bytes) -> None:
+    with tar_open(sdist) as tar:
+        read = tar.extractfile(f"tox_toml_fmt-0/{member}")
+        assert read is not None
+        assert read.read() == content

--- a/tox-toml-fmt/tox.toml
+++ b/tox-toml-fmt/tox.toml
@@ -1,5 +1,5 @@
 requires = ["tox>=4.60", "tox-uv>=1.36"]
-env_list = ["fix", "3.15", "3.15t", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta"]
+env_list = ["fix", "3.15", "3.15t", "3.14", "3.13", "3.12", "3.11", "3.10", "type", "docs", "pkg_meta", "pkg_sdist"]
 skip_missing_interpreters = true
 
 [env_run_base]
@@ -50,6 +50,7 @@ set_env.MATURIN_PEP517_ARGS = "--no-default-features --features extension-module
 [env.type]
 description = "run type check on code base"
 dependency_groups = ["type"]
+set_env.MYPYPATH = "{tox_root}{/}..{/}toml-fmt-common{/}src"
 commands = [["mypy", "src{/}tox_toml_fmt"], ["mypy", "tests"]]
 
 [env.docs]
@@ -118,4 +119,16 @@ commands = [["python", "tasks{/}generate_readme.py", "tox-toml-fmt"]]
 description = "dev environment with all deps at {envdir}"
 package = "editable"
 dependency_groups = ["dev"]
-commands = [["uv", "pip", "tree"], ["python", "-c", 'print(r"{env_python}")']]
+commands = [
+    ["uv", "pip", "tree"],
+    ["python", "-c", "import toml_fmt_common"],
+    ["python", "-c", 'print(r"{env_python}")'],
+]
+
+[env.pkg_sdist]
+description = "build a wheel from the sdist and check it carries toml-fmt-common"
+runner = "uv-venv-runner"
+skip_install = true
+dependency_groups = []
+change_dir = "{tox_root}{/}.."
+commands = [["python", "tasks{/}check_sdist.py", "tox-toml-fmt"]]

--- a/uv.lock
+++ b/uv.lock
@@ -1401,9 +1401,6 @@ wheels = [
 [[package]]
 name = "pyproject-fmt"
 source = { editable = "pyproject-fmt" }
-dependencies = [
-    { name = "toml-fmt-common" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -1454,7 +1451,6 @@ type = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "toml-fmt-common", editable = "toml-fmt-common" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2121,9 +2117,6 @@ wheels = [
 [[package]]
 name = "tox-toml-fmt"
 source = { editable = "tox-toml-fmt" }
-dependencies = [
-    { name = "toml-fmt-common" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -2173,7 +2166,6 @@ type = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "toml-fmt-common", editable = "toml-fmt-common" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What broke

pyproject-fmt 2.29.0 and tox-toml-fmt 1.10.0 ship an sdist that declares `Requires-Dist: toml-fmt-common`. A build from it (a distro packager, `pip install --no-binary`, `pip install -e .`) resolves that name from PyPI, where the last upload is 1.3.5 from 2026-05-29. This tree's copy carries the same version number and over 400 different lines, so the install runs May's settings reader against August's formatter. #450 reports the 26 test failures that follow.

Vendoring ran in `build_wheel` alone, and only where `../toml-fmt-common/src/toml_fmt_common` sat beside the package:

```python
if not (_COMMON / "src" / _VENDOR).is_dir():  # no workspace (e.g. building from sdist)
    return maturin.build_wheel(...)
```

The sdist shipped the Rust `common/` crate without the Python sibling, so a build from it took that escape hatch and wrote an unvendored wheel. `build_editable` vendored nothing.

## Changes

- `build_sdist` writes toml-fmt-common's Python sources and its `pyproject.toml` into the tarball, so a wheel built from the sdist vendors like any other.
- `build_editable` adds a `.pth` naming toml-fmt-common's source directory, so an editable install reads the live sources rather than a published snapshot.
- `_MODULE` and `_COMMON` resolve in the sdist layout, where the backend sits at the tarball root rather than beside the package. `_MODULE` now reads the project name instead of the directory name, which in an sdist is `pyproject_fmt-2.29.0`.
- Both packages drop `dependencies = ["toml-fmt-common"]`, and the workspace drops the uv source that pointed it at the local member. Nothing resolves the published distribution now, and a vendor step that goes missing raises an ImportError instead of installing four-month-old code.

## Why CI missed it

The test environments install a wheel built from the working tree, where the sibling is present, so vendoring ran. `pkg_meta` built an sdist and then only linted its metadata with `twine check`. The `dev` environment built an editable install and never imported through it.

- `pkg_sdist` builds the sdist, builds a wheel from it, and fails if that wheel holds no `_vendor/toml_fmt_common` or still requires toml-fmt-common. It runs in the `check` matrix of both packages.
- `dev` runs `import toml_fmt_common`.

Fixes #450
