### PR TITLE
Update Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -411,7 +411,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 lexical-sort = { version = "0.3.1" } # the natural order names sort in
 regex = { version = "1.13.1" }
 toml-doc = { path = "../toml-doc" }
-unicode-segmentation = { version = "1.13.0" } # where a line may break, which is between graphemes
+unicode-segmentation = { version = "1.13.3" } # where a line may break, which is between graphemes
 unicode-width = { version = "0.2.2" }         # how many columns the text takes to write
 # handing the settings a file writes to the Python wrappers, which read them with this parser
 # rather than a second one of an older TOML


### PR DESCRIPTION
Automated Rust dependency update.

- Updated `Cargo.lock` with latest compatible versions