### PR TITLE
🐛 fix(build): read the project metadata from the sdist

### DIFF
--- a/pyproject-fmt/build_backend.py
+++ b/pyproject-fmt/build_backend.py
@@ -40,7 +40,9 @@ if TYPE_CHECKING:
 environ.setdefault("MATURIN_NO_MISSING_BUILD_BACKEND_WARNING", "1")
 
 _HERE = Path(__file__).resolve().parent
-_MODULE = findall(r'(?m)^name = "(.*)"', (_HERE / "pyproject.toml").read_text())[0].replace("-", "_")
+# the sdist keeps a copy of this file beside the tests, a directory below the pyproject.toml it belongs to
+_OWN = next(p for p in (_HERE / "pyproject.toml", _HERE.parent / "pyproject.toml") if p.is_file())
+_MODULE = findall(r'(?m)^name = "(.*)"', _OWN.read_text())[0].replace("-", "_")
 _VENDOR = "toml_fmt_common"
 # a checkout keeps toml-fmt-common beside the package; the sdist carries it within
 _COMMON = _HERE / "toml-fmt-common" if (_HERE / "toml-fmt-common").is_dir() else _HERE.parent / "toml-fmt-common"

--- a/pyproject-fmt/tox.toml
+++ b/pyproject-fmt/tox.toml
@@ -126,9 +126,9 @@ commands = [
 ]
 
 [env.pkg_sdist]
-description = "build a wheel from the sdist and check it carries toml-fmt-common"
+description = "build the sdist, then install and test it the way a packager does"
 runner = "uv-venv-runner"
 skip_install = true
-dependency_groups = []
+dependency_groups = ["test"]
 change_dir = "{tox_root}{/}.."
 commands = [["python", "tasks{/}check_sdist.py", "pyproject-fmt"]]

--- a/tasks/check_sdist.py
+++ b/tasks/check_sdist.py
@@ -1,4 +1,4 @@
-"""Build a package the way a release builds it and run what comes out with no index behind it."""
+"""Build a package the way a release builds it, then use it the way a packager does."""
 
 from __future__ import annotations
 
@@ -17,7 +17,8 @@ def main(package: str) -> None:
         at = Path(folder)
         sdist = build_sdist(package, at / "sdist")
         carries_common(sdist)
-        runs_on_its_own(package, wheel_from(sdist, at / "wheel"), at / "venv")
+        runs_on_its_own(package, wheel_from(sdist, at / "wheel"))
+        ships_a_suite_that_passes(package, sdist, at / "unpacked")
 
 
 def build_sdist(package: str, at: Path) -> Path:
@@ -37,17 +38,27 @@ def wheel_from(sdist: Path, at: Path) -> Path:
     return next(at.glob("*.whl"))
 
 
-def runs_on_its_own(package: str, wheel: Path, venv: Path) -> None:
-    run("uv", "venv", str(venv))
-    scripts = venv / ("Scripts" if sys.platform == "win32" else "bin")
+def runs_on_its_own(package: str, wheel: Path) -> None:
     # --no-index leaves nothing to fall back on, so an unvendored wheel cannot install or import
-    run("uv", "pip", "install", "--no-index", "--python", str(scripts / "python"), str(wheel))
-    run(str(scripts / package), "--version")
+    run("uv", "pip", "install", "--python", sys.executable, "--no-index", str(wheel))
+    run(str(Path(sys.executable).parent / package), "--version")
     print(f"{wheel.name} built from the sdist runs with no index behind it")
 
 
-def run(*command: str) -> None:
-    subprocess.check_call(command)
+def ships_a_suite_that_passes(package: str, sdist: Path, at: Path) -> None:
+    # what a packager runs: unpack the sdist, install it, run the suite it ships
+    at.mkdir()
+    with tar_open(sdist) as tar:
+        tar.extractall(at, filter="data")
+    root = next(at.iterdir())
+
+    run("uv", "pip", "install", "--python", sys.executable, "-e", ".", at=root)
+    run(sys.executable, "-m", "pytest", package, at=root)
+    print(f"{sdist.name} passes the suite it ships")
+
+
+def run(*command: str, at: Path | None = None) -> None:
+    subprocess.check_call(command, cwd=at)
 
 
 if __name__ == "__main__":

--- a/tox-toml-fmt/build_backend.py
+++ b/tox-toml-fmt/build_backend.py
@@ -40,7 +40,9 @@ if TYPE_CHECKING:
 environ.setdefault("MATURIN_NO_MISSING_BUILD_BACKEND_WARNING", "1")
 
 _HERE = Path(__file__).resolve().parent
-_MODULE = findall(r'(?m)^name = "(.*)"', (_HERE / "pyproject.toml").read_text())[0].replace("-", "_")
+# the sdist keeps a copy of this file beside the tests, a directory below the pyproject.toml it belongs to
+_OWN = next(p for p in (_HERE / "pyproject.toml", _HERE.parent / "pyproject.toml") if p.is_file())
+_MODULE = findall(r'(?m)^name = "(.*)"', _OWN.read_text())[0].replace("-", "_")
 _VENDOR = "toml_fmt_common"
 # a checkout keeps toml-fmt-common beside the package; the sdist carries it within
 _COMMON = _HERE / "toml-fmt-common" if (_HERE / "toml-fmt-common").is_dir() else _HERE.parent / "toml-fmt-common"

--- a/tox-toml-fmt/tox.toml
+++ b/tox-toml-fmt/tox.toml
@@ -126,9 +126,9 @@ commands = [
 ]
 
 [env.pkg_sdist]
-description = "build a wheel from the sdist and check it carries toml-fmt-common"
+description = "build the sdist, then install and test it the way a packager does"
 runner = "uv-venv-runner"
 skip_install = true
-dependency_groups = []
+dependency_groups = ["test"]
 change_dir = "{tox_root}{/}.."
 commands = [["python", "tasks{/}check_sdist.py", "tox-toml-fmt"]]


### PR DESCRIPTION
`pytest` against an unpacked 2.29.2 sdist ends with eight errors, all of them `FileNotFoundError` on `pyproject-fmt/pyproject.toml` ([#454](https://github.com/tox-dev/toml-fmt/issues/454)).

maturin hoists the package's `pyproject.toml` to the root of the tarball and ships a copy of `build_backend.py` under `pyproject-fmt/`, beside the tests. #451 made the backend read that file from beside itself, which holds in a checkout and in the tarball root, and holds nowhere in the directory the tests load it from. The backend reads it from either place.

## The check that surfaced it

`pkg_sdist` built the sdist, built a wheel from it, installed that with `--no-index` and ran the console script. It proved the artifact installs. It never ran the suite the sdist ships, which is what a packager does and what the report in #450 spelled out.

It now ends with those steps: unpack the sdist, install it, run the suite it carries. tox supplies the environment and the test group, so the check installs into the interpreter it already runs under rather than building an environment of its own.

Against the code this PR fixes the check ends:

```
======================== 73 passed, 8 errors in 0.79s ========================
```

the same eight ids #454 lists. With the fix, 81 pass, and 60 for tox-toml-fmt.

Fixes #454
