### PR TITLE
🐛 fix(build): vendor into the sdist a release builds

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -220,6 +220,17 @@ jobs:
         with:
           command: sdist
           args: -m ${{ inputs.package-name }}/Cargo.toml --out dist
+      - name: 📦 Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: 📦 Vendor toml-fmt-common into the sdist
+        # maturin sdist (run by maturin-action) skips PEP 517, so vendor via the backend's CLI
+        run: uv run --no-project "$PACKAGE/build_backend.py" dist
+        shell: bash
+        env:
+          PACKAGE: ${{ inputs.package-name }}
+      - name: ✅ Check the sdist carries toml-fmt-common
+        run: tar tzf dist/*.tar.gz | grep -q "toml-fmt-common/src/toml_fmt_common/__init__.py"
+        shell: bash
       - name: 📤 Upload sdist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/pyproject-fmt/build_backend.py
+++ b/pyproject-fmt/build_backend.py
@@ -103,12 +103,19 @@ def common_is_present() -> bool:
 
 def main() -> None:
     target = Path(argv[1])
-    if not (wheels := sorted(target.glob("*.whl")) if target.is_dir() else [target]):
-        print(f"no wheels found in {target}")
+    if not common_is_present():
+        print(f"no toml-fmt-common sources under {_COMMON}")
         raise SystemExit(1)
-    for wheel in wheels:
-        vendor_into_wheel(wheel)
-        print(f"vendored toml-fmt-common into {wheel.name}")
+    built = sorted(target.glob("*.whl")) + sorted(target.glob("*.tar.gz")) if target.is_dir() else [target]
+    if not built:
+        print(f"no wheel or sdist found in {target}")
+        raise SystemExit(1)
+    for path in built:
+        if path.suffix == ".whl":
+            vendor_into_wheel(path)
+        else:
+            vendor_into_sdist(path)
+        print(f"vendored toml-fmt-common into {path.name}")
 
 
 def vendor_into_wheel(wheel: Path) -> None:

--- a/pyproject-fmt/tests/test_build_backend.py
+++ b/pyproject-fmt/tests/test_build_backend.py
@@ -57,7 +57,11 @@ def backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Backend:
     (src / ".DS_Store").write_bytes(b"junk")
 
     monkeypatch.setitem(loaded["vendor_into_wheel"].__globals__, "_COMMON", common)
-    return Backend(loaded["vendor_into_wheel"], loaded["link_common_into_wheel"], loaded["vendor_into_sdist"])
+    return Backend(
+        loaded["vendor_into_wheel"],
+        loaded["link_common_into_wheel"],
+        loaded["vendor_into_sdist"],
+    )
 
 
 @pytest.fixture
@@ -83,7 +87,7 @@ def editable(backend: Backend, unvendored: Path) -> Path:
 
 
 @pytest.fixture
-def sdist(backend: Backend, tmp_path: Path) -> Path:
+def plain_sdist(tmp_path: Path) -> Path:
     path = tmp_path / "pyproject_fmt-0.tar.gz"
     root = TarInfo("pyproject_fmt-0")
     root.type = DIRTYPE
@@ -92,9 +96,13 @@ def sdist(backend: Backend, tmp_path: Path) -> Path:
     with tar_open(path, "w:gz") as tar:
         tar.addfile(root)
         tar.addfile(held, BytesIO(_SDIST_HELD))
-
-    backend.vendor_into_sdist(path)
     return path
+
+
+@pytest.fixture
+def sdist(backend: Backend, plain_sdist: Path) -> Path:
+    backend.vendor_into_sdist(plain_sdist)
+    return plain_sdist
 
 
 def test_vendor_into_wheel_ships_only_python_sources(wheel: Path) -> None:

--- a/tasks/check_sdist.py
+++ b/tasks/check_sdist.py
@@ -1,37 +1,62 @@
-"""Build a package from its own sdist and check the wheel that comes out carries toml-fmt-common."""
+"""Build a package the way each release path builds it and run what comes out with no index behind it."""
 
 from __future__ import annotations
 
 import subprocess
 import sys
 from pathlib import Path
+from tarfile import open as tar_open
 from tempfile import TemporaryDirectory
-from zipfile import ZipFile
 
 _ROOT = Path(__file__).resolve().parents[1]
+_CARRIED = "toml-fmt-common/src/toml_fmt_common/__init__.py"
 
 
 def main(package: str) -> None:
     with TemporaryDirectory() as folder:
-        out = Path(folder)
-        subprocess.check_call(["uv", "build", "--sdist", "--out-dir", str(out), str(_ROOT / package)])
-        sdist = next(out.glob("*.tar.gz"))
-        subprocess.check_call(["uv", "build", "--wheel", "--out-dir", str(out), str(sdist)])
-        check(next(out.glob("*.whl")), package.replace("-", "_"))
+        at = Path(folder)
+        released = maturin_sdist(package, at / "maturin")
+        for sdist in (pep517_sdist(package, at / "pep517"), released):
+            carries_common(sdist)
+        runs_on_its_own(package, wheel_from(released, at / "wheel"), at / "venv")
 
 
-def check(wheel: Path, module: str) -> None:
-    with ZipFile(wheel) as zf:
-        names = zf.namelist()
-        metadata = zf.read(next(n for n in names if n.endswith(".dist-info/METADATA"))).decode()
+def maturin_sdist(package: str, at: Path) -> Path:
+    # a release builds the sdist through maturin-action, which never reaches the PEP 517 hooks
+    manifest = _ROOT / package / "Cargo.toml"
+    run("uv", "run", "--no-project", "--with", "maturin", "maturin", "sdist", "-m", str(manifest), "--out", str(at))
+    run("uv", "run", "--no-project", str(_ROOT / package / "build_backend.py"), str(at))
+    return next(at.glob("*.tar.gz"))
 
-    if (vendored := f"{module}/_vendor/toml_fmt_common/__init__.py") not in names:
-        print(f"{wheel.name} built from the sdist holds no {vendored}")
-        sys.exit(1)
-    if "Requires-Dist: toml-fmt-common" in metadata:
-        print(f"{wheel.name} built from the sdist still requires toml-fmt-common")
-        sys.exit(1)
-    print(f"{wheel.name} built from the sdist carries toml-fmt-common")
+
+def pep517_sdist(package: str, at: Path) -> Path:
+    run("uv", "build", "--sdist", "--out-dir", str(at), str(_ROOT / package))
+    return next(at.glob("*.tar.gz"))
+
+
+def carries_common(sdist: Path) -> None:
+    with tar_open(sdist) as tar:
+        if not [name for name in tar.getnames() if name.endswith(_CARRIED)]:
+            print(f"{sdist.name} holds no {_CARRIED}")
+            sys.exit(1)
+
+
+def wheel_from(sdist: Path, at: Path) -> Path:
+    run("uv", "build", "--wheel", "--out-dir", str(at), str(sdist))
+    return next(at.glob("*.whl"))
+
+
+def runs_on_its_own(package: str, wheel: Path, venv: Path) -> None:
+    run("uv", "venv", str(venv))
+    scripts = venv / ("Scripts" if sys.platform == "win32" else "bin")
+    # --no-index leaves nothing to fall back on, so an unvendored wheel cannot install or import
+    run("uv", "pip", "install", "--no-index", "--python", str(scripts / "python"), str(wheel))
+    run(str(scripts / package), "--version")
+    print(f"{wheel.name} built from the sdist runs with no index behind it")
+
+
+def run(*command: str) -> None:
+    subprocess.check_call(command)
 
 
 if __name__ == "__main__":

--- a/tox-toml-fmt/build_backend.py
+++ b/tox-toml-fmt/build_backend.py
@@ -103,12 +103,19 @@ def common_is_present() -> bool:
 
 def main() -> None:
     target = Path(argv[1])
-    if not (wheels := sorted(target.glob("*.whl")) if target.is_dir() else [target]):
-        print(f"no wheels found in {target}")
+    if not common_is_present():
+        print(f"no toml-fmt-common sources under {_COMMON}")
         raise SystemExit(1)
-    for wheel in wheels:
-        vendor_into_wheel(wheel)
-        print(f"vendored toml-fmt-common into {wheel.name}")
+    built = sorted(target.glob("*.whl")) + sorted(target.glob("*.tar.gz")) if target.is_dir() else [target]
+    if not built:
+        print(f"no wheel or sdist found in {target}")
+        raise SystemExit(1)
+    for path in built:
+        if path.suffix == ".whl":
+            vendor_into_wheel(path)
+        else:
+            vendor_into_sdist(path)
+        print(f"vendored toml-fmt-common into {path.name}")
 
 
 def vendor_into_wheel(wheel: Path) -> None:

--- a/tox-toml-fmt/tests/test_build_backend.py
+++ b/tox-toml-fmt/tests/test_build_backend.py
@@ -57,7 +57,11 @@ def backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Backend:
     (src / ".DS_Store").write_bytes(b"junk")
 
     monkeypatch.setitem(loaded["vendor_into_wheel"].__globals__, "_COMMON", common)
-    return Backend(loaded["vendor_into_wheel"], loaded["link_common_into_wheel"], loaded["vendor_into_sdist"])
+    return Backend(
+        loaded["vendor_into_wheel"],
+        loaded["link_common_into_wheel"],
+        loaded["vendor_into_sdist"],
+    )
 
 
 @pytest.fixture
@@ -83,7 +87,7 @@ def editable(backend: Backend, unvendored: Path) -> Path:
 
 
 @pytest.fixture
-def sdist(backend: Backend, tmp_path: Path) -> Path:
+def plain_sdist(tmp_path: Path) -> Path:
     path = tmp_path / "tox_toml_fmt-0.tar.gz"
     root = TarInfo("tox_toml_fmt-0")
     root.type = DIRTYPE
@@ -92,9 +96,13 @@ def sdist(backend: Backend, tmp_path: Path) -> Path:
     with tar_open(path, "w:gz") as tar:
         tar.addfile(root)
         tar.addfile(held, BytesIO(_SDIST_HELD))
-
-    backend.vendor_into_sdist(path)
     return path
+
+
+@pytest.fixture
+def sdist(backend: Backend, plain_sdist: Path) -> Path:
+    backend.vendor_into_sdist(plain_sdist)
+    return plain_sdist
 
 
 def test_vendor_into_wheel_ships_only_python_sources(wheel: Path) -> None:


### PR DESCRIPTION
pyproject-fmt 2.29.1 and tox-toml-fmt 1.10.1 ship an sdist that carries no `toml-fmt-common` and no dependency naming one, so a wheel built from either fails to import. The wheels on PyPI hold their vendored copy and install as before.

#451 removed the dependency and vendored toml-fmt-common in the PEP 517 `build_sdist` hook. A release stops short of that hook, building the sdist through maturin-action, the same bypass the wheel jobs work around by running the backend's CLI afterwards (`_build.yaml:120`). The sdist job had no such step, so what got published skipped the vendoring.

## Changes

- The backend CLI patches a tarball as well as a wheel, and exits where the sources it vendors are missing rather than write an artifact that imports nothing.
- The sdist job runs that CLI and then reads the tarball back to confirm the sources landed.

## The gate

`pkg_sdist` built the sdist with `uv build`, which does reach the hook, so it passed on a path no release takes. It now builds the sdist both ways and runs the release one end to end:

```
maturin sdist → build_backend.py → wheel → empty venv, --no-index → pyproject-fmt --version
```

`--no-index` leaves nothing to fall back on, so a wheel whose common went missing cannot install or import. Against the code this PR fixes, the check fails at the first step.
