### PR TITLE
🔧 chore(ci): build the sdist through PEP 517

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -215,22 +215,14 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: source
-      - name: 📦 Build sdist
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-        with:
-          command: sdist
-          args: -m ${{ inputs.package-name }}/Cargo.toml --out dist
       - name: 📦 Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-      - name: 📦 Vendor toml-fmt-common into the sdist
-        # maturin sdist (run by maturin-action) skips PEP 517, so vendor via the backend's CLI
-        run: uv run --no-project "$PACKAGE/build_backend.py" dist
+      - name: 📦 Build sdist
+        # an sdist compiles nothing, so it goes through PEP 517 and the backend vendors toml-fmt-common
+        run: uv build --sdist --out-dir dist "$PACKAGE"
         shell: bash
         env:
           PACKAGE: ${{ inputs.package-name }}
-      - name: ✅ Check the sdist carries toml-fmt-common
-        run: tar tzf dist/*.tar.gz | grep -q "toml-fmt-common/src/toml_fmt_common/__init__.py"
-        shell: bash
       - name: 📤 Upload sdist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/pyproject-fmt/build_backend.py
+++ b/pyproject-fmt/build_backend.py
@@ -106,16 +106,12 @@ def main() -> None:
     if not common_is_present():
         print(f"no toml-fmt-common sources under {_COMMON}")
         raise SystemExit(1)
-    built = sorted(target.glob("*.whl")) + sorted(target.glob("*.tar.gz")) if target.is_dir() else [target]
-    if not built:
-        print(f"no wheel or sdist found in {target}")
+    if not (wheels := sorted(target.glob("*.whl")) if target.is_dir() else [target]):
+        print(f"no wheels found in {target}")
         raise SystemExit(1)
-    for path in built:
-        if path.suffix == ".whl":
-            vendor_into_wheel(path)
-        else:
-            vendor_into_sdist(path)
-        print(f"vendored toml-fmt-common into {path.name}")
+    for wheel in wheels:
+        vendor_into_wheel(wheel)
+        print(f"vendored toml-fmt-common into {wheel.name}")
 
 
 def vendor_into_wheel(wheel: Path) -> None:

--- a/tasks/check_sdist.py
+++ b/tasks/check_sdist.py
@@ -1,4 +1,4 @@
-"""Build a package the way each release path builds it and run what comes out with no index behind it."""
+"""Build a package the way a release builds it and run what comes out with no index behind it."""
 
 from __future__ import annotations
 
@@ -15,21 +15,12 @@ _CARRIED = "toml-fmt-common/src/toml_fmt_common/__init__.py"
 def main(package: str) -> None:
     with TemporaryDirectory() as folder:
         at = Path(folder)
-        released = maturin_sdist(package, at / "maturin")
-        for sdist in (pep517_sdist(package, at / "pep517"), released):
-            carries_common(sdist)
-        runs_on_its_own(package, wheel_from(released, at / "wheel"), at / "venv")
+        sdist = build_sdist(package, at / "sdist")
+        carries_common(sdist)
+        runs_on_its_own(package, wheel_from(sdist, at / "wheel"), at / "venv")
 
 
-def maturin_sdist(package: str, at: Path) -> Path:
-    # a release builds the sdist through maturin-action, which never reaches the PEP 517 hooks
-    manifest = _ROOT / package / "Cargo.toml"
-    run("uv", "run", "--no-project", "--with", "maturin", "maturin", "sdist", "-m", str(manifest), "--out", str(at))
-    run("uv", "run", "--no-project", str(_ROOT / package / "build_backend.py"), str(at))
-    return next(at.glob("*.tar.gz"))
-
-
-def pep517_sdist(package: str, at: Path) -> Path:
+def build_sdist(package: str, at: Path) -> Path:
     run("uv", "build", "--sdist", "--out-dir", str(at), str(_ROOT / package))
     return next(at.glob("*.tar.gz"))
 

--- a/tox-toml-fmt/build_backend.py
+++ b/tox-toml-fmt/build_backend.py
@@ -106,16 +106,12 @@ def main() -> None:
     if not common_is_present():
         print(f"no toml-fmt-common sources under {_COMMON}")
         raise SystemExit(1)
-    built = sorted(target.glob("*.whl")) + sorted(target.glob("*.tar.gz")) if target.is_dir() else [target]
-    if not built:
-        print(f"no wheel or sdist found in {target}")
+    if not (wheels := sorted(target.glob("*.whl")) if target.is_dir() else [target]):
+        print(f"no wheels found in {target}")
         raise SystemExit(1)
-    for path in built:
-        if path.suffix == ".whl":
-            vendor_into_wheel(path)
-        else:
-            vendor_into_sdist(path)
-        print(f"vendored toml-fmt-common into {path.name}")
+    for wheel in wheels:
+        vendor_into_wheel(wheel)
+        print(f"vendored toml-fmt-common into {wheel.name}")
 
 
 def vendor_into_wheel(wheel: Path) -> None:


### PR DESCRIPTION
An sdist compiles nothing, so building it through maturin-action bought nothing beyond a bypass of the PEP 517 hooks that vendor toml-fmt-common. That bypass shipped a broken sdist in 2.29.1 and 1.10.1, and #452 answered it with a step running the backend CLI over the tarball afterwards.

`uv build --sdist` reaches `build_sdist`, so the vendoring holds by construction instead of resting on a step someone has to remember to keep beside the build.

## Changes

- The sdist job builds with `uv build --sdist`, and drops the backend CLI call and the tarball assertion that stood in for the hook.
- The backend CLI patches wheels again, where cross-compilation leaves maturin-action no way through PEP 517.
- `check_sdist.py` builds one sdist rather than two, since one path remains.

The end-to-end check still proves the same thing: sdist, then a wheel built from it, then an empty environment with `--no-index` where the console script has to run on what the wheel alone carries.
