### PR TITLE
🐛 fix(pyproject-fmt): bump the newest Python the default names

### DIFF
--- a/.github/workflows/python_versions.yaml
+++ b/.github/workflows/python_versions.yaml
@@ -1,0 +1,44 @@
+name: 🐍 python versions
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
+permissions: {}
+jobs:
+  bump:
+    name: ⬆️ bump
+    runs-on: ubuntu-24.04
+    environment: update-deps
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: 🐍 Setup uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: ⬆️ Set the releases the defaults name
+        run: uv run tasks/python_versions.py
+      - name: 🎨 Run prek
+        run: uvx prek run --all-files || true
+      - name: 🔀 Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          commit-message: "Set the Python releases the defaults name"
+          title: "Set the Python releases the defaults name"
+          body: |
+            The newest release the defaults name has to satisfy two things at once: PyPI publishes
+            a classifier for it, and Python has published a release candidate. A classifier appears
+            while a release is still changing, and a candidate PyPI has no classifier for is one no
+            upload may carry, so neither alone is enough.
+
+            The oldest comes from the release cycles still carrying fixes.
+
+            Each run reads what is true that day rather than any date published ahead of it, so a
+            release that slips arrives when it arrives. Anyone naming `max_supported_python`
+            themselves keeps what they set.
+          branch: update-python-versions
+          delete-branch: true

--- a/pyproject-fmt/README.rst
+++ b/pyproject-fmt/README.rst
@@ -58,7 +58,7 @@ Put per-file settings in ``[tool.pyproject-fmt]``:
     indent = 2
     keep_full_version = false
     generate_python_version_classifiers = true
-    max_supported_python = "3.14"
+    max_supported_python = "3.15"
     table_format = "short"
     sub_table_spacing = ""
     separate_root_table = "\n"
@@ -84,7 +84,7 @@ A standalone ``pyproject-fmt.toml`` can hold settings for several projects. The 
     column_width = 120
     indent = 2
     table_format = "short"
-    max_supported_python = "3.14"
+    max_supported_python = "3.15"
 
 For each input, the formatter searches from the input's directory toward the filesystem root and uses the nearest
 ``pyproject-fmt.toml``. ``--config`` selects a file directly:
@@ -622,7 +622,7 @@ at whitespace; without it, installers read the ``;`` and the marker as part of t
    [project]
    optional-dependencies.dev-tools = [ "pytest" ]
 
-**Python version classifiers** derive from ``requires-python`` and ``max_supported_python`` (here ``3.14``).
+**Python version classifiers** derive from ``requires-python`` and ``max_supported_python`` (here ``3.15``).
 Disable generation with ``generate_python_version_classifiers = false``:
 
 .. code-block:: toml
@@ -641,6 +641,7 @@ Disable generation with ``generate_python_version_classifiers = false``:
      "Programming Language :: Python :: 3.12",
      "Programming Language :: Python :: 3.13",
      "Programming Language :: Python :: 3.14",
+     "Programming Language :: Python :: 3.15",
    ]
 
 **Entry points:** inline tables within ``entry-points`` expand to dotted keys:

--- a/pyproject-fmt/docs/configuration.rst
+++ b/pyproject-fmt/docs/configuration.rst
@@ -13,7 +13,7 @@ Put per-file settings in ``[tool.pyproject-fmt]``:
     indent = 2
     keep_full_version = false
     generate_python_version_classifiers = true
-    max_supported_python = "3.14"
+    max_supported_python = "3.15"
     table_format = "short"
     sub_table_spacing = ""
     separate_root_table = "\n"
@@ -39,7 +39,7 @@ A standalone ``pyproject-fmt.toml`` can hold settings for several projects. The 
     column_width = 120
     indent = 2
     table_format = "short"
-    max_supported_python = "3.14"
+    max_supported_python = "3.15"
 
 For each input, the formatter searches from the input's directory toward the filesystem root and uses the nearest
 ``pyproject-fmt.toml``. ``--config`` selects a file directly:

--- a/pyproject-fmt/docs/formatting.rst
+++ b/pyproject-fmt/docs/formatting.rst
@@ -362,7 +362,7 @@ keywords, and validates the version.
         [project.optional-dependencies]
         Dev_Tools = ["pytest"]
 
-    **Python version classifiers** derive from ``requires-python`` and ``max_supported_python`` (here ``3.14``).
+    **Python version classifiers** derive from ``requires-python`` and ``max_supported_python`` (here ``3.15``).
     Disable generation with ``generate_python_version_classifiers = false``:
 
     .. fmt-example::

--- a/pyproject-fmt/pyproject.toml
+++ b/pyproject-fmt/pyproject.toml
@@ -52,6 +52,7 @@ test = [
   "pytest-cov>=7.1",
   "pytest-mock>=3.15.1",
   "tomli>=2.4.1; python_version<'3.11'",
+  "trove-classifiers>=2026.6.1.19",
 ]
 type = [
   "mypy==2.3.1",

--- a/pyproject-fmt/src/pyproject_fmt/__main__.py
+++ b/pyproject-fmt/src/pyproject_fmt/__main__.py
@@ -59,7 +59,7 @@ class _PyProjectFormatter(TOMLFormatter[_PyProjectFmtNamespace]):
             "--max-supported-python",
             metavar="major.minor",
             type=_version_argument,
-            default=(3, 14),
+            default=(3, 15),
             help="latest Python version the project supports (e.g. 3.14)",
         )
 

--- a/pyproject-fmt/tests/test_main.py
+++ b/pyproject-fmt/tests/test_main.py
@@ -10,12 +10,39 @@ else:  # pragma: <3.11 cover
     import tomli as tomllib
 
 import pytest
+from trove_classifiers import classifiers
 
 from pyproject_fmt import build_parser, run
 
 
 def test_build_parser_uses_program_name() -> None:
     assert build_parser().prog == "pyproject-fmt"
+
+
+def test_the_default_max_supported_python_names_a_published_classifier() -> None:
+    """PyPI turns away an upload naming a classifier it does not publish, so the default writes none."""
+    major, minor = build_parser().get_default("max_supported_python")
+
+    assert f"Programming Language :: Python :: {major}.{minor}" in classifiers
+
+
+def test_the_default_max_supported_python_trails_the_newest_classifier_by_one() -> None:
+    """
+    A classifier is published while its release is still in beta, so the newest one runs a release
+    ahead of the newest that ships. Two ahead says a release has shipped that the default leaves out,
+    which is what asks for the bump.
+    """
+    major, minor = build_parser().get_default("max_supported_python")
+    published = max(
+        int(held)
+        for name in classifiers
+        if (held := name.removeprefix(f"Programming Language :: Python :: {major}.")).isdigit()
+        and name.startswith(f"Programming Language :: Python :: {major}.")
+    )
+
+    assert published - minor <= 1, (
+        f"Python {major}.{published} has a classifier, so the default may name {major}.{published - 1}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tasks/fmt_examples.py
+++ b/tasks/fmt_examples.py
@@ -16,7 +16,7 @@ _DEFAULTS: Final[Mapping[str, Mapping[str, _Setting]]] = {
         "column_width": 120,
         "indent": 2,
         "keep_full_version": False,
-        "max_supported_python": (3, 14),
+        "max_supported_python": (3, 15),
         "min_supported_python": (3, 10),
         "generate_python_version_classifiers": True,
         "table_format": "short",

--- a/tasks/python_versions.py
+++ b/tasks/python_versions.py
@@ -1,0 +1,155 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["trove-classifiers>=2026.6.1.19"]
+# ///
+"""
+The Python releases the formatter's defaults stand for.
+
+The two ends answer different questions and are read from different places. The newest release a
+project may be given a classifier for has to satisfy two things at once: PyPI publishes a classifier
+naming it, and it has reached its release candidate. Either alone says too little, since a
+classifier appears while a release is still changing and a candidate PyPI has no classifier for
+cannot be written down. The oldest is the one still carrying fixes, which a classifier outlives by
+years and so cannot say.
+
+Nothing here is predicted. Each run reads what is true that day and writes down the numbers, so a
+release that slips arrives when it arrives. Someone naming `max_supported_python` themselves is
+saying what their own project supports, which no rule here overrides.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final
+
+from trove_classifiers import classifiers
+
+_ROOT: Final[Path] = Path(__file__).resolve().parents[1]
+_MAJOR: Final[int] = 3
+
+
+def main(*, check: bool) -> None:
+    places = written_places(newest_candidate(), oldest_supported())
+    drifted = [(place, said) for place in places if (said := place.said()) != place.spelling]
+    if not drifted:
+        print(f"the defaults name {_MAJOR}.{places[-1].minor} through {_MAJOR}.{places[0].minor}")
+        return
+    for place, said in drifted:
+        print(f"{place.path.relative_to(_ROOT)}: {said} -> {place.spelling}")
+    if check:
+        sys.exit(1)
+    for place, said in drifted:
+        place.write(said)
+
+
+def newest_candidate() -> int:
+    """
+    The newest release both PyPI and Python itself have got to: a classifier naming it, and a
+    release candidate published.
+
+    A release still in alpha or beta is one whose own behavior is still moving, so a project saying
+    it runs there says more than it knows. A candidate PyPI publishes no classifier for is one no
+    project can name, since an upload carrying an unknown classifier is turned away.
+    """
+    return max(with_a_candidate() & with_a_classifier())
+
+
+def with_a_candidate() -> set[int]:
+    """The releases Python has published a candidate for."""
+    released = fetch("https://www.python.org/api/v2/downloads/release/?is_published=true")
+    named = re.compile(rf"^Python {_MAJOR}\.(\d+)\.\d+rc\d+$")
+    return {int(found[1]) for release in released if (found := named.match(release["name"]))}
+
+
+def with_a_classifier() -> set[int]:
+    """The releases PyPI publishes a classifier for."""
+    prefix = f"Programming Language :: Python :: {_MAJOR}."
+    return {
+        int(minor) for name in classifiers if name.startswith(prefix) and (minor := name.removeprefix(prefix)).isdigit()
+    }
+
+
+def oldest_supported() -> int:
+    """The oldest release still carrying fixes, which is the oldest the formatter writes for."""
+    today = datetime.now(tz=UTC).date().isoformat()
+    cycles = fetch("https://endoflife.date/api/python.json")
+    live = (row for row in cycles if isinstance(row["eol"], str) and row["eol"] > today)
+    return min(int(row["cycle"].split(".")[1]) for row in live)
+
+
+def fetch(url: str) -> list[dict[str, str]]:
+    with urllib.request.urlopen(url, timeout=30) as response:  # ruff: ignore[suspicious-url-open-usage]  # a named host
+        return json.load(response)
+
+
+def written_places(newest: int, oldest: int) -> list[Place]:
+    """Every file that spells either release, the newest ones first."""
+    spelled = [
+        ("pyproject-fmt/src/pyproject_fmt/__main__.py", r"default=\(\d+, \d+\)", f"default=({_MAJOR}, {newest})"),
+        (
+            "tasks/fmt_examples.py",
+            r'"max_supported_python": \(\d+, \d+\)',
+            f'"max_supported_python": ({_MAJOR}, {newest})',
+        ),
+        (
+            "pyproject-fmt/pyproject.toml",
+            r'max_supported_python = "\d+\.\d+"',
+            f'max_supported_python = "{_MAJOR}.{newest}"',
+        ),
+        (
+            "tox-toml-fmt/pyproject.toml",
+            r'max_supported_python = "\d+\.\d+"',
+            f'max_supported_python = "{_MAJOR}.{newest}"',
+        ),
+        (
+            "pyproject-fmt/docs/configuration.rst",
+            r'max_supported_python = "\d+\.\d+"',
+            f'max_supported_python = "{_MAJOR}.{newest}"',
+        ),
+        (
+            "pyproject-fmt/docs/formatting.rst",
+            r"``max_supported_python`` \(here ``\d+\.\d+``\)",
+            f"``max_supported_python`` (here ``{_MAJOR}.{newest}``)",
+        ),
+    ]
+    places = [Place(_ROOT / name, pattern, newest, spelling) for name, pattern, spelling in spelled]
+    places.append(
+        Place(
+            _ROOT / "pyproject-fmt/src/pyproject_fmt/__main__.py",
+            r"_MIN_SUPPORTED_PYTHON: Final\[tuple\[int, int\]\] = \(_PYTHON_MAJOR, \d+\)",
+            oldest,
+            f"_MIN_SUPPORTED_PYTHON: Final[tuple[int, int]] = (_PYTHON_MAJOR, {oldest})",
+        )
+    )
+    return places
+
+
+@dataclass(frozen=True)
+class Place:
+    """One spelling of a release, in the file that writes it."""
+
+    path: Path
+    pattern: str
+    minor: int
+    spelling: str
+
+    def said(self) -> str:
+        """What the file writes there, which a run holds against the spelling it should write."""
+        found = re.search(self.pattern, self.path.read_text(encoding="utf-8"))
+        if found is None:
+            print(f"{self.path.relative_to(_ROOT)}: nothing matches {self.pattern}")
+            sys.exit(1)
+        return found.group(0)
+
+    def write(self, said: str) -> None:
+        self.path.write_text(self.path.read_text(encoding="utf-8").replace(said, self.spelling), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main(check="--check" in sys.argv[1:])

--- a/uv.lock
+++ b/uv.lock
@@ -1408,6 +1408,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "trove-classifiers" },
     { name = "types-cachetools" },
     { name = "types-chardet" },
 ]
@@ -1435,6 +1436,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "trove-classifiers" },
 ]
 type = [
     { name = "covdefaults" },
@@ -1443,6 +1445,7 @@ type = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "trove-classifiers" },
     { name = "types-cachetools" },
     { name = "types-chardet" },
 ]
@@ -1458,6 +1461,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.1" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.4.1" },
+    { name = "trove-classifiers", specifier = ">=2026.6.1.19" },
     { name = "types-cachetools", specifier = ">=7.0.0.20260713" },
     { name = "types-chardet", specifier = ">=5.0.4.6" },
 ]
@@ -1483,6 +1487,7 @@ test = [
     { name = "pytest-cov", specifier = ">=7.1" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.4.1" },
+    { name = "trove-classifiers", specifier = ">=2026.6.1.19" },
 ]
 type = [
     { name = "covdefaults", specifier = ">=2.3" },
@@ -1491,6 +1496,7 @@ type = [
     { name = "pytest-cov", specifier = ">=7.1" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.4.1" },
+    { name = "trove-classifiers", specifier = ">=2026.6.1.19" },
     { name = "types-cachetools", specifier = ">=7.0.0.20260713" },
     { name = "types-chardet", specifier = ">=5.0.4.6" },
 ]
@@ -2207,6 +2213,15 @@ type = [
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.4.1" },
     { name = "types-cachetools", specifier = ">=7.0.0.20260713" },
     { name = "types-chardet", specifier = ">=5.0.4.6" },
+]
+
+[[package]]
+name = "trove-classifiers"
+version = "2026.6.1.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/e3/7ca82ee24c82d344584abd5b8637b3bd056f2900226e8d82fc22f1184b92/trove_classifiers-2026.6.1.19.tar.gz", hash = "sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745", size = 17059, upload-time = "2026-06-01T19:41:34.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/a4/81502f486f01db95bc8320646a8a12511f5e556cb63d5e224d91816605c4/trove_classifiers-2026.6.1.19-py3-none-any.whl", hash = "sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3", size = 14211, upload-time = "2026-06-01T19:41:33.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A project writing `requires-python = ">=3.12,<3.16"` says it runs on 3.15, and since 2.29.0 the formatter drops the classifier naming that release, as [#460](https://github.com/tox-dev/toml-fmt/issues/460) reports. 🐛 Setting `max_supported_python` by hand puts it back, which is the workaround the reporter found.

Classifier generation reads the floor from `requires-python` and caps the result at `max_supported_python`, as [the configuration docs](https://pyproject-fmt.readthedocs.io/en/latest/configuration.html) describe. That cap named 3.14 while 3.15 sits at its release candidate, so it fell below what these files say they support and took the classifier with it. Whether a release exists is the question the cap answers, and a requirement cannot answer it, since `<3.30` would otherwise name a dozen releases that have no classifier for PyPI to accept.

What let a stale number sit there is that nothing watched it, so both ends now move on their own. ✨ They stay written down in the source, and a run each day sets them from what is true that day. The newest has to satisfy two things at once, since either alone says too little: PyPI publishes a classifier naming it, and Python has published a release candidate. 3.16 has the first and not the second, so it names nothing yet, while a release still in alpha carries a classifier long before its behavior settles. The oldest is the release still carrying fixes, which 3.10 stops doing at the end of October.

Neither run writes down a date published ahead of time, nor compares against one, so a release that slips arrives when it arrives rather than on the day someone predicted. ✨ The seven places that spell either number move together, documentation included, and anyone naming `max_supported_python` themselves keeps what they set.

Bumping either end changes what the formatter writes, so the daily run opens a pull request rather than pushing, and whoever reviews it updates the expectations that name a release.

Fixes #460
